### PR TITLE
fix: AuthExceptionHandler 누락

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionHandler.java
@@ -1,14 +1,14 @@
 package leaguehub.leaguehubbackend.exception.auth;
 
-import leaguehub.leaguehubbackend.exception.auth.exception.AuthExpiredTokenException;
-import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidRefreshToken;
-import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidTokenException;
+import leaguehub.leaguehubbackend.exception.auth.exception.*;
 import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
@@ -45,6 +45,19 @@ public class AuthExceptionHandler {
     @ExceptionHandler(AuthInvalidRefreshToken.class)
     public ResponseEntity<ExceptionResponse> authInvalidRefreshToken(
             AuthInvalidRefreshToken e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(AuthTokenNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> authNoRefreshToken(
+            AuthTokenNotFoundException e
     ) {
         ExceptionCode exceptionCode = e.getExceptionCode();
         log.error("{}", exceptionCode.getMessage());


### PR DESCRIPTION
## 🙆‍♂️ Issue

#56 

## 📝 Description

AuthExceptionHandler 으로 인한 잘못된 에러 메시지가 반환되는 것을 수정했습니다.

## ✨ Feature

#56 을 참고해주세요

## 👌 Review Change

This closes #56 