### PR TITLE
Test#27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
 
 }
 

--- a/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoUserDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoUserDto.java
@@ -2,12 +2,12 @@ package leaguehub.leaguehubbackend.dto.kakao;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 import lombok.Getter;
 import lombok.ToString;
 
 import java.io.Serializable;
-
-@Getter
+@Data
 @ToString
 public class KakaoUserDto implements Serializable {
 
@@ -21,7 +21,7 @@ public class KakaoUserDto implements Serializable {
     @JsonProperty("kakao_account")
     private KakaoAccount kakaoAccount;
 
-    @Getter
+    @Data
     @ToString
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Properties {
@@ -35,7 +35,7 @@ public class KakaoUserDto implements Serializable {
         private String thumbnailImage;
 
     }
-    @Getter
+    @Data
     @ToString
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KakaoAccount {
@@ -48,7 +48,7 @@ public class KakaoUserDto implements Serializable {
 
         private Profile profile;
 
-        @Getter
+        @Data
         @ToString
         @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Profile {

--- a/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoUserDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/kakao/KakaoUserDto.java
@@ -8,7 +8,6 @@ import lombok.ToString;
 
 import java.io.Serializable;
 @Data
-@ToString
 public class KakaoUserDto implements Serializable {
 
     private Long id;
@@ -22,7 +21,6 @@ public class KakaoUserDto implements Serializable {
     private KakaoAccount kakaoAccount;
 
     @Data
-    @ToString
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Properties {
 
@@ -36,7 +34,6 @@ public class KakaoUserDto implements Serializable {
 
     }
     @Data
-    @ToString
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KakaoAccount {
 
@@ -49,7 +46,6 @@ public class KakaoUserDto implements Serializable {
         private Profile profile;
 
         @Data
-        @ToString
         @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Profile {
             private String nickname;

--- a/src/test/java/leaguehub/leaguehubbackend/controller/KakaoControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/KakaoControllerTest.java
@@ -1,0 +1,89 @@
+package leaguehub.leaguehubbackend.controller;
+
+import leaguehub.leaguehubbackend.dto.kakao.KakaoTokenResponseDto;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
+import leaguehub.leaguehubbackend.dto.member.LoginMemberResponse;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.exception.kakao.exception.KakaoInvalidCodeException;
+import leaguehub.leaguehubbackend.fixture.UserFixture;
+import leaguehub.leaguehubbackend.service.jwt.JwtService;
+import leaguehub.leaguehubbackend.service.kakao.KakaoService;
+import leaguehub.leaguehubbackend.service.member.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class KakaoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @InjectMocks
+    private KakaoController kakaoController;
+
+    @MockBean
+    private KakaoService kakaoService;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @Test
+    @DisplayName("유효하지 않은 카카오 코드시 KakaoInvalidCodeException")
+    public void whenKakaoCodeIsMissingOrEmpty_thenThrowKakaoInvalidCodeException() throws Exception {
+        HttpHeaders headers = new HttpHeaders();
+
+        assertThrows(KakaoInvalidCodeException.class, () -> {
+            kakaoController.handleKakaoLogin(headers);
+        });
+
+        headers.add("Kakao-Code", "");
+
+        assertThrows(KakaoInvalidCodeException.class, () -> {
+            kakaoController.handleKakaoLogin(headers);
+        });
+    }
+
+    @Test
+    @DisplayName("유효한 카카오 코드시 200 Ok 응답")
+    public void whenValidCode_thenReturnOk() throws Exception {
+        KakaoTokenResponseDto kakaoTokenResponseDto = new KakaoTokenResponseDto();
+        kakaoTokenResponseDto.setAccessToken("validToken");
+        KakaoUserDto kakaoUserDto = new KakaoUserDto();
+        Member member = UserFixture.createMember();
+        LoginMemberResponse loginMemberResponse = UserFixture.createLoginResponse();
+
+        when(kakaoService.getKakaoToken(anyString())).thenReturn(kakaoTokenResponseDto);
+        when(kakaoService.getKakaoUser(kakaoTokenResponseDto)).thenReturn(kakaoUserDto);
+        when(memberService.findMemberByPersonalId(String.valueOf(kakaoUserDto.getId()))).thenReturn(Optional.empty());
+        when(memberService.saveMember(kakaoUserDto)).thenReturn(Optional.of(member));
+        when(jwtService.createTokens(String.valueOf(kakaoUserDto.getId()))).thenReturn(loginMemberResponse);
+
+        mockMvc.perform(get("/api/app/login/kakao")
+                        .header("Kakao-Code", "testCode")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+
+}

--- a/src/test/java/leaguehub/leaguehubbackend/fixture/KakaoTokenResponseDtoFixture.java
+++ b/src/test/java/leaguehub/leaguehubbackend/fixture/KakaoTokenResponseDtoFixture.java
@@ -1,0 +1,18 @@
+package leaguehub.leaguehubbackend.fixture;
+
+import leaguehub.leaguehubbackend.dto.kakao.KakaoTokenResponseDto;
+
+public class KakaoTokenResponseDtoFixture {
+    public static KakaoTokenResponseDto createKakaoTokenResponseDto() {
+        KakaoTokenResponseDto responseDto = new KakaoTokenResponseDto();
+
+        responseDto.setAccessToken("WjqFifAeMXPI2z-OXYFLthU6ag");
+        responseDto.setTokenType("bearer");
+        responseDto.setRefreshToken("eQOIu2LcFLCFX-MwSg44zmwIM50MzxDhaVV");
+        responseDto.setExpiresIn(21599);
+        responseDto.setScope("profile_image profile_nickname");
+        responseDto.setRefreshTokenExpiresIn(5183999);
+
+        return responseDto;
+    }
+}

--- a/src/test/java/leaguehub/leaguehubbackend/fixture/KakaoUserDtoFixture.java
+++ b/src/test/java/leaguehub/leaguehubbackend/fixture/KakaoUserDtoFixture.java
@@ -1,0 +1,31 @@
+package leaguehub.leaguehubbackend.fixture;
+
+import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
+
+public class KakaoUserDtoFixture {
+    public static KakaoUserDto createKakaoUserDto() {
+        KakaoUserDto responseDto = new KakaoUserDto();
+
+        responseDto.setId(2808743059L);
+        responseDto.setConnectedAt("2023-05-27T15:53:05Z");
+
+        KakaoUserDto.Properties properties = new KakaoUserDto.Properties();
+        properties.setNickname("성우");
+        properties.setProfileImage("http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1Y");
+        properties.setThumbnailImage("http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz");
+        responseDto.setProperties(properties);
+
+        KakaoUserDto.KakaoAccount kakaoAccount = new KakaoUserDto.KakaoAccount();
+        kakaoAccount.setProfileNicknameNeedsAgreement(false);
+        kakaoAccount.setProfileImageNeedsAgreement(false);
+
+        KakaoUserDto.KakaoAccount.Profile profile = new KakaoUserDto.KakaoAccount.Profile();
+        profile.setNickname("성우");
+        profile.setThumbnailImageUrl("http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz");
+
+        kakaoAccount.setProfile(profile);
+        responseDto.setKakaoAccount(kakaoAccount);
+
+        return responseDto;
+    }
+}

--- a/src/test/java/leaguehub/leaguehubbackend/service/kakao/KakaoServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/kakao/KakaoServiceTest.java
@@ -1,0 +1,102 @@
+package leaguehub.leaguehubbackend.service.kakao;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoTokenResponseDto;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
+import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
+import leaguehub.leaguehubbackend.exception.kakao.exception.KakaoInvalidCodeException;
+import leaguehub.leaguehubbackend.fixture.KakaoTokenResponseDtoFixture;
+import leaguehub.leaguehubbackend.fixture.KakaoUserDtoFixture;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class KakaoServiceTest {
+
+    MockWebServer mockWebServer;
+    KakaoService kakaoService;
+    WebClient webClient;
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        objectMapper = new ObjectMapper();
+        webClient = WebClient.create(mockWebServer.url("/").toString());
+        kakaoService = new KakaoService(webClient);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    @DisplayName("유효한 카카오 코드일시 카카오 토큰을 받는다")
+    void whenValidKakaoToken_thenGetKakaoToken() throws JsonProcessingException {
+        KakaoTokenResponseDto mockResponse = KakaoTokenResponseDtoFixture.createKakaoTokenResponseDto();
+        String mockResponseJson = objectMapper.writeValueAsString(mockResponse);
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponseJson)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        KakaoTokenResponseDto actualResponse = kakaoService.getKakaoToken("valid_code");
+
+        assertEquals(mockResponse, actualResponse);
+    }
+
+    @Test
+    @DisplayName("유효한 카카오 토큰일시 카카오 유저를 받는다")
+    void whenValidAccessToken_thenGetUserInfo() throws JsonProcessingException {
+        KakaoTokenResponseDto tokenResponseDto = KakaoTokenResponseDtoFixture.createKakaoTokenResponseDto();
+        KakaoUserDto mockResponse = KakaoUserDtoFixture.createKakaoUserDto();
+        String mockResponseJson = objectMapper.writeValueAsString(mockResponse);
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockResponseJson)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        KakaoUserDto actualResponse = kakaoService.getKakaoUser(tokenResponseDto);
+
+        assertEquals(mockResponse, actualResponse);
+    }
+
+    @Test
+    @DisplayName("잘못된 카카오 코드일시 KakaoInvalidCodeException Throw")
+    void whenInvalidKakaoCode_thenThrowKakaoInvalidCodeException() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(400)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        assertThrows(KakaoInvalidCodeException.class, () -> kakaoService.getKakaoToken("invalid_code"));
+    }
+
+    @Test
+    @DisplayName("카카오 서버에 문제가 있을 때 GlobalServerErrorException Throw")
+    void whenKakaoServerProblem_thenThrowGlobalServerErrorException() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        assertThrows(GlobalServerErrorException.class, () -> kakaoService.getKakaoToken("valid_code"));
+    }
+
+
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue

#27 

## 📝 Description

카카오 로그인 기능에 대한 테스트 코드를 추가했습니다.
KakaoControllerTest에서는 유효한/유효하지 않은 카카오 코드에 따른 동작을 검증합니다.
KakaoServiceTest에서는 카카오 코드 및 카카오 토큰에 대한 유효성 검사와 응답에 대한 테스트를 합니다.
WebClient 테스트를 위해 mockWebServer 의존성을 추가하였습니다.

![KakaoControllertest](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/9d4ea96d-f68e-4875-a4ce-9e95f3efdb88)
![카카오서비스](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/e9a8cc33-33f4-4724-a6ca-837b3cd3c79e)


## ✨ Feature

#27 이슈를 참고해주세요

## 👌 Review Change

This closes #27 