### PR TITLE
Feat#58 최초 로그인시 Guest와 일반 User 구분

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import leaguehub.leaguehubbackend.dto.member.LoginMemberResponse;
 import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.member.MemberService;
@@ -19,10 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -60,5 +56,21 @@ public class MemberController  {
         memberService.logoutMember(userDetails.getUsername(), userDetails, request, response);
 
         return ResponseEntity.ok("Logout Success!");
+    }
+
+    @Operation(summary = "멤버 이메일 등록", description = "멤버의 이메일을 등록한다.")
+    @Parameter(in = ParameterIn.PATH, name = "email", description = "email", required = true)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "이메일 등록 성공", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "MB-C-003 유효하지 않은 이메일 형식입니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "409", description = "MB-C-004 중복되는 이메일입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+    })
+    @PostMapping("/member/email")
+    public ResponseEntity<String> updateEmail(@RequestParam String email) {
+
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+        memberService.updateEmail(email, userDetails.getUsername());
+
+        return ResponseEntity.ok(email);
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/member/LoginMemberResponse.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/member/LoginMemberResponse.java
@@ -9,5 +9,6 @@ public class LoginMemberResponse {
 
     private String accessToken;
     private String refreshToken;
+    private boolean verifiedUser;
 }
 

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/BaseRole.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/BaseRole.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum BaseRole {
     ADMIN("ROLE_ADMIN"),
-    USER("ROLE_USER");
+    USER("ROLE_USER"),
+    GUEST("ROLE_GUEST");
     private final String key;
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -27,9 +27,10 @@ public class Member extends BaseTimeEntity {
 
     private String refreshToken;
 
+    private String email;
+
     @Enumerated(EnumType.STRING)
     private LoginProvider loginProvider;
-
 
     @Enumerated(EnumType.STRING)
     private BaseRole baseRole;
@@ -37,13 +38,15 @@ public class Member extends BaseTimeEntity {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+    public void updateEmail(String email) { this.email = email; }
+    public void updateRole(BaseRole role) { this.baseRole = role; }
 
     public static Member kakaoUserToMember(KakaoUserDto kakaoUserDto) {
         return Member.builder()
                 .personalId(String.valueOf(kakaoUserDto.getId()))
                 .nickname(kakaoUserDto.getProperties().getNickname())
                 .profileImageUrl(kakaoUserDto.getProperties().getProfileImage())
-                .baseRole(BaseRole.USER)
+                .baseRole(BaseRole.GUEST)
                 .loginProvider(LoginProvider.KAKAO)
                 .build();
 

--- a/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionCode.java
@@ -12,8 +12,9 @@ import static org.springframework.http.HttpStatus.*;
 public enum MemberExceptionCode implements ExceptionCode {
 
     MEMBER_NOT_FOUND(NOT_FOUND, "MB-C-001", "존재하지 않는 회원입니다."),
-    INVALID_MEMBER_IMAGE(BAD_REQUEST, "MB-C-002", "유효하지 않은 이미지입니다.");
-
+    INVALID_MEMBER_IMAGE(BAD_REQUEST, "MB-C-002", "유효하지 않은 이미지입니다."),
+    INVALID_EMAIL_ADDRESS(BAD_REQUEST, "MB-C-003", "유효하지 않은 이메일 형식입니다."),
+    DUPLICATE_EMAIL_EXCEPTION(CONFLICT, "MB-C-004", "중복되는 이메일입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionHandler.java
@@ -1,8 +1,9 @@
 package leaguehub.leaguehubbackend.exception.member;
 
-import leaguehub.leaguehubbackend.exception.auth.exception.AuthExpiredTokenException;
 import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.exception.member.exception.DuplicateEmailException;
+import leaguehub.leaguehubbackend.exception.member.exception.InvalidEmailAddressException;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,32 @@ public class MemberExceptionHandler {
     @ExceptionHandler(MemberNotFoundException.class)
     public ResponseEntity<ExceptionResponse> memberNotFoundException(
             MemberNotFoundException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(InvalidEmailAddressException.class)
+    public ResponseEntity<ExceptionResponse> invalidEmailAddress(
+            InvalidEmailAddressException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(DuplicateEmailException.class)
+    public ResponseEntity<ExceptionResponse> invalidEmailAddress(
+            DuplicateEmailException e
     ) {
         ExceptionCode exceptionCode = e.getExceptionCode();
         log.error("{}", exceptionCode.getMessage());

--- a/src/main/java/leaguehub/leaguehubbackend/exception/member/exception/DuplicateEmailException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/member/exception/DuplicateEmailException.java
@@ -1,0 +1,19 @@
+package leaguehub.leaguehubbackend.exception.member.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.member.MemberExceptionCode.DUPLICATE_EMAIL_EXCEPTION;
+
+public class DuplicateEmailException extends RuntimeException{
+
+    private final ExceptionCode exceptionCode;
+
+    public DuplicateEmailException() {
+        super(DUPLICATE_EMAIL_EXCEPTION.getMessage());
+        this.exceptionCode = DUPLICATE_EMAIL_EXCEPTION;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/member/exception/InvalidEmailAddressException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/member/exception/InvalidEmailAddressException.java
@@ -1,0 +1,20 @@
+package leaguehub.leaguehubbackend.exception.member.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.member.MemberExceptionCode.INVALID_EMAIL_ADDRESS;
+
+public class InvalidEmailAddressException extends IllegalArgumentException  {
+    private final ExceptionCode exceptionCode;
+
+    public InvalidEmailAddressException() {
+
+        super(INVALID_EMAIL_ADDRESS.getMessage());
+        this.exceptionCode = INVALID_EMAIL_ADDRESS;
+
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/member/MemberRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/member/MemberRepository.java
@@ -11,5 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberByPersonalId(String personalId);
     Optional<Member> findByNickname(String nickname);
     Optional<Member> findByRefreshToken(String refreshToken);
+    Optional<Member> findMemberByEmail(String email);
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -5,8 +5,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
+import leaguehub.leaguehubbackend.entity.member.BaseRole;
 import leaguehub.leaguehubbackend.entity.member.Member;
 
+import leaguehub.leaguehubbackend.exception.member.exception.DuplicateEmailException;
+import leaguehub.leaguehubbackend.exception.member.exception.InvalidEmailAddressException;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
@@ -17,8 +20,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.Authentication;
 
-
 import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static leaguehub.leaguehubbackend.exception.member.MemberExceptionCode.INVALID_EMAIL_ADDRESS;
 
 @Service
 @RequiredArgsConstructor
@@ -73,6 +78,31 @@ public class MemberService {
         } else {
             throw new MemberNotFoundException();
         }
+    }
+
+    @Transactional
+    public void updateEmail(String email, String personalId) {
+
+        if (!isValidEmailFormat(email)) {
+            throw new InvalidEmailAddressException();
+        }
+
+        if (memberRepository.findMemberByEmail(email).isPresent()) {
+            throw new DuplicateEmailException();
+        }
+
+        Member member = memberRepository.findMemberByPersonalId(personalId)
+                .orElseThrow(MemberNotFoundException::new);
+        member.updateEmail(email);
+        member.updateRole(BaseRole.USER);
+
+        memberRepository.save(member);
+    }
+
+    public static boolean isValidEmailFormat(String email) {
+        String emailRegex = "^[A-Za-z0-9+_.-]+@(.+)$";
+        Pattern pat = Pattern.compile(emailRegex);
+        return pat.matcher(email).matches();
     }
 }
 

--- a/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
+++ b/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
@@ -17,6 +17,7 @@ public class UserFixture {
         Member member = Member.builder()
                 .personalId("id").profileImageUrl("url")
                 .nickname("id").refreshToken("refreshToken")
+                .email("id@example.com")
                 .loginProvider(LoginProvider.KAKAO).baseRole(BaseRole.USER)
                 .build();
 

--- a/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
 import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.exception.member.exception.DuplicateEmailException;
+import leaguehub.leaguehubbackend.exception.member.exception.InvalidEmailAddressException;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 import leaguehub.leaguehubbackend.fixture.KakaoUserDtoFixture;
 import leaguehub.leaguehubbackend.fixture.UserFixture;
@@ -143,5 +145,39 @@ class MemberServiceTest {
 
         assertThrows(MemberNotFoundException.class, () -> memberService.logoutMember("id", userDetails, request, response));
     }
+
+    @Test
+    void updateEmailWithValidEmail() {
+        String testEmail = "test@example.com";
+        String testId = "12345678";
+
+        Member testMember = UserFixture.createMember();
+        when(memberRepository.findMemberByEmail(testEmail)).thenReturn(Optional.empty());
+        when(memberRepository.findMemberByPersonalId(testId)).thenReturn(Optional.of(testMember));
+
+        assertDoesNotThrow(() -> memberService.updateEmail(testEmail, testId));
+        verify(memberRepository, times(1)).save(any(Member.class));
+    }
+
+    @Test
+    void updateEmailWithInvalidEmail() {
+        String testEmail = "invalidemail";
+        String testId = "12345678";
+
+        assertThrows(InvalidEmailAddressException.class, () -> memberService.updateEmail(testEmail, testId));
+    }
+
+    @Test
+    void updateEmailWithDuplicateEmail() {
+        String testEmail = "id@example.com";
+        String testId = "12345678";
+
+        Member duplicateMember = UserFixture.createMember();
+
+        when(memberRepository.findMemberByEmail(testEmail)).thenReturn(Optional.of(duplicateMember));
+
+        assertThrows(DuplicateEmailException.class, () -> memberService.updateEmail(testEmail, testId));
+    }
+
 
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#58 

## 📝 Description
이 변경사항은 최초 로그인시 이메일을 입력한 유저와 입력하지 않은 유저를 구분하기 위해
최초 로그인시 ROLE_GUEST을 부여 받습니다.
Email 등록 api를 사용하여 Email 등록시ROLE_USER로 변경하여 서비스를 정상 사용 할 수 있습니다.

추가된 코드에 따른 테스트 코드도 구현했습니다.

![웹 캡처_24-7-2023_125345_localhost](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/68a6a4d7-db1b-4055-8aa5-32fe9b2cfd1f)
![웹 캡처_24-7-2023_125250_localhost](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/154dba94-d92d-4bcd-9f94-46131e589c1a)

## ✨ Feature

1. 유저 최초 로그인시 guest role 부여
2. email 입력시 Role user로 변경
3. 테스트 코드 구현

## 👌 Review Change

This closes #58 