### PR TITLE
Refactor#23 티어 조회에 대한 리팩터링

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/GameTier.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/GameTier.java
@@ -1,0 +1,41 @@
+package leaguehub.leaguehubbackend.entity.participant;
+
+import lombok.Getter;
+
+@Getter
+public enum GameTier {
+
+    UNRANKED(-1, "랭크없음"),
+    IRON(0, "아이언"), BRONZE(400, "브론즈"), SILVER(800, "실버"),
+    GOLD(1200, "골드"), PLATINUM(1600, "플래티넘"), DIAMOND(2000, "다이아몬드"),
+    MASTER(2400, "마스터"), GRANDMASTER(2400, "그랜드 마스터"), CHALLENGER(2400, "챌린저"),
+    IV(0, "4"), III(100, "3"), II(200, "2"), I(300, "1");
+
+
+    private int score;
+    private String tier;
+
+    GameTier(int score, String tier){
+        this.score = score;
+        this.tier = tier;
+    }
+
+
+
+    //
+    public static String findGameTier(String rank, String grade){
+
+        String resultTier = "";
+        String resultGrade = "";
+
+        for(GameTier gameTier : GameTier.values()){
+            if(gameTier.toString().equalsIgnoreCase(rank))
+                resultTier = gameTier.tier;
+            if(gameTier.toString().equalsIgnoreCase(grade))
+                resultGrade = gameTier.tier;
+        }
+
+        return resultTier.concat(" ").concat(resultGrade);
+    }
+
+}

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -2,6 +2,7 @@ package leaguehub.leaguehubbackend.service.participant;
 
 import jakarta.transaction.Transactional;
 import leaguehub.leaguehubbackend.dto.participant.ResponseUserDetailDto;
+import leaguehub.leaguehubbackend.entity.participant.GameTier;
 import leaguehub.leaguehubbackend.exception.participant.exception.ParticipantGameIdNotFoundException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -31,16 +32,14 @@ class ParticipantServiceTest {
         ResponseUserDetailDto testDto1 = participantService.getTierAndPlayCount("칸영기");
         ResponseUserDetailDto testDto2 = participantService.getTierAndPlayCount("서초임");
         ResponseUserDetailDto testDto3 = participantService.getTierAndPlayCount("채수채수밭");
-        ResponseUserDetailDto testDto4 = participantService.getTierAndPlayCount("사라진검 리븐");
 
-        assertThat(testDto1.getTier()).isEqualToIgnoringCase("platinum iv");
-        assertThat(testDto2.getTier()).isEqualToIgnoringCase("unranked");
-        assertThat(testDto3.getTier()).isEqualToIgnoringCase("challenger i");
-        assertThat(testDto4.getTier()).isEqualToIgnoringCase("challenger i");
-
+        assertThat(testDto1.getTier()).isEqualTo("플래티넘 4");
+        assertThat(testDto2.getTier()).isEqualTo("랭크없음");
 
         assertThat(testDto1.getPlayCount()).isEqualTo(39);
         assertThat(testDto2.getPlayCount()).isEqualTo(0);
+
+        System.out.println(testDto3.getTier());
     }
 
     @Test
@@ -50,4 +49,6 @@ class ParticipantServiceTest {
         assertThatThrownBy(() -> participantService.getTierAndPlayCount("saovkovsk"))
                 .isInstanceOf(ParticipantGameIdNotFoundException.class);
     }
+
+
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#23 

## 📝 Description

Enum을 생성하여 Iron, Bronze등 티어에 대한 고유 점수를 넣어줬어요
게임사 API 요청을 통하여 티어를 반환하는 로직을 리팩터링 했어요

테스트 코드에서 실제 플레이어를 조회하여 그 티어와 맞는지 테스트를 하였고
최상위 티어 플레이어는 계속해서 점수가 바뀌어서 println문을 통하여 티어를 표시하였어요
없는 플레이어를 조회하였을 때 실패하는 테스트도 구현하였어요
![image](https://github.com/TheUpperPart/leaguehub-backend/assets/87762815/cf080d71-c5a3-4360-830e-9dcf06703481)


## ✨ Feature

#23 이슈를 참고해주세요


## 👌 Review Change
This closes #23 
