### PR TITLE
Fix#30 회원이 아닌 유저의 요청 필터

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/JwtAuthenticationEntryPoint.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import static leaguehub.leaguehubbackend.exception.auth.AuthExceptionCode.AUTH_MEMBER_NOT_FOUND;
+
 
 @Component
 @Slf4j
@@ -21,6 +23,9 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         String exception = (String) request.getAttribute("exception");
         AuthExceptionCode errorCode;
+
+
+
         /**
          * 토큰 없는 경우
          */
@@ -29,6 +34,16 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             setResponse(response, errorCode);
             return;
         }
+
+        /**
+         *  해당 멤버가 데이터베이스에 없을 경우
+         */
+        if (exception.equals(AUTH_MEMBER_NOT_FOUND.getCode())) {
+            errorCode = AUTH_MEMBER_NOT_FOUND;
+            setResponse(response, errorCode);
+            return;
+        }
+
         /**
          * 토큰 만료된 경우
          */

--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionCode.java
@@ -33,6 +33,7 @@ public enum AuthExceptionCode implements ExceptionCode {
     INVALID_MEMBER_ROLE(FORBIDDEN, "AT-C-102", "유효하지 않은 사용자 권한입니다."),
     NOT_AUTHORIZATION_USER(NOT_FOUND, "AT-C-103", "인가된 사용자가 아닙니다."),
     INVALID_REDIRECT_URI(UNAUTHORIZED, "AT-C-104", "허용되지 않은 리다이렉션 URI 입니다."),
+    AUTH_MEMBER_NOT_FOUND(NOT_FOUND, "AT-C-105", "존재하지 않는 회원입니다."),
 
 
     /**

--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/exception/AuthMemberNotFoundException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/exception/AuthMemberNotFoundException.java
@@ -1,0 +1,18 @@
+package leaguehub.leaguehubbackend.exception.auth.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import org.springframework.security.core.AuthenticationException;
+
+import static leaguehub.leaguehubbackend.exception.auth.AuthExceptionCode.AUTH_MEMBER_NOT_FOUND;
+
+public class AuthMemberNotFoundException extends AuthenticationException {
+    private final ExceptionCode exceptionCode;
+    public AuthMemberNotFoundException() {
+        super(AUTH_MEMBER_NOT_FOUND.getCode());
+        this.exceptionCode = AUTH_MEMBER_NOT_FOUND;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue

#30 

## 📝 Description

회원이 아닌 유저가 토큰 사용하여 요청시 필터링하여 AUTH_MEMBER_NOT_FOUND 코드를 return합니다.

## ✨ Feature


## 👌 Review Change
This closes #30 
