### PR TITLE
Fix#39 : 리프레시 토큰 상태코드 변경

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/JwtController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/JwtController.java
@@ -3,9 +3,9 @@ package leaguehub.leaguehubbackend.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import leaguehub.leaguehubbackend.dto.member.LoginMemberResponse;
 import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidRefreshToken;
 import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidTokenException;
 import leaguehub.leaguehubbackend.exception.auth.exception.AuthTokenNotFoundException;
-import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 import leaguehub.leaguehubbackend.service.jwt.JwtService;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +47,7 @@ public class JwtController {
 
         Member member = memberOpt.orElseThrow(() -> {
             log.info("해당 refreshToken을 가지고 있는 멤버 없음: " + refreshToken);
-            return new MemberNotFoundException();
+            return new AuthInvalidRefreshToken();
         });
 
         LoginMemberResponse loginMemberResponse = jwtService.createTokens(member.getPersonalId());

--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionCode.java
@@ -20,7 +20,7 @@ public enum AuthExceptionCode implements ExceptionCode {
     EXPIRED_TOKEN(UNAUTHORIZED, "AT-C-002", "만료된 토큰입니다."),
     NOT_EXPIRED_TOKEN(BAD_REQUEST, "AT-C-003", "만료되지 않은 토큰입니다."),
     REQUEST_TOKEN_NOT_FOUND(BAD_REQUEST, "AT-C-004", "요청에 토큰이 존재하지 않습니다."),
-    INVALID_REFRESH_TOKEN(BAD_REQUEST, "AT-C-005", "유효하지 않은 리프레쉬 토큰입니다."),
+    INVALID_REFRESH_TOKEN(BAD_REQUEST, "AT-C-005", "해당 리프레쉬 토큰을 가지는 멤버가 없습니다."),
     UNTRUSTED_CREDENTIAL(UNAUTHORIZED, "AT-C-006", "신뢰할 수 없는 자격증명 입니다."),
     LOGGED_OUT_TOKEN(UNAUTHORIZED, "AT-C-007", "로그아웃된 토큰입니다."),
 

--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionHandler.java
@@ -1,6 +1,7 @@
 package leaguehub.leaguehubbackend.exception.auth;
 
 import leaguehub.leaguehubbackend.exception.auth.exception.AuthExpiredTokenException;
+import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidRefreshToken;
 import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidTokenException;
 import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
@@ -31,6 +32,19 @@ public class AuthExceptionHandler {
     @ExceptionHandler(AuthExpiredTokenException.class)
     public ResponseEntity<ExceptionResponse> authExpiredTokenException(
             AuthExpiredTokenException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(AuthInvalidRefreshToken.class)
+    public ResponseEntity<ExceptionResponse> authInvalidRefreshToken(
+            AuthInvalidRefreshToken e
     ) {
         ExceptionCode exceptionCode = e.getExceptionCode();
         log.error("{}", exceptionCode.getMessage());

--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/exception/AuthInvalidRefreshToken.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/exception/AuthInvalidRefreshToken.java
@@ -1,0 +1,19 @@
+package leaguehub.leaguehubbackend.exception.auth.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import org.springframework.security.core.AuthenticationException;
+
+import static leaguehub.leaguehubbackend.exception.auth.AuthExceptionCode.INVALID_REFRESH_TOKEN;
+
+
+public class AuthInvalidRefreshToken extends AuthenticationException {
+    private final ExceptionCode exceptionCode;
+    public AuthInvalidRefreshToken() {
+        super(INVALID_REFRESH_TOKEN.getCode());
+        this.exceptionCode = INVALID_REFRESH_TOKEN;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/exception/AuthInvalidTokenException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/exception/AuthInvalidTokenException.java
@@ -1,6 +1,5 @@
 package leaguehub.leaguehubbackend.exception.auth.exception;
 
-import leaguehub.leaguehubbackend.exception.auth.AuthExceptionCode;
 import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
 import org.springframework.security.core.AuthenticationException;
 
@@ -10,7 +9,7 @@ public class AuthInvalidTokenException extends AuthenticationException {
     private final ExceptionCode exceptionCode;
     public AuthInvalidTokenException() {
         super(INVALID_TOKEN.getCode());
-        this.exceptionCode = AuthExceptionCode.INVALID_TOKEN;
+        this.exceptionCode = INVALID_TOKEN;
     }
 
     public ExceptionCode getExceptionCode() {

--- a/src/test/java/leaguehub/leaguehubbackend/controller/JwtControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/JwtControllerTest.java
@@ -2,7 +2,6 @@ package leaguehub.leaguehubbackend.controller;
 
 import leaguehub.leaguehubbackend.dto.member.LoginMemberResponse;
 import leaguehub.leaguehubbackend.entity.member.Member;
-import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidTokenException;
 import leaguehub.leaguehubbackend.fixture.UserFixture;
 import leaguehub.leaguehubbackend.service.jwt.JwtService;
 import leaguehub.leaguehubbackend.service.member.MemberService;
@@ -20,7 +19,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Optional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
@@ -69,6 +67,7 @@ public class JwtControllerTest {
         mockMvc.perform(get("/api/reissue/token")
                         .header("Authorization-refresh", "Bearer invalidToken")
                         .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("AT-C-001"));
     }
 
@@ -81,7 +80,8 @@ public class JwtControllerTest {
         mockMvc.perform(get("/api/reissue/token")
                         .header("Authorization-refresh", "Bearer validToken")
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound());
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.code").value("AT-C-005"));
     }
 
     @Test
@@ -90,6 +90,7 @@ public class JwtControllerTest {
         Mockito.when(jwtService.extractRefreshToken(Mockito.any())).thenReturn(Optional.empty());
         mockMvc.perform(get("/api/reissue/token")
                         .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError())
                 .andExpect(jsonPath("$.code").value("AT-C-004"));
     }
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#39 

## 📝 Description

해당 리프레쉬 토큰을 가지고 있는 멤버가 없을시 "요청에 토큰이 존재하지 않습니다" 를 return 하는 버그를 고쳤습니다.
새로운 핸들러를 구현하여 "해당 리프레쉬 토큰을 가지는 멤버가 없습니다." return 합니다.

## ✨ Feature

#39 이슈를 참고해주세요

## 👌 Review Change

This closes #39 