### PR TITLE
Feat#90 채널 룰과 참가자 제한 관리 작업

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/Controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/MatchController.java
@@ -1,4 +1,4 @@
-package leaguehub.leaguehubbackend.Controller;
+package leaguehub.leaguehubbackend.controller;
 
 import leaguehub.leaguehubbackend.dto.match.MatchRankResultDto;
 import leaguehub.leaguehubbackend.dto.match.MatchResponseDto;

--- a/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantResponseDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantResponseDto.java
@@ -9,4 +9,6 @@ public class ParticipantResponseDto {
     String channelLink;
 
     String gameId;
+
+    String nickname;
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
@@ -108,4 +108,11 @@ public class Channel extends BaseTimeEntity {
         return channelImageUrl;
     }
 
+    //실제 참가자 수를 업데이트 한다.
+    public Channel updateRealPlayer(Integer realPlayer){
+        this.realPlayer = realPlayer;
+
+        return this;
+    }
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
@@ -94,9 +94,10 @@ public class Participant extends BaseTimeEntity {
     }
 
 
-    public Participant updateParticipantStatus(String gameId, String gameTier){
+    public Participant updateParticipantStatus(String gameId, String gameTier, String nickname){
         this.gameId = gameId;
         this.gameTier = gameTier;
+        this.nickname = nickname;
 
         this.requestStatus = RequestStatus.REQUEST;
 

--- a/src/main/java/leaguehub/leaguehubbackend/exception/participant/ParticipantExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/participant/ParticipantExceptionCode.java
@@ -21,7 +21,8 @@ public enum ParticipantExceptionCode implements ExceptionCode {
     PARTICIPANT_ALREADY_REQUESTED(BAD_REQUEST, "PA-C-010", "이미 참가요청 되었습니다."),
     PARTICIPANT_REJECTED_REQUESTED(BAD_REQUEST, "PA-C-011", "거절된 사용자입니다."),
     PARTICIPANT_DUPLICATED_GAME_ID(BAD_REQUEST, "PA-C-012", "해당 게임아이디는 이미 존재합니다."),
-    PARTICIPANT_NOT_GAME_HOST(BAD_REQUEST, "PA-C-013", "해당 채널 관리자가 아닙니다.");
+    PARTICIPANT_NOT_GAME_HOST(BAD_REQUEST, "PA-C-013", "해당 채널 관리자가 아닙니다."),
+    PARTICIPANT_REAL_PLAYER_IS_MAX(BAD_REQUEST, "PA-C-014", "플레이어의 수가 최대입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/leaguehub/leaguehubbackend/exception/participant/ParticipantExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/participant/ParticipantExceptionHandler.java
@@ -143,4 +143,17 @@ public class ParticipantExceptionHandler {
         );
     }
 
+    @ExceptionHandler(ParticipantRealPlayerIsMaxException.class)
+    public ResponseEntity<ExceptionResponse> ParticipantRealPlayerIsMaxException(
+            ParticipantRealPlayerIsMaxException e
+    ){
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/exception/participant/exception/ParticipantRealPlayerIsMaxException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/participant/exception/ParticipantRealPlayerIsMaxException.java
@@ -1,0 +1,19 @@
+package leaguehub.leaguehubbackend.exception.participant.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.participant.ParticipantExceptionCode.PARTICIPANT_REAL_PLAYER_IS_MAX;
+
+public class ParticipantRealPlayerIsMaxException extends RuntimeException{
+
+    private final ExceptionCode exceptionCode;
+
+    public ParticipantRealPlayerIsMaxException(){
+        super(PARTICIPANT_REAL_PLAYER_IS_MAX.getMessage());
+        this.exceptionCode = PARTICIPANT_REAL_PLAYER_IS_MAX;
+    }
+
+    public ExceptionCode getExceptionCode(){
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -347,7 +347,7 @@ public class ParticipantService {
 
         checkRule(channelRule, userDetail, tier);
 
-        participant.updateParticipantStatus(responseDto.getGameId(), tier.getGameRank().toString());
+        participant.updateParticipantStatus(responseDto.getGameId(), tier.getGameRank().toString(), responseDto.getNickname());
     }
 
     /**

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -391,6 +391,14 @@ public class ParticipantService {
 
     }
 
+    public void checkRealPlayerCount(String channelLink) {
+        Channel channel = channelRepository.findByChannelLink(channelLink)
+                .orElseThrow(ChannelNotFoundException::new);
+
+        if (channel.getRealPlayer() >= channel.getMaxPlayer())
+            throw new ParticipantRealPlayerIsMaxException();
+    }
+
     /**
      * 해당 채널의 요청한 참가자를 승인해줌
      *
@@ -400,6 +408,8 @@ public class ParticipantService {
     public void approveParticipantRequest(String channelLink, Long participantId) {
 
         checkRoleHost(channelLink);
+
+        checkRealPlayerCount(channelLink);
 
         Participant findParticipant = participantRepository.findParticipantByIdAndChannel_ChannelLink(participantId, channelLink);
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -421,7 +421,7 @@ public class ParticipantService {
         Channel channel = channelRepository.findByChannelLink(channelLink)
                 .orElseThrow(ChannelNotFoundException::new);
 
-        channel.updateRealPlayer(playerLists.toArray().length);
+        channel.updateRealPlayer(playerLists.size());
 
     }
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -1,12 +1,14 @@
 package leaguehub.leaguehubbackend.service.participant;
 
 import leaguehub.leaguehubbackend.dto.participant.*;
+import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.entity.channel.ChannelRule;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.entity.participant.GameTier;
 import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.entity.participant.RequestStatus;
 import leaguehub.leaguehubbackend.entity.participant.Role;
+import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundException;
 import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
 import leaguehub.leaguehubbackend.exception.participant.exception.*;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
@@ -403,6 +405,14 @@ public class ParticipantService {
 
         findParticipant.approveParticipantMatch();
 
+        List<Participant> playerLists = participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink,
+                Role.PLAYER, RequestStatus.DONE);
+
+        Channel channel = channelRepository.findByChannelLink(channelLink)
+                .orElseThrow(ChannelNotFoundException::new);
+
+        channel.updateRealPlayer(playerLists.toArray().length);
+
     }
 
     /**
@@ -448,7 +458,6 @@ public class ParticipantService {
                 })
                 .collect(Collectors.toList());
     }
-
 
 
 }

--- a/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
@@ -29,6 +29,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -97,10 +99,10 @@ class ParticipantControllerTest {
         Participant doneParticipant1 = participantRepository.save(Participant.participateChannel(doneMember1, channel));
         Participant doneParticipant2 = participantRepository.save(Participant.participateChannel(doneMember2, channel));
 
-        alreadyParticipant.updateParticipantStatus("bronze", "bronze");
+        alreadyParticipant.updateParticipantStatus("bronze", "bronze", "요청한사람");
         rejectedParticipant.rejectParticipantRequest();
-        doneParticipant1.updateParticipantStatus("참가된사람1", "platinum");
-        doneParticipant2.updateParticipantStatus("참가된사람2", "iron");
+        doneParticipant1.updateParticipantStatus("참가된사람1", "platinum", "참가된사람1");
+        doneParticipant2.updateParticipantStatus("참가된사람2", "iron", "참가된사람2");
         doneParticipant1.approveParticipantMatch();
         doneParticipant2.approveParticipantMatch();
 
@@ -378,8 +380,8 @@ class ParticipantControllerTest {
 
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("더미1"));
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
-        dummy1.updateParticipantStatus("더미1", "platinum");
-        //when
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
+
 
         mockMvc.perform(post("/api/player/approve/" + channel.getChannelLink() + "/" + dummy1.getId()))
                 .andExpect(status().isOk());
@@ -387,7 +389,7 @@ class ParticipantControllerTest {
     }
 
     @Test
-    @DisplayName("요청한사람 승인 테스트 (관리자 o) - 실패")
+    @DisplayName("요청한사람 승인 테스트 (관리자 x) - 실패")
     public void approveParticipantFailTest() throws Exception{
         //given
         Channel channel = createCustomChannel(false, false, "master", "100",20);
@@ -395,7 +397,7 @@ class ParticipantControllerTest {
 
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("더미1"));
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
-        dummy1.updateParticipantStatus("더미1", "platinum");
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
 
         mockMvc.perform(post("/api/player/approve/" + channel.getChannelLink() + "/" + dummy1.getId()))
                 .andExpect(status().isBadRequest());
@@ -411,7 +413,7 @@ class ParticipantControllerTest {
 
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("더미1"));
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
-        dummy1.updateParticipantStatus("더미1", "platinum");
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
 
         mockMvc.perform(post("/api/player/reject/" + channel.getChannelLink() + "/" + dummy1.getId()))
                 .andExpect(status().isOk());
@@ -427,7 +429,7 @@ class ParticipantControllerTest {
 
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("더미1"));
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
-        dummy1.updateParticipantStatus("더미1", "platinum");
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
 
         mockMvc.perform(post("/api/player/reject/" + channel.getChannelLink() + "/" + dummy1.getId()))
                 .andExpect(status().isBadRequest());

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -32,6 +32,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -108,10 +109,10 @@ class ParticipantServiceTest {
         Participant doneParticipant1 = participantRepository.save(Participant.participateChannel(doneMember1, channel));
         Participant doneParticipant2 = participantRepository.save(Participant.participateChannel(doneMember2, channel));
 
-        alreadyParticipant.updateParticipantStatus("bronze", "bronze");
+        alreadyParticipant.updateParticipantStatus("bronze", "bronze", "참가된사람1");
         rejectedParticipant.rejectParticipantRequest();
-        doneParticipant1.updateParticipantStatus("참가된사람1", "platinum");
-        doneParticipant2.updateParticipantStatus("참가된사람2", "iron");
+        doneParticipant1.updateParticipantStatus("참가된사람1", "platinum", "참가된사람1");
+        doneParticipant2.updateParticipantStatus("참가된사람2", "iron", "참가된사람2");
         doneParticipant1.approveParticipantMatch();
         doneParticipant2.approveParticipantMatch();
 
@@ -350,8 +351,8 @@ class ParticipantServiceTest {
         Participant part2 = participantRepository.save(Participant.participateChannel(platinumMember, channel));
         Participant part3 = participantRepository.save(Participant.participateChannel(ironMember, channel));
 
-        part2.updateParticipantStatus("손성한", "platinum");
-        part3.updateParticipantStatus("썹맹구", "iron");
+        part2.updateParticipantStatus("손성한", "platinum", "손성한");
+        part3.updateParticipantStatus("썹맹구", "iron", "썹맹구");
 
         part2.approveParticipantMatch();
         part3.approveParticipantMatch();
@@ -385,8 +386,8 @@ class ParticipantServiceTest {
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
         Participant dummy2 = participantRepository.save(Participant.participateChannel(dummyMember2, channel));
 
-        dummy1.updateParticipantStatus("더미1", "platinum");
-        dummy2.updateParticipantStatus("더미2", "iron");
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
+        dummy2.updateParticipantStatus("더미2", "iron", "더미2");
 
         //when
         assertThatThrownBy(() -> participantService.loadRequestStatusPlayerList(channel.getChannelLink()))
@@ -406,8 +407,7 @@ class ParticipantServiceTest {
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
         Participant dummy2 = participantRepository.save(Participant.participateChannel(dummyMember2, channel));
 
-        dummy1.updateParticipantStatus("더미1", "platinum");
-        dummy2.updateParticipantStatus("더미2", "iron");
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
 
         //when
         List<ResponseStatusPlayerDto> DtoList = participantService.loadRequestStatusPlayerList(channel.getChannelLink());
@@ -419,12 +419,6 @@ class ParticipantServiceTest {
         assertThat(dummy1.getGameId()).isEqualTo(DtoList.get(0).getGameId());
         assertThat(dummy1.getGameTier()).isEqualTo(DtoList.get(0).getTier());
         assertThat(dummy1.getRequestStatus()).isEqualTo(RequestStatus.REQUEST);
-
-        assertThat(dummy2.getId()).isEqualTo(DtoList.get(1).getPk());
-        assertThat(dummy2.getNickname()).isEqualTo(DtoList.get(1).getNickname());
-        assertThat(dummy2.getGameId()).isEqualTo(DtoList.get(1).getGameId());
-        assertThat(dummy2.getGameTier()).isEqualTo(DtoList.get(1).getTier());
-        assertThat(dummy2.getRequestStatus()).isEqualTo(RequestStatus.REQUEST);
 
     }
 
@@ -438,17 +432,20 @@ class ParticipantServiceTest {
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("더미1"));
 
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
-        dummy1.updateParticipantStatus("더미1", "platinum");
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
 
         //when
         participantService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId());
 
         Participant updateDummy = participantRepository.findParticipantByIdAndChannel_ChannelLink(dummy1.getId(), channel.getChannelLink());
+        Optional<Channel> channel1 = channelRepository.findByChannelLink(channel.getChannelLink());
+        int updateRealPlayerCount = 3;
 
         //then
         assertThat(updateDummy.getId()).isEqualTo(dummy1.getId());
         assertThat(updateDummy.getRole().getNum()).isEqualTo(Role.PLAYER.getNum());
         assertThat(updateDummy.getRequestStatus().getNum()).isEqualTo(RequestStatus.DONE.getNum());
+        assertThat(channel1.get().getRealPlayer()).isEqualTo(updateRealPlayerCount);
 
     }
 
@@ -461,13 +458,10 @@ class ParticipantServiceTest {
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("더미1"));
 
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
-        dummy1.updateParticipantStatus("더미1", "platinum");
-
-        //
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
 
         assertThatThrownBy(() -> participantService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId()))
                 .isInstanceOf(ParticipantNotGameHostException.class);
-
 
     }
 
@@ -480,7 +474,7 @@ class ParticipantServiceTest {
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("더미1"));
 
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
-        dummy1.updateParticipantStatus("더미1", "platinum");
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
 
         //when
         participantService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId());
@@ -503,7 +497,7 @@ class ParticipantServiceTest {
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("더미1"));
 
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
-        dummy1.updateParticipantStatus("더미1", "platinum");
+        dummy1.updateParticipantStatus("더미1", "platinum", "더미1");
 
         //
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#90 

## 📝 Description

참가 신청을 할 때 추가적으로 닉네임을 받기로 하였어요 그에 따른 dto를 수정했어요
관리자가 요청을 승인하였을 때 실제 경기 참여자 수를 갱신해주는 기능을 만들었어요
해당 기능을 만듦에 따라 실제 경기 참여자 수가 최대 경기 참여자 수가 되면 승인을 하지 못하도록 하는 제약을 추가했어요
제약에 따른 예외처리 코드로 하나 추가했어요

## ✨ Feature

요청을 승인했을 때 실제 참가자 수 갱신 기능
실제 참가자 수가 최대가 되었을 때 승인 제약 추가

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.
This closes #90 