### PR TITLE
Feat#35 로그아웃 기능

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
@@ -1,12 +1,16 @@
 package leaguehub.leaguehubbackend.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import leaguehub.leaguehubbackend.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,5 +28,14 @@ public class MemberController {
         UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
 
         return memberService.getMemberProfile(userDetails.getUsername());
+    }
+
+    @PostMapping("/app/logout")
+    public ResponseEntity<String> handleKakaoLogout(HttpServletRequest request, HttpServletResponse response) {
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+
+        memberService.logoutMember(userDetails.getUsername(), userDetails, request, response);
+
+        return ResponseEntity.ok("Logout Success!");
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -1,16 +1,21 @@
 package leaguehub.leaguehubbackend.service.member;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
 import leaguehub.leaguehubbackend.entity.member.Member;
 
-import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Service;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.Authentication;
 
 
 import java.util.Optional;
@@ -52,6 +57,22 @@ public class MemberService {
                 .profileImageUrl(member.getProfileImageUrl())
                 .nickName(member.getNickname())
                 .build();
+    }
+
+    public void logoutMember(String personalId, UserDetails userDetails, HttpServletRequest request, HttpServletResponse response) {
+        Member member = memberRepository.findMemberByPersonalId(personalId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        if (member.getPersonalId().equals(userDetails.getUsername())) {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null){
+                new SecurityContextLogoutHandler().logout(request, response, auth);
+                member.updateRefreshToken(null);
+                memberRepository.save(member);
+            }
+        } else {
+            throw new MemberNotFoundException();
+        }
     }
 }
 

--- a/src/test/java/leaguehub/leaguehubbackend/controller/MemberControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/MemberControllerTest.java
@@ -1,5 +1,7 @@
 package leaguehub.leaguehubbackend.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
 import leaguehub.leaguehubbackend.fixture.ProfileResponseFixture;
 import leaguehub.leaguehubbackend.service.member.MemberService;
@@ -11,15 +13,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
@@ -31,23 +36,32 @@ class MemberControllerTest {
     @MockBean
     private MemberService memberService;
 
+    @BeforeEach
+    void setUp() throws IOException {
+        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                .username("12345")
+                .password("12345")
+                .roles("USER")
+                .build();
+
+        GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetailsUser, null
+                , authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    }
+
     @Test
     @DisplayName("로그인한 상태에서 사용자 정보 요청시 사용자 정보 return")
     public void whenAuthenticated_thenReturnProfile() throws Exception {
 
-        UserDetails userDetails = mock(UserDetails.class);
-
-        when(userDetails.getUsername()).thenReturn("12345");
-
-        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, "");
-
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
         ProfileResponseDto mockResponse = ProfileResponseFixture.createProfileResponse();
 
-        UserDetails userContext = SecurityUtils.getAuthenticatedUser();
+        UserDetails userDetail = SecurityUtils.getAuthenticatedUser();
 
-        when(memberService.getMemberProfile(userContext.getUsername()))
+        when(memberService.getMemberProfile(userDetail.getUsername()))
                 .thenReturn(mockResponse);
 
         mockMvc.perform(get("/api/profile"))
@@ -56,5 +70,30 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.profileImageUrl").value("http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1Y"))
                 .andExpect(jsonPath("$.nickName").value("성우"));
 
+    }
+
+    @Test
+    @DisplayName("로그아웃 요청시 성공 메시지 return")
+    public void whenLogout_thenReturnSuccessMessage() throws Exception {
+
+        UserDetails userDetail = SecurityUtils.getAuthenticatedUser();
+
+        doNothing().when(memberService).logoutMember(
+                eq(userDetail.getUsername()),
+                eq(userDetail),
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class)
+        );
+
+        mockMvc.perform(post("/api/app/logout"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Logout Success!"));
+
+        verify(memberService).logoutMember(
+                eq(userDetail.getUsername()),
+                eq(userDetail),
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class)
+        );
     }
 }

--- a/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
@@ -1,0 +1,143 @@
+package leaguehub.leaguehubbackend.service.member;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
+import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
+import leaguehub.leaguehubbackend.fixture.KakaoUserDtoFixture;
+import leaguehub.leaguehubbackend.fixture.UserFixture;
+import leaguehub.leaguehubbackend.repository.member.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    void findMemberByPersonalId() {
+        Member expectedMember = UserFixture.createMember();
+        when(memberRepository.findMemberByPersonalId("id")).thenReturn(Optional.of(expectedMember));
+
+        Optional<Member> actualMember = memberService.findMemberByPersonalId("id");
+
+        assertTrue(actualMember.isPresent());
+        assertEquals(expectedMember, actualMember.get());
+    }
+
+    @Test
+    void findMemberByRefreshToken() {
+        Member expectedMember = UserFixture.createMember();
+        when(memberRepository.findByRefreshToken("refreshToken")).thenReturn(Optional.of(expectedMember));
+
+        Optional<Member> actualMember = memberService.findMemberByRefreshToken("refreshToken");
+
+        assertTrue(actualMember.isPresent());
+        assertEquals(expectedMember, actualMember.get());
+    }
+
+    @Test
+    void saveMember() {
+        KakaoUserDto kakaoUserDto = KakaoUserDtoFixture.createKakaoUserDto();
+        Member expectedMember = Member.kakaoUserToMember(KakaoUserDtoFixture.createKakaoUserDto()); 
+        when(memberRepository.save(any(Member.class))).thenReturn(expectedMember);
+
+        Optional<Member> actualMember = memberService.saveMember(kakaoUserDto);
+
+        assertTrue(actualMember.isPresent());
+        assertEquals(expectedMember.getId(), actualMember.get().getId());
+        assertEquals(expectedMember.getPersonalId(), actualMember.get().getPersonalId());
+        assertEquals(expectedMember.getRefreshToken(), actualMember.get().getRefreshToken());
+        assertEquals(expectedMember.getLoginProvider(), actualMember.get().getLoginProvider());
+
+    }
+
+    @Test
+    void validateMember() {
+        Member expectedMember = UserFixture.createMember();
+        when(memberRepository.findMemberByPersonalId("id")).thenReturn(Optional.of(expectedMember));
+
+        Member actualMember = memberService.validateMember("id");
+        assertEquals(expectedMember, actualMember);
+
+        when(memberRepository.findMemberByPersonalId(eq("invalidId"))).thenReturn(Optional.empty());
+
+        assertThrows(MemberNotFoundException.class, () -> memberService.validateMember("invalidId"));
+    }
+
+    @Test
+    void getMemberProfile() {
+        Member testMember = UserFixture.createMember();
+        when(memberRepository.findMemberByPersonalId("id")).thenReturn(Optional.of(testMember));
+
+        ProfileResponseDto profile = memberService.getMemberProfile("id");
+
+        assertEquals(testMember.getPersonalId(), profile.getProfileId());
+        assertEquals(testMember.getProfileImageUrl(), profile.getProfileImageUrl());
+        assertEquals(testMember.getNickname(), profile.getNickName());
+
+        when(memberRepository.findMemberByPersonalId("invalidId")).thenReturn(Optional.empty());
+
+        assertThrows(MemberNotFoundException.class, () -> memberService.getMemberProfile("invalidId"));
+    }
+
+    @Test
+    void logoutMember() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        UserDetails userDetails = mock(UserDetails.class);
+        Member testMember = UserFixture.createMember();
+        when(memberRepository.findMemberByPersonalId("id")).thenReturn(Optional.of(testMember));
+        when(userDetails.getUsername()).thenReturn("id");
+
+        Authentication auth = Mockito.mock(Authentication.class);
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(securityContext);
+
+        memberService.logoutMember("id", userDetails, request, response);
+
+        verify(memberRepository).save(testMember);
+
+    }
+
+    @Test
+    void logoutMember_WhenUsernamesDoNotMatch() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        UserDetails userDetails = mock(UserDetails.class);
+        Member testMember = UserFixture.createMember();
+        when(memberRepository.findMemberByPersonalId("id")).thenReturn(Optional.of(testMember));
+        when(userDetails.getUsername()).thenReturn("otherId");
+
+        Authentication auth = Mockito.mock(Authentication.class);
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(securityContext);
+
+        assertThrows(MemberNotFoundException.class, () -> memberService.logoutMember("id", userDetails, request, response));
+    }
+
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue

#35 

## 📝 Description
멤버 로그아웃 기능과 테스트 코드를 구현했습니다.
UserDetails에 있는 유저 정보 logout 시키고 refreshToken을 삭제합니다.

![MemberController](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/8a7d88d3-b494-438a-9aff-29c07eba8907)
![MemberService](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/934b5ba6-5d4b-495d-9545-cc25feb78e5b)


## ✨ Feature

#35 를 참고해주세요

## 👌 Review Change

This closes #35 