### PR TITLE
Feat#89 클라이언트 UserProfile 요청시 email 정보 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/dto/member/ProfileResponseDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/member/ProfileResponseDto.java
@@ -13,4 +13,8 @@ public class ProfileResponseDto {
 
     private String nickName;
 
+    private String email;
+
+    private Boolean userEmailVerified;
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -29,6 +29,8 @@ public class Member extends BaseTimeEntity {
 
     private String email;
 
+    private boolean emailUserVerified;
+
     @Enumerated(EnumType.STRING)
     private LoginProvider loginProvider;
 
@@ -46,6 +48,7 @@ public class Member extends BaseTimeEntity {
                 .personalId(String.valueOf(kakaoUserDto.getId()))
                 .nickname(kakaoUserDto.getProperties().getNickname())
                 .profileImageUrl(kakaoUserDto.getProperties().getProfileImage())
+                .emailUserVerified(false)
                 .baseRole(BaseRole.GUEST)
                 .loginProvider(LoginProvider.KAKAO)
                 .build();

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -31,7 +31,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-
     public Optional<Member> findMemberByPersonalId(String personalId) {
         return memberRepository.findMemberByPersonalId(personalId);
     }
@@ -61,6 +60,8 @@ public class MemberService {
                 .profileId(member.getPersonalId())
                 .profileImageUrl(member.getProfileImageUrl())
                 .nickName(member.getNickname())
+                .email(member.getEmail() != null && member.isEmailUserVerified() ? member.getEmail() : "N/A")
+                .userEmailVerified(member.isEmailUserVerified())
                 .build();
     }
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -60,9 +60,16 @@ public class MemberService {
                 .profileId(member.getPersonalId())
                 .profileImageUrl(member.getProfileImageUrl())
                 .nickName(member.getNickname())
-                .email(member.getEmail() != null && member.isEmailUserVerified() ? member.getEmail() : "N/A")
+                .email(getVerifiedEmail(member))
                 .userEmailVerified(member.isEmailUserVerified())
                 .build();
+    }
+
+    public String getVerifiedEmail(Member member) {
+        if (member.getEmail() != null && member.isEmailUserVerified()) {
+            return member.getEmail();
+        }
+        return "N/A";
     }
 
     public void logoutMember(String personalId, UserDetails userDetails, HttpServletRequest request, HttpServletResponse response) {


### PR DESCRIPTION
## 🙆‍♂️ Issue

#89 

## 📝 Description

프로필 조회시 email 과 email이 인증이 되었는지에 대한 정보를 추가로 반환합니다.
유저가 인증이 되었는지 확인을 위해 Memer Entity에 emailUserVerified를 추가했습니다.

## ✨ Feature

1. Entity에 email이 인증이 되었는지 확인을 위한 userEmailVerified 추가 
2. 클라이언트에서 유저의 이메일과 이메일이 유효한지 판별하기 위해 email과 emailUserVerified 데이터 반환

## 👌 Review Change

This closes #89 