### PR TITLE
Feat#4  카카오 로그인 및 Access, Refresh 토큰 발급

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+src/main/resources/application-API-KEY.properties

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'com.auth0:java-jwt:4.4.0'
 
 }
 

--- a/src/main/java/leaguehub/leaguehubbackend/config/WebClientConfig.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package leaguehub.leaguehubbackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.create();
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/controller/JwtController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/JwtController.java
@@ -9,9 +9,9 @@ import leaguehub.leaguehubbackend.service.jwt.JwtService;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
@@ -19,13 +19,12 @@ import java.util.Optional;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class JwtController {
 
-    @Autowired
-    private MemberService memberService;
+    private final MemberService memberService;
 
-    @Autowired
-    private JwtService jwtService;
+    private final JwtService jwtService;
 
     @GetMapping("/reissue/token")
     public ResponseEntity<LoginMemberResponse> refreshAccessToken(HttpServletRequest request) {

--- a/src/main/java/leaguehub/leaguehubbackend/controller/JwtController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/JwtController.java
@@ -1,0 +1,54 @@
+package leaguehub.leaguehubbackend.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import leaguehub.leaguehubbackend.dto.member.LoginMemberResponse;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidTokenException;
+import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
+import leaguehub.leaguehubbackend.service.jwt.JwtService;
+import leaguehub.leaguehubbackend.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class JwtController {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @GetMapping("/reissue/token")
+    public ResponseEntity<LoginMemberResponse> refreshAccessToken(HttpServletRequest request) {
+
+        Optional<String> optionalToken = jwtService.extractRefreshToken(request);
+
+        String refreshToken = optionalToken.orElseThrow(() -> {
+            log.info("요청에 refreshToken 없음");
+            return new AuthInvalidTokenException();
+        });
+
+        Optional<Member> memberOpt = Optional.empty();
+        if (jwtService.isTokenValid(refreshToken)) {
+            memberOpt = memberService.findMemberByRefreshToken(refreshToken);
+        }
+
+        Member member = memberOpt.orElseThrow(() -> {
+            log.info("해당 refreshToken을 가지고 있는 멤버 없음: " + refreshToken);
+            return new MemberNotFoundException();
+        });
+
+        LoginMemberResponse loginMemberResponse = jwtService.createTokens(member.getPersonalId());
+
+        return ResponseEntity.ok(loginMemberResponse);
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/controller/KakaoController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/KakaoController.java
@@ -10,7 +10,6 @@ import leaguehub.leaguehubbackend.service.kakao.KakaoService;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,14 +24,11 @@ import java.util.function.Predicate;
 @RequiredArgsConstructor
 public class KakaoController {
 
-    @Autowired
-    private KakaoService kakaoService;
+    private final KakaoService kakaoService;
 
-    @Autowired
-    private MemberService memberService;
+    private final MemberService memberService;
 
-    @Autowired
-    private JwtService jwtService;
+    private final JwtService jwtService;
 
     @GetMapping("/app/login/kakao")
     public ResponseEntity<LoginMemberResponse> handleKakaoLogin(@RequestHeader HttpHeaders headers) {

--- a/src/main/java/leaguehub/leaguehubbackend/controller/KakaoController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/KakaoController.java
@@ -49,8 +49,10 @@ public class KakaoController {
         memberService.findMemberByPersonalId(String.valueOf(userDto.getId()))
                 .orElseGet(() -> memberService.saveMember(userDto).orElseThrow(GlobalServerErrorException::new));
 
-        LoginMemberResponse loginMemberResponse = jwtService.createTokens(userDto);
+        LoginMemberResponse loginMemberResponse = jwtService.createTokens(String.valueOf(userDto.getId()));
 
         return ResponseEntity.ok(loginMemberResponse);
     }
+
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/controller/KakaoController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/KakaoController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
@@ -22,6 +23,7 @@ import java.util.function.Predicate;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class KakaoController {
 
     private final KakaoService kakaoService;

--- a/src/main/java/leaguehub/leaguehubbackend/controller/KakaoController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/KakaoController.java
@@ -1,0 +1,56 @@
+package leaguehub.leaguehubbackend.controller;
+
+import leaguehub.leaguehubbackend.dto.kakao.KakaoTokenResponseDto;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
+import leaguehub.leaguehubbackend.dto.member.LoginMemberResponse;
+import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
+import leaguehub.leaguehubbackend.exception.kakao.exception.KakaoInvalidCodeException;
+import leaguehub.leaguehubbackend.service.jwt.JwtService;
+import leaguehub.leaguehubbackend.service.kakao.KakaoService;
+import leaguehub.leaguehubbackend.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class KakaoController {
+
+    @Autowired
+    private KakaoService kakaoService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @GetMapping("/app/login/kakao")
+    public ResponseEntity<LoginMemberResponse> handleKakaoLogin(@RequestHeader HttpHeaders headers) {
+        String kakaoCode = headers.getFirst("Kakao-Code");
+
+        Optional.ofNullable(kakaoCode)
+                .filter(Predicate.not(String::isEmpty))
+                .orElseThrow(KakaoInvalidCodeException::new);
+
+        KakaoTokenResponseDto KakaoToken = kakaoService.getKakaoToken(kakaoCode);
+
+        KakaoUserDto userDto = kakaoService.getKakaoUser(KakaoToken);
+
+        memberService.findMemberByPersonalId(String.valueOf(userDto.getId()))
+                .orElseGet(() -> memberService.saveMember(userDto).orElseThrow(GlobalServerErrorException::new));
+
+        LoginMemberResponse loginMemberResponse = jwtService.createTokens(userDto);
+
+        return ResponseEntity.ok(loginMemberResponse);
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoTokenRequestDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoTokenRequestDto.java
@@ -1,22 +1,16 @@
 package leaguehub.leaguehubbackend.dto.kakao;
 
+import lombok.AllArgsConstructor;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+@AllArgsConstructor
 public class KakaoTokenRequestDto {
 
     private String grantType;
     private String clientId;
     private String redirectUri;
     private String code;
-
-    public KakaoTokenRequestDto(String grantType, String clientId, String redirectUri, String code) {
-        this.grantType = grantType;
-        this.clientId = clientId;
-        this.redirectUri = redirectUri;
-        this.code = code;
-    }
-
     public MultiValueMap<String, String> toMultiValueMap() {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", grantType);

--- a/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoTokenRequestDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoTokenRequestDto.java
@@ -1,0 +1,29 @@
+package leaguehub.leaguehubbackend.dto.kakao;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public class KakaoTokenRequestDto {
+
+    private String grantType;
+    private String clientId;
+    private String redirectUri;
+    private String code;
+
+    public KakaoTokenRequestDto(String grantType, String clientId, String redirectUri, String code) {
+        this.grantType = grantType;
+        this.clientId = clientId;
+        this.redirectUri = redirectUri;
+        this.code = code;
+    }
+
+    public MultiValueMap<String, String> toMultiValueMap() {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", grantType);
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        return params;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoTokenResponseDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoTokenResponseDto.java
@@ -1,0 +1,32 @@
+package leaguehub.leaguehubbackend.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoTokenResponseDto {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private int expiresIn;
+
+    private String scope;
+
+    @JsonProperty("refresh_token_expires_in")
+    private int refreshTokenExpiresIn;
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoTokenResponseDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoTokenResponseDto.java
@@ -1,15 +1,9 @@
 package leaguehub.leaguehubbackend.dto.kakao;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
-@Getter
-@ToString
-@AllArgsConstructor
-@NoArgsConstructor
+@Data
 public class KakaoTokenResponseDto {
 
     @JsonProperty("access_token")

--- a/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoUserDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoUserDto.java
@@ -2,9 +2,7 @@ package leaguehub.leaguehubbackend.dto.kakao;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.io.Serializable;
@@ -25,7 +23,6 @@ public class KakaoUserDto implements Serializable {
 
     @Getter
     @ToString
-
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Properties {
 
@@ -40,7 +37,6 @@ public class KakaoUserDto implements Serializable {
     }
     @Getter
     @ToString
-
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KakaoAccount {
 
@@ -54,7 +50,6 @@ public class KakaoUserDto implements Serializable {
 
         @Getter
         @ToString
-
         @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Profile {
             private String nickname;

--- a/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoUserDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoUserDto.java
@@ -1,0 +1,69 @@
+package leaguehub.leaguehubbackend.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+@Getter
+@ToString
+public class KakaoUserDto implements Serializable {
+
+    private Long id;
+
+    @JsonProperty("connected_at")
+    private String connectedAt;
+
+    private Properties properties;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @ToString
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Properties {
+
+        private String nickname;
+
+        @JsonProperty("profile_image")
+        private String profileImage;
+
+        @JsonProperty("thumbnail_image")
+        private String thumbnailImage;
+
+    }
+    @Getter
+    @ToString
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoAccount {
+
+        @JsonProperty("profile_nickname_needs_agreement")
+        private Boolean profileNicknameNeedsAgreement;
+
+        @JsonProperty("profile_image_needs_agreement")
+        private Boolean profileImageNeedsAgreement;
+
+        private Profile profile;
+
+        @Getter
+        @ToString
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Profile {
+            private String nickname;
+
+            @JsonProperty("thumbnail_image_url")
+            private String thumbnailImageUrl;
+
+        }
+
+    }
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/member/LoginMemberResponse.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/member/LoginMemberResponse.java
@@ -1,0 +1,16 @@
+package leaguehub.leaguehubbackend.dto.member;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LoginMemberResponse {
+    private String nickName;
+    private String profileUrl;
+    private String accessToken;
+    private Long accessTokenExpirationTime;
+    private String refreshToken;
+    private Long refreshTokenExpirationTime;
+}
+

--- a/src/main/java/leaguehub/leaguehubbackend/dto/member/LoginMemberResponse.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/member/LoginMemberResponse.java
@@ -6,8 +6,7 @@ import lombok.Data;
 @Data
 @Builder
 public class LoginMemberResponse {
-    private String nickName;
-    private String profileUrl;
+
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/member/LoginMemberResponse.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/member/LoginMemberResponse.java
@@ -9,8 +9,6 @@ public class LoginMemberResponse {
     private String nickName;
     private String profileUrl;
     private String accessToken;
-    private Long accessTokenExpirationTime;
     private String refreshToken;
-    private Long refreshTokenExpirationTime;
 }
 

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/BaseRole.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/BaseRole.java
@@ -1,0 +1,13 @@
+package leaguehub.leaguehubbackend.entity.member;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BaseRole {
+    ADMIN("ROLE_ADMIN"),
+    USER("ROLE_USER");
+    private final String key;
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -38,7 +38,7 @@ public class Member extends BaseTimeEntity {
         this.refreshToken = refreshToken;
     }
 
-    public static Member fromKakaoUserDto(KakaoUserDto kakaoUserDto) {
+    public static Member kakaoUserToMember(KakaoUserDto kakaoUserDto) {
         return Member.builder()
                 .personalId(String.valueOf(kakaoUserDto.getId()))
                 .nickname(kakaoUserDto.getProperties().getNickname())

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -1,13 +1,18 @@
 package leaguehub.leaguehubbackend.entity.member;
 
 import jakarta.persistence.*;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.entity.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @Entity
+@Builder
+@AllArgsConstructor
 public class Member extends BaseTimeEntity {
 
     @Id
@@ -21,7 +26,25 @@ public class Member extends BaseTimeEntity {
 
     private String profileImageUrl;
 
+    private String refreshToken;
+
     @Enumerated(EnumType.STRING)
     private LoginProvider loginProvider;
 
+    @Enumerated(EnumType.STRING)
+    private BaseRole baseRole;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public static Member fromKakaoUserDto(KakaoUserDto kakaoUserDto) {
+        return Member.builder()
+                .personalId(String.valueOf(kakaoUserDto.getId()))
+                .nickname(kakaoUserDto.getProperties().getNickname())
+                .profileImageUrl(kakaoUserDto.getProperties().getProfileImage())
+                .baseRole(BaseRole.USER)
+                .loginProvider(LoginProvider.KAKAO)
+                .build();
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -3,16 +3,13 @@ package leaguehub.leaguehubbackend.entity.member;
 import jakarta.persistence.*;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.entity.BaseTimeEntity;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
-@NoArgsConstructor
-@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
+@Entity
 public class Member extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionHandler.java
@@ -1,0 +1,31 @@
+package leaguehub.leaguehubbackend.exception.auth;
+
+import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidTokenException;
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.exception.kakao.exception.KakaoInvalidCodeException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+@RequiredArgsConstructor
+public class AuthExceptionHandler {
+
+    @ExceptionHandler(AuthInvalidTokenException.class)
+    public ResponseEntity<ExceptionResponse> authInvalidTokenException(
+            AuthInvalidTokenException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/exception/AuthInvalidTokenException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/exception/AuthInvalidTokenException.java
@@ -1,0 +1,21 @@
+package leaguehub.leaguehubbackend.exception.auth.exception;
+
+import leaguehub.leaguehubbackend.exception.auth.AuthExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import org.springframework.security.core.AuthenticationException;
+
+import static leaguehub.leaguehubbackend.exception.auth.AuthExceptionCode.INVALID_TOKEN;
+
+public class AuthInvalidTokenException extends AuthenticationException {
+    private final ExceptionCode exceptionCode;
+
+    public AuthInvalidTokenException() {
+        super(INVALID_TOKEN.getMessage());
+        this.exceptionCode = AuthExceptionCode.INVALID_TOKEN;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/global/GlobalExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/global/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
-package leaguehub.leaguehubbackend.exception.kakao;
+package leaguehub.leaguehubbackend.exception.global;
 
-import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
-import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
 import leaguehub.leaguehubbackend.exception.kakao.exception.KakaoInvalidCodeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,10 +11,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @Slf4j
 @ControllerAdvice
 @RequiredArgsConstructor
-public class KakaoExceptionHandler {
+public class GlobalExceptionHandler {
 
-    @ExceptionHandler(KakaoInvalidCodeException.class)
-    public ResponseEntity<ExceptionResponse> kakaoInvalidCodeException(
+    @ExceptionHandler(GlobalServerErrorException.class)
+    public ResponseEntity<ExceptionResponse> internalServerErrorException(
             KakaoInvalidCodeException e
     ) {
         ExceptionCode exceptionCode = e.getExceptionCode();

--- a/src/main/java/leaguehub/leaguehubbackend/exception/global/exception/GlobalServerErrorException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/global/exception/GlobalServerErrorException.java
@@ -1,0 +1,19 @@
+package leaguehub.leaguehubbackend.exception.global.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.global.GlobalErrorCode.SERVER_ERROR;
+
+public class GlobalServerErrorException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public GlobalServerErrorException() {
+        super(SERVER_ERROR.getMessage());
+        this.exceptionCode = SERVER_ERROR;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/kakao/KakaoExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/kakao/KakaoExceptionCode.java
@@ -1,0 +1,18 @@
+package leaguehub.leaguehubbackend.exception.kakao;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum KakaoExceptionCode implements ExceptionCode {
+    INVALID_KAKAO_CODE(BAD_REQUEST, "KA-C-001", "유효하지 않은 카카오 코드입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/kakao/KakaoExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/kakao/KakaoExceptionHandler.java
@@ -1,0 +1,27 @@
+package leaguehub.leaguehubbackend.exception.kakao;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.exception.kakao.exception.KakaoInvalidCodeException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@RequiredArgsConstructor
+public class KakaoExceptionHandler {
+
+    @ExceptionHandler(KakaoInvalidCodeException.class)
+    public ResponseEntity<ExceptionResponse> kakaoException(
+            KakaoInvalidCodeException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/kakao/exception/KakaoInvalidCodeException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/kakao/exception/KakaoInvalidCodeException.java
@@ -1,0 +1,19 @@
+package leaguehub.leaguehubbackend.exception.kakao.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.kakao.KakaoExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.kakao.KakaoExceptionCode.INVALID_KAKAO_CODE;
+
+public class KakaoInvalidCodeException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+
+    public KakaoInvalidCodeException() {
+        super(INVALID_KAKAO_CODE.getMessage());
+        this.exceptionCode = KakaoExceptionCode.INVALID_KAKAO_CODE;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/member/exception/MemberNotFoundException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/member/exception/MemberNotFoundException.java
@@ -1,0 +1,20 @@
+package leaguehub.leaguehubbackend.exception.member.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.member.MemberExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.member.MemberExceptionCode.MEMBER_NOT_FOUND;
+
+public class MemberNotFoundException extends RuntimeException{
+
+    private final ExceptionCode exceptionCode;
+
+    public MemberNotFoundException() {
+        super(MEMBER_NOT_FOUND.getMessage());
+        this.exceptionCode = MemberExceptionCode.MEMBER_NOT_FOUND;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/member/memberExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/member/memberExceptionHandler.java
@@ -1,0 +1,29 @@
+package leaguehub.leaguehubbackend.exception.member;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+@RequiredArgsConstructor
+public class memberExceptionHandler {
+
+    @ExceptionHandler(MemberNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> memberInvalidException(
+            MemberNotFoundException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/member/MemberRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/member/MemberRepository.java
@@ -1,0 +1,14 @@
+package leaguehub.leaguehubbackend.repository.member;
+
+import leaguehub.leaguehubbackend.entity.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+
+    Optional<Member> findMemberByPersonalId(String personalId);
+    Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/jwt/JwtService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/jwt/JwtService.java
@@ -77,12 +77,12 @@ public class JwtService {
      */
     public Optional<String> extractPersonalId(String accessToken) {
         try {
-            Long nickname = JWT.require(Algorithm.HMAC512(secretKey))
+            String personalId = JWT.require(Algorithm.HMAC512(secretKey))
                     .build()
                     .verify(accessToken)
                     .getClaim("personalId")
-                    .asLong();
-            return Optional.ofNullable(nickname != null ? String.valueOf(nickname) : null);
+                    .asString();
+            return Optional.ofNullable(personalId);
         } catch (Exception e) {
             log.error("액세스 토큰이 유효하지 않습니다.");
             return Optional.empty();
@@ -106,9 +106,9 @@ public class JwtService {
      */
     public boolean isTokenValid(String token) {
         try {
-            log.info("토큰 유효함");
             // 토큰 유효성 검증
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+            log.info("토큰 유효함");
             return true;
         } catch (Exception e) {
             log.error("유효하지 않은 토큰입니다. {}", e.getMessage());

--- a/src/main/java/leaguehub/leaguehubbackend/service/jwt/JwtService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/jwt/JwtService.java
@@ -1,0 +1,132 @@
+package leaguehub.leaguehubbackend.service.jwt;
+
+import com.auth0.jwt.algorithms.Algorithm;
+import jakarta.servlet.http.HttpServletRequest;
+import leaguehub.leaguehubbackend.dto.member.LoginMemberResponse;
+import leaguehub.leaguehubbackend.repository.member.MemberRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import com.auth0.jwt.JWT;
+
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Getter
+@Slf4j
+public class JwtService {
+    @Value("${JWT_SECRET_KEY}")
+    private String secretKey;
+
+    @Value("${JWT_ACCESS_TOKEN_TIME}")
+    private Long accessTokenExpirationPeriod;
+
+    @Value("${JWT_REFRESH_TOKEN_TIME}")
+    private Long refreshTokenExpirationPeriod;
+
+    private static final String BEARER = "Bearer ";
+
+    private final MemberRepository memberRepository;
+
+
+    /**
+     * AccessToken 생성 메소드
+     */
+    public String createAccessToken(String personalId) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject("AccessToken")
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .withClaim("personalId", personalId)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+    /**
+     * Refresh 토큰 생성 메소드
+     */
+    public String createRefreshToken() {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject("RefreshToken")
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    /**
+     * 헤더에서 RefreshToken 추출
+     */
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader("Authorization-refresh"))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    /**
+     * 헤더에서 AccessToken 추출
+     */
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader("Authorization"))
+                .filter(accessToken -> accessToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+    /**
+     * AccessToken에서 PersonalId 추출
+     */
+    public Optional<String> extractPersonalId(String accessToken) {
+        try {
+            Long nickname = JWT.require(Algorithm.HMAC512(secretKey))
+                    .build()
+                    .verify(accessToken)
+                    .getClaim("personalId")
+                    .asLong();
+            return Optional.ofNullable(nickname != null ? String.valueOf(nickname) : null);
+        } catch (Exception e) {
+            log.error("액세스 토큰이 유효하지 않습니다.");
+            return Optional.empty();
+        }
+    }
+    /**
+     * AccessToken과 RefreshToken 생성
+     */
+    public LoginMemberResponse createTokens(String personalId) {
+        String accessToken = createAccessToken(personalId);
+        String refreshToken = createRefreshToken();
+        updateRefreshToken(personalId, refreshToken);
+        LoginMemberResponse tokenDto = LoginMemberResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+        return tokenDto;
+    }
+    /**
+     * 매번 검증을 위한 매서드
+     */
+    public boolean isTokenValid(String token) {
+        try {
+            log.info("토큰 유효함");
+            // 토큰 유효성 검증
+            JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+            return true;
+        } catch (Exception e) {
+            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            return false;
+        }
+    }
+    /**
+     * RefreshToken DB 저장(업데이트)
+     */
+    public void updateRefreshToken(String personalId, String refreshToken) {
+        memberRepository.findMemberByPersonalId(personalId)
+                .ifPresentOrElse(
+                        member -> {
+                            member.updateRefreshToken(refreshToken);
+                            memberRepository.save(member);
+                        },
+                        () -> new Exception("일치하는 회원이 없습니다.")
+                );
+    }
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/kakao/KakaoService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/kakao/KakaoService.java
@@ -1,12 +1,9 @@
 package leaguehub.leaguehubbackend.service.kakao;
 
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoTokenRequestDto;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoTokenResponseDto;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
-import leaguehub.leaguehubbackend.exception.global.GlobalErrorCode;
 import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
 import leaguehub.leaguehubbackend.exception.kakao.exception.KakaoInvalidCodeException;
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
@@ -18,7 +15,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-import org.springframework.http.HttpStatus;
 @Service
 public class KakaoService {
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/kakao/KakaoService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/kakao/KakaoService.java
@@ -6,8 +6,7 @@ import leaguehub.leaguehubbackend.dto.kakao.KakaoTokenResponseDto;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
 import leaguehub.leaguehubbackend.exception.kakao.exception.KakaoInvalidCodeException;
-import leaguehub.leaguehubbackend.repository.member.MemberRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
@@ -16,6 +15,7 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 @Service
+@RequiredArgsConstructor
 public class KakaoService {
 
     @Value("${KAKAO_CLIENT_ID}")
@@ -30,11 +30,7 @@ public class KakaoService {
     @Value("${KAKAO_USERINFO_REQUEST_URI}")
     private String kakaoUserInfoRequestUri;
 
-    @Autowired
-    MemberRepository memberRepository;
-
-    @Autowired
-    private WebClient webClient;
+    private final WebClient webClient;
 
     /**
      * 카카오로 부터 토큰을 받는 함수

--- a/src/main/java/leaguehub/leaguehubbackend/service/kakao/KakaoService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/kakao/KakaoService.java
@@ -1,0 +1,78 @@
+package leaguehub.leaguehubbackend.service.kakao;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoTokenRequestDto;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoTokenResponseDto;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
+import leaguehub.leaguehubbackend.exception.global.GlobalErrorCode;
+import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
+import leaguehub.leaguehubbackend.exception.kakao.exception.KakaoInvalidCodeException;
+import leaguehub.leaguehubbackend.repository.member.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import org.springframework.http.HttpStatus;
+@Service
+public class KakaoService {
+
+    @Value("${KAKAO_CLIENT_ID}")
+    private String kakaoClientId;
+
+    @Value("${KAKAO_REDIRECT_URI}")
+    private String kakaoRedirectUri;
+
+    @Value("${KAKAO_TOKEN_REQUEST_URI}")
+    private String kakaoToeknRequestUri;
+
+    @Value("${KAKAO_USERINFO_REQUEST_URI}")
+    private String kakaoUserInfoRequestUri;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    private WebClient webClient;
+
+    /**
+     * 카카오로 부터 토큰을 받는 함수
+     */
+    public KakaoTokenResponseDto getKakaoToken(String kakaoCode) {
+
+        KakaoTokenRequestDto kakaoTokenRequestDto = new KakaoTokenRequestDto("authorization_code", kakaoClientId, kakaoRedirectUri, kakaoCode);
+        MultiValueMap<String , String> params = kakaoTokenRequestDto.toMultiValueMap();
+
+        return webClient.post()
+                .uri(kakaoToeknRequestUri)
+                .body(BodyInserters.fromFormData(params))
+                .header("Content-type","application/x-www-form-urlencoded;charset=utf-8")
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new KakaoInvalidCodeException()))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new GlobalServerErrorException()))
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .block();
+
+    }
+
+    /**
+     * 카카오로 부터 유저 정보를 받는 함수
+     */
+    public KakaoUserDto getKakaoUser(KakaoTokenResponseDto token) {
+
+        return webClient.get()
+                .uri(kakaoUserInfoRequestUri)
+                .header("Content-type","application/x-www-form-urlencoded;charset=utf-8" )
+                .header("Authorization","Bearer " + token.getAccessToken())
+                .retrieve()
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new GlobalServerErrorException()))
+                .bodyToMono(KakaoUserDto.class)
+                .block();
+
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -1,0 +1,33 @@
+package leaguehub.leaguehubbackend.service.member;
+
+
+import jakarta.transaction.Transactional;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Optional<Member> findMemberByPersonalId(String personalId) {
+        return memberRepository.findMemberByPersonalId(personalId);
+    }
+
+    public Optional<Member> findMemberByRefreshToken(String refreshToken) {
+        return memberRepository.findByRefreshToken(refreshToken);
+    }
+
+    @Transactional
+    public Optional<Member> saveMember(KakaoUserDto kakaoUserDto) {
+        Member newUser = Member.kakaoUserToMember(kakaoUserDto);
+        memberRepository.save(newUser);
+        return Optional.of(newUser);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.devtools.livereload.enabled=true
 spring.jpa.properties.hibernate.default_batch_fetch_size=1000
+spring.profiles.include=API-KEY


### PR DESCRIPTION
## 🙆‍♂️ Issue

#4 

## 📝 Description

클라이언트에서 카카오코드를 받은 후 유효하다면 카카오 엑세스 토큰을 받는다.
엑세스 토큰을 사용하여 사용자 정보를 받아온 후 회원가입/로그인을 수행한다.
회원가입/로그인 완료 후 Access, Refresh Token을 발급한다.

테스트 코드는 시큐리티필터와 함께 추가할 예정입니다.


## ✨ Feature

#4 이슈를 참고해주세요

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.
This closes #4 