### PR TITLE
Feat#7: Exception Feat

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionCode.java
@@ -1,0 +1,49 @@
+package leaguehub.leaguehubbackend.exception.auth;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthExceptionCode implements ExceptionCode {
+
+    /**
+     * JWT
+     * 001 ~ 099
+     */
+
+    INVALID_TOKEN(UNAUTHORIZED, "AT-C-001", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(UNAUTHORIZED, "AT-C-002", "만료된 토큰입니다."),
+    NOT_EXPIRED_TOKEN(BAD_REQUEST, "AT-C-003", "만료되지 않은 토큰입니다."),
+    REQUEST_TOKEN_NOT_FOUND(BAD_REQUEST, "AT-C-004", "요청에 토큰이 존재하지 않습니다."),
+    INVALID_REFRESH_TOKEN(BAD_REQUEST, "AT-C-005", "유효하지 않은 리프레쉬 토큰입니다."),
+    UNTRUSTED_CREDENTIAL(UNAUTHORIZED, "AT-C-006", "신뢰할 수 없는 자격증명 입니다."),
+    LOGGED_OUT_TOKEN(UNAUTHORIZED, "AT-C-007", "로그아웃된 토큰입니다."),
+
+    /**
+     * MEMBER
+     * 100 ~ 199
+     */
+    LOGIN_PROVIDER_MISMATCH(BAD_REQUEST, "AT-C-100", "잘못된 OAuth2 인증입니다."),
+    INVALID_LOGIN_PROVIDER(BAD_REQUEST, "AT-C-101", "유효하지 않은 로그인 제공자입니다."),
+    INVALID_MEMBER_ROLE(FORBIDDEN, "AT-C-102", "유효하지 않은 사용자 권한입니다."),
+    NOT_AUTHORIZATION_USER(NOT_FOUND, "AT-C-103", "인가된 사용자가 아닙니다."),
+    INVALID_REDIRECT_URI(UNAUTHORIZED, "AT-C-104", "허용되지 않은 리다이렉션 URI 입니다."),
+
+
+    /**
+     * Common Exception
+     * 200 ~
+     */
+    AUTHENTICATION_ERROR(UNAUTHORIZED, "AT-C-200", "Authentication exception."),
+    INTERNAL_AUTHENTICATION_SERVICE_EXCEPTION(INTERNAL_SERVER_ERROR, "AT-S-200", "Internal authentication service exception.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/channel/ChannelExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/channel/ChannelExceptionCode.java
@@ -1,0 +1,23 @@
+package leaguehub.leaguehubbackend.exception.channel;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChannelExceptionCode implements ExceptionCode {
+
+    INVALID_PARTICIPATED_REQUEST(BAD_REQUEST, "CH-C-001", "유효하지 않은 대회 참가 요청입니다."),
+    INELIGIBLE_PARTICIPANT_REQUEST(BAD_REQUEST, "CH-C-001", "정해진 대회 룰에 적합하지 않는 대회 참가 요청입니다."),
+    INVALID_JOIN_REQUEST(BAD_REQUEST, "CH-C-002", "유효하지 않은 참가 링크입니다."),
+    INVALID_CHANNEL_IMAGE(BAD_REQUEST, "CH-C-003", "유효하지 않은 이미지입니다."),
+    INVALID_ACCESS_CODE(BAD_REQUEST, "CH-C-004", "유효하지 않은 대회 참가 코드입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/channel/ChannelExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/channel/ChannelExceptionCode.java
@@ -12,10 +12,10 @@ import static org.springframework.http.HttpStatus.*;
 public enum ChannelExceptionCode implements ExceptionCode {
 
     INVALID_PARTICIPATED_REQUEST(BAD_REQUEST, "CH-C-001", "유효하지 않은 대회 참가 요청입니다."),
-    INELIGIBLE_PARTICIPANT_REQUEST(BAD_REQUEST, "CH-C-001", "정해진 대회 룰에 적합하지 않는 대회 참가 요청입니다."),
-    INVALID_JOIN_REQUEST(BAD_REQUEST, "CH-C-002", "유효하지 않은 참가 링크입니다."),
-    INVALID_CHANNEL_IMAGE(BAD_REQUEST, "CH-C-003", "유효하지 않은 이미지입니다."),
-    INVALID_ACCESS_CODE(BAD_REQUEST, "CH-C-004", "유효하지 않은 대회 참가 코드입니다.");
+    INELIGIBLE_PARTICIPANT_REQUEST(BAD_REQUEST, "CH-C-002", "정해진 대회 룰에 적합하지 않는 대회 참가 요청입니다."),
+    INVALID_JOIN_REQUEST(BAD_REQUEST, "CH-C-003", "유효하지 않은 참가 링크입니다."),
+    INVALID_CHANNEL_IMAGE(BAD_REQUEST, "CH-C-004", "유효하지 않은 이미지입니다."),
+    INVALID_ACCESS_CODE(BAD_REQUEST, "CH-C-005", "유효하지 않은 대회 참가 코드입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/leaguehub/leaguehubbackend/exception/global/ExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/global/ExceptionCode.java
@@ -1,0 +1,11 @@
+package leaguehub.leaguehubbackend.exception.global;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionCode {
+    HttpStatus getHttpStatus();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/global/ExceptionResponse.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/global/ExceptionResponse.java
@@ -1,0 +1,25 @@
+package leaguehub.leaguehubbackend.exception.global;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExceptionResponse {
+
+    private Integer statusCode;
+    private String code;
+    private String message;
+    private LocalDateTime timestamp;
+
+    public ExceptionResponse(final ExceptionCode exceptionCode) {
+        this.statusCode = exceptionCode.getHttpStatus().value();
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.timestamp = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/global/GlobalErrorCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/global/GlobalErrorCode.java
@@ -1,0 +1,27 @@
+package leaguehub.leaguehubbackend.exception.global;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ExceptionCode {
+
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "G-S-001", "Internal Server Error"),
+    INVALID_REQUEST_METHOD(METHOD_NOT_ALLOWED, "G-C-001", "유효하지 않는 http 요청입니다."),
+    INVALID_REQUEST_PARAMETER(BAD_REQUEST, "G-C-002", "유효하지 않는 파라미터 요청입니다."),
+    INVALID_RESOURCE_OWNER(FORBIDDEN, "G-C-003", "해당 리소스를 처리할 권한이 없습니다.");
+
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionCode.java
@@ -1,0 +1,19 @@
+package leaguehub.leaguehubbackend.exception.match;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchExceptionCode implements ExceptionCode {
+
+    MATCH_NOT_FOUND(NOT_FOUND, "MA-C-001", "유효하지 않은 경기입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionCode.java
@@ -1,0 +1,21 @@
+package leaguehub.leaguehubbackend.exception.member;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberExceptionCode implements ExceptionCode {
+
+    MEMBER_NOT_FOUND(NOT_FOUND, "MB-C-001", "존재하지 않는 회원입니다."),
+    INVALID_MEMBER_IMAGE(BAD_REQUEST, "MB-C-002", "유효하지 않은 이미지입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/participant/ParticipantExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/participant/ParticipantExceptionCode.java
@@ -1,0 +1,19 @@
+package leaguehub.leaguehubbackend.exception.participant;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Getter
+@RequiredArgsConstructor
+public enum ParticipantExceptionCode implements ExceptionCode {
+
+    INVALID_PARTICIPANT_IMAGE(BAD_REQUEST, "PA-C-003", "유효하지 않은 이미지입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue

#7 

## 📝 Description

엔티티및 전역적으로 발생할 수 있는 예외 상황을 Enum으로 HttpStatus 코드, 커스텀 코드, 메시지로 구성했어요.
커스텀 코드는 "Entity(Global)이니셜-(**C**lient, **S**erver)-숫자"로 구성되어 있어요.
예를 들면 "MB-C-001"은 멤버 엔티티에서 클라이언트쪽 에러의 첫번째 에러라는 뜻이예요.

## ✨ Feature

Exception Enum 클래스를 구현했어요.

## 👌 Review Change

This closes #7 