### PR TITLE
Feat#94 이메일인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
-
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/leaguehub/leaguehubbackend/Controller/EmailController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/EmailController.java
@@ -1,0 +1,39 @@
+package leaguehub.leaguehubbackend.controller;
+
+import leaguehub.leaguehubbackend.dto.email.EmailDto;
+import leaguehub.leaguehubbackend.service.email.EmailService;
+import leaguehub.leaguehubbackend.util.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @PostMapping("/api/member/verify/email")
+    public ResponseEntity<String> verifyUser(@RequestBody EmailDto emailDto) {
+
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+
+        emailService.sendEmailWithConfirmation(emailDto.getEmail(), userDetails);
+
+        return ResponseEntity.ok("Email Sent Success");
+    }
+
+    @GetMapping("/confirm/Email")
+    public String confirmUserEmail(@RequestParam("token") String token) {
+        if (emailService.confirmUserEmail(token)) {
+            return "redirect:/verifiedPage.html";
+        } else {
+            return "redirect:/invalidPage.html";
+        }
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
@@ -58,19 +58,4 @@ public class MemberController  {
         return ResponseEntity.ok("Logout Success!");
     }
 
-    @Operation(summary = "멤버 이메일 등록", description = "멤버의 이메일을 등록한다.")
-    @Parameter(in = ParameterIn.PATH, name = "email", description = "email", required = true)
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "이메일 등록 성공", content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "MB-C-003 유효하지 않은 이메일 형식입니다.", content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "409", description = "MB-C-004 중복되는 이메일입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
-    })
-    @PostMapping("/member/email")
-    public ResponseEntity<String> updateEmail(@RequestParam String email) {
-
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
-        memberService.updateEmail(email, userDetails.getUsername());
-
-        return ResponseEntity.ok(email);
-    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/config/EmailConfig.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/EmailConfig.java
@@ -1,0 +1,42 @@
+package leaguehub.leaguehubbackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${LEAGUE_HUB_EMAIL}")
+    private String emailAddress;
+
+    @Value("${LEAGUE_HUB_EMAIL_PW}")
+    private String emailPassword;
+
+    @Bean
+    public JavaMailSender mailSender() {
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername(emailAddress);
+        mailSender.setPassword(emailPassword);
+
+        Properties javaMailProperties = new Properties();
+        javaMailProperties.put("mail.transport.protocol", "smtp");
+        javaMailProperties.put("mail.smtp.auth", "true");
+        javaMailProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+        javaMailProperties.put("mail.smtp.starttls.enable", "true");
+        javaMailProperties.put("mail.debug", "true");
+        javaMailProperties.put("mail.smtp.ssl.trust", "smtp.gmail.com");
+        javaMailProperties.put("mail.smtp.ssl.protocols", "TLSv1.2");
+
+        mailSender.setJavaMailProperties(javaMailProperties);
+
+        return mailSender;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/config/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/JwtAuthenticationProcessingFilter.java
@@ -40,7 +40,11 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
             "/v3/api-docs/**",
             "/h2-console/**",
             "/api/app/login/kakao",
-            "/api/reissue/token"
+            "/api/reissue/token",
+            "/confirm/**",
+            "/verifiedPage.html",
+            "/invalidPage.html"
+
     );
     private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
     private final AntPathMatcher pathMatcher = new AntPathMatcher();

--- a/src/main/java/leaguehub/leaguehubbackend/config/SecurityConfiguration.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/SecurityConfiguration.java
@@ -32,7 +32,10 @@ public class SecurityConfiguration {
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",
-
+            "/api/send/verification/email",
+            "/confirm/**",
+            "/verifiedPage.html",
+            "/invalidPage.html"
     };
 
     @Bean

--- a/src/main/java/leaguehub/leaguehubbackend/dto/email/EmailDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/email/EmailDto.java
@@ -1,0 +1,14 @@
+package leaguehub.leaguehubbackend.dto.email;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailDto {
+
+    private String email;
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/email/EmailAuth.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/email/EmailAuth.java
@@ -1,0 +1,37 @@
+package leaguehub.leaguehubbackend.entity.email;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import leaguehub.leaguehubbackend.entity.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailAuth extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "email_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private String authToken;
+
+    private LocalDateTime emailExpireDate;
+    @Builder
+    public EmailAuth(String email, String authToken) {
+        this.email = email;
+        this.authToken = authToken;
+        this.emailExpireDate = LocalDateTime.now().plusMinutes(10);
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -56,12 +56,13 @@ public class Member extends BaseTimeEntity {
                 .build();
 
     }
-
-    public void setEmailAuth(EmailAuth emailAuth) {
+    public void assignEmailAuth(EmailAuth emailAuth) {
         this.emailAuth = emailAuth;
     }
-
-    public void setEmailUserVerified(boolean b) {
-        this.emailUserVerified = b;
+    public void verifyEmail() {
+        this.emailUserVerified = true;
+    }
+    public void unverifyEmail() {
+        this.emailUserVerified = false;
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.entity.BaseTimeEntity;
 
+import leaguehub.leaguehubbackend.entity.email.EmailAuth;
 import lombok.*;
 
 
@@ -27,7 +28,9 @@ public class Member extends BaseTimeEntity {
 
     private String refreshToken;
 
-    private String email;
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "email_auth_id", referencedColumnName = "email_id")
+    private EmailAuth emailAuth;
 
     private boolean emailUserVerified;
 
@@ -40,7 +43,6 @@ public class Member extends BaseTimeEntity {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
-    public void updateEmail(String email) { this.email = email; }
     public void updateRole(BaseRole role) { this.baseRole = role; }
 
     public static Member kakaoUserToMember(KakaoUserDto kakaoUserDto) {
@@ -53,5 +55,13 @@ public class Member extends BaseTimeEntity {
                 .loginProvider(LoginProvider.KAKAO)
                 .build();
 
+    }
+
+    public void setEmailAuth(EmailAuth emailAuth) {
+        this.emailAuth = emailAuth;
+    }
+
+    public void setEmailUserVerified(boolean b) {
+        this.emailUserVerified = b;
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/exception/email/EmailExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/email/EmailExceptionCode.java
@@ -1,0 +1,21 @@
+package leaguehub.leaguehubbackend.exception.email;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmailExceptionCode implements ExceptionCode {
+
+    INVALID_EMAIL_ADDRESS(BAD_REQUEST, "MB-C-003", "유효하지 않은 이메일 형식입니다."),
+    DUPLICATE_EMAIL_EXCEPTION(CONFLICT, "MB-C-004", "중복되는 이메일입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/email/EmailExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/email/EmailExceptionHandler.java
@@ -1,0 +1,43 @@
+package leaguehub.leaguehubbackend.exception.email;
+
+import leaguehub.leaguehubbackend.exception.email.exception.DuplicateEmailException;
+import leaguehub.leaguehubbackend.exception.email.exception.InvalidEmailAddressException;
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class EmailExceptionHandler {
+
+    @ExceptionHandler(InvalidEmailAddressException.class)
+    public ResponseEntity<ExceptionResponse> invalidEmailAddress(
+            InvalidEmailAddressException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(DuplicateEmailException.class)
+    public ResponseEntity<ExceptionResponse> invalidEmailAddress(
+            DuplicateEmailException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/email/exception/DuplicateEmailException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/email/exception/DuplicateEmailException.java
@@ -1,12 +1,14 @@
-package leaguehub.leaguehubbackend.exception.member.exception;
+package leaguehub.leaguehubbackend.exception.email.exception;
 
+import leaguehub.leaguehubbackend.exception.email.EmailExceptionCode;
 import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
 
-import static leaguehub.leaguehubbackend.exception.member.MemberExceptionCode.DUPLICATE_EMAIL_EXCEPTION;
+import static leaguehub.leaguehubbackend.exception.email.EmailExceptionCode.DUPLICATE_EMAIL_EXCEPTION;
+
 
 public class DuplicateEmailException extends RuntimeException{
 
-    private final ExceptionCode exceptionCode;
+    private final EmailExceptionCode exceptionCode;
 
     public DuplicateEmailException() {
         super(DUPLICATE_EMAIL_EXCEPTION.getMessage());

--- a/src/main/java/leaguehub/leaguehubbackend/exception/email/exception/InvalidEmailAddressException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/email/exception/InvalidEmailAddressException.java
@@ -1,11 +1,13 @@
-package leaguehub.leaguehubbackend.exception.member.exception;
+package leaguehub.leaguehubbackend.exception.email.exception;
 
+import leaguehub.leaguehubbackend.exception.email.EmailExceptionCode;
 import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
 
-import static leaguehub.leaguehubbackend.exception.member.MemberExceptionCode.INVALID_EMAIL_ADDRESS;
+import static leaguehub.leaguehubbackend.exception.email.EmailExceptionCode.INVALID_EMAIL_ADDRESS;
+
 
 public class InvalidEmailAddressException extends IllegalArgumentException  {
-    private final ExceptionCode exceptionCode;
+    private final EmailExceptionCode exceptionCode;
 
     public InvalidEmailAddressException() {
 

--- a/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionCode.java
@@ -12,9 +12,8 @@ import static org.springframework.http.HttpStatus.*;
 public enum MemberExceptionCode implements ExceptionCode {
 
     MEMBER_NOT_FOUND(NOT_FOUND, "MB-C-001", "존재하지 않는 회원입니다."),
-    INVALID_MEMBER_IMAGE(BAD_REQUEST, "MB-C-002", "유효하지 않은 이미지입니다."),
-    INVALID_EMAIL_ADDRESS(BAD_REQUEST, "MB-C-003", "유효하지 않은 이메일 형식입니다."),
-    DUPLICATE_EMAIL_EXCEPTION(CONFLICT, "MB-C-004", "중복되는 이메일입니다.");
+    INVALID_MEMBER_IMAGE(BAD_REQUEST, "MB-C-002", "유효하지 않은 이미지입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/member/MemberExceptionHandler.java
@@ -2,8 +2,6 @@ package leaguehub.leaguehubbackend.exception.member;
 
 import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
-import leaguehub.leaguehubbackend.exception.member.exception.DuplicateEmailException;
-import leaguehub.leaguehubbackend.exception.member.exception.InvalidEmailAddressException;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,29 +27,5 @@ public class MemberExceptionHandler {
         );
     }
 
-    @ExceptionHandler(InvalidEmailAddressException.class)
-    public ResponseEntity<ExceptionResponse> invalidEmailAddress(
-            InvalidEmailAddressException e
-    ) {
-        ExceptionCode exceptionCode = e.getExceptionCode();
-        log.error("{}", exceptionCode.getMessage());
 
-        return new ResponseEntity<>(
-                new ExceptionResponse(exceptionCode),
-                exceptionCode.getHttpStatus()
-        );
-    }
-
-    @ExceptionHandler(DuplicateEmailException.class)
-    public ResponseEntity<ExceptionResponse> invalidEmailAddress(
-            DuplicateEmailException e
-    ) {
-        ExceptionCode exceptionCode = e.getExceptionCode();
-        log.error("{}", exceptionCode.getMessage());
-
-        return new ResponseEntity<>(
-                new ExceptionResponse(exceptionCode),
-                exceptionCode.getHttpStatus()
-        );
-    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/email/EmailAuthRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/email/EmailAuthRepository.java
@@ -1,0 +1,12 @@
+package leaguehub.leaguehubbackend.repository.email;
+
+import leaguehub.leaguehubbackend.entity.email.EmailAuth;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
+    Optional<EmailAuth> findAuthByEmail(String email);
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/member/MemberRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/member/MemberRepository.java
@@ -1,7 +1,10 @@
 package leaguehub.leaguehubbackend.repository.member;
 
+import leaguehub.leaguehubbackend.entity.email.EmailAuth;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -11,6 +14,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findMemberByPersonalId(String personalId);
     Optional<Member> findByNickname(String nickname);
     Optional<Member> findByRefreshToken(String refreshToken);
-    Optional<Member> findMemberByEmail(String email);
+    @Query("SELECT m FROM Member m JOIN m.emailAuth e WHERE e.email = :email")
+    Optional<Member> findMemberByEmail(@Param("email") String email);
+    @Query("SELECT m FROM Member m WHERE m.emailAuth = :emailAuth")
+    Optional<Member> findByEmailAuth(@Param("emailAuth") EmailAuth emailAuth);
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/email/EmailService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/email/EmailService.java
@@ -1,0 +1,135 @@
+package leaguehub.leaguehubbackend.service.email;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import jakarta.transaction.Transactional;
+import leaguehub.leaguehubbackend.entity.email.EmailAuth;
+import leaguehub.leaguehubbackend.entity.member.BaseRole;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.exception.email.exception.DuplicateEmailException;
+import leaguehub.leaguehubbackend.exception.email.exception.InvalidEmailAddressException;
+import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
+import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
+import leaguehub.leaguehubbackend.repository.email.EmailAuthRepository;
+import leaguehub.leaguehubbackend.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final MemberRepository memberRepository;
+
+    private final EmailAuthRepository emailAuthRepository;
+
+    @Value("${EMAIL_SECRET_KEY}")
+    private String secretKey;
+
+    @Value("${LEAGUE_HUB_ADDRESS}")
+    private String leagueHubAddress;
+
+    private final JavaMailSender mailSender;
+
+    @Transactional
+    public void sendEmailWithConfirmation(String email, UserDetails userDetails) {
+
+        validateEmail(email);
+
+        Member member = memberRepository.findMemberByPersonalId(userDetails.getUsername())
+                .orElseThrow(MemberNotFoundException::new);
+
+        removeExistingEmailAuth(member);
+
+        String uniqueToken = generateUniqueTokenForUser(email);
+
+        EmailAuth emailAuth = createAndSaveEmailAuth(email, member, uniqueToken);
+
+        sendConfirmationEmail(emailAuth, uniqueToken);
+
+    }
+
+    private void validateEmail(String email) {
+        if (!isValidEmailFormat(email)) throw new InvalidEmailAddressException();
+        if (memberRepository.findMemberByEmail(email).isPresent()) throw new DuplicateEmailException();
+    }
+    private void sendConfirmationEmail(EmailAuth emailAuth, String uniqueToken) {
+        try {
+            String link = "http://" + leagueHubAddress + "/confirm/Email?token=" + uniqueToken;
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(emailAuth.getEmail());
+            message.setSubject("회원가입 이메일 인증");
+            message.setText(link);
+            mailSender.send(message);
+        } catch (Exception e) {
+            throw new GlobalServerErrorException();
+        }
+    }
+    private EmailAuth createAndSaveEmailAuth(String email, Member member, String uniqueToken) {
+        EmailAuth emailAuth = new EmailAuth(email, uniqueToken);
+
+        member.setEmailUserVerified(false);
+        member.setEmailAuth(emailAuth);
+
+        emailAuthRepository.save(emailAuth);
+        memberRepository.save(member);
+
+        return emailAuth;
+    }
+    private void removeExistingEmailAuth(Member member) {
+        if (member.isEmailUserVerified() && member.getEmailAuth() != null) {
+            emailAuthRepository.delete(member.getEmailAuth());
+            member.setEmailAuth(null);
+        }
+    }
+
+    private String generateUniqueTokenForUser(String email) {
+        return JWT.create()
+                .withSubject(email)
+                .sign(Algorithm.HMAC256(secretKey));
+    }
+    public boolean isValidEmailFormat(String email) {
+        String emailRegex = "^[A-Za-z0-9+_.-]+@(.+)$";
+        Pattern pat = Pattern.compile(emailRegex);
+        return pat.matcher(email).matches();
+    }
+
+    @Transactional
+    public boolean confirmUserEmail(String token) {
+        try {
+            String email = JWT.require(Algorithm.HMAC256(secretKey))
+                    .build()
+                    .verify(token)
+                    .getSubject();
+
+            EmailAuth emailAuth = emailAuthRepository.findAuthByEmail(email)
+                    .orElseThrow(() -> new IllegalArgumentException("인증 토큰이 잘못되었습니다."));
+
+            if (emailAuth.getEmailExpireDate().isBefore(LocalDateTime.now())) {
+                throw new IllegalArgumentException("인증 토큰이 만료되었습니다.");
+            }
+
+            Member member = memberRepository.findByEmailAuth(emailAuth)
+                    .orElseThrow(() -> new IllegalArgumentException("멤버 정보를 찾을 수 없습니다."));
+
+            member.setEmailUserVerified(true);
+
+            if (member.getBaseRole() == BaseRole.GUEST) {
+                member.updateRole(BaseRole.USER);
+            }
+
+            memberRepository.save(member);
+
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/email/EmailService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/email/EmailService.java
@@ -76,8 +76,8 @@ public class EmailService {
     private EmailAuth createAndSaveEmailAuth(String email, Member member, String uniqueToken) {
         EmailAuth emailAuth = new EmailAuth(email, uniqueToken);
 
-        member.setEmailUserVerified(false);
-        member.setEmailAuth(emailAuth);
+        member.unverifyEmail();
+        member.assignEmailAuth(emailAuth);
 
         emailAuthRepository.save(emailAuth);
         memberRepository.save(member);
@@ -87,7 +87,7 @@ public class EmailService {
     private void removeExistingEmailAuth(Member member) {
         if (member.isEmailUserVerified() && member.getEmailAuth() != null) {
             emailAuthRepository.delete(member.getEmailAuth());
-            member.setEmailAuth(null);
+            member.assignEmailAuth(null);
         }
     }
 
@@ -120,7 +120,7 @@ public class EmailService {
             Member member = memberRepository.findByEmailAuth(emailAuth)
                     .orElseThrow(() -> new RuntimeException("멤버 정보를 찾을 수 없습니다."));
 
-            member.setEmailUserVerified(true);
+            member.verifyEmail();
 
             if (member.getBaseRole() == BaseRole.GUEST) {
                 member.updateRole(BaseRole.USER);

--- a/src/main/java/leaguehub/leaguehubbackend/service/email/EmailService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/email/EmailService.java
@@ -13,6 +13,7 @@ import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundExcep
 import leaguehub.leaguehubbackend.repository.email.EmailAuthRepository;
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -21,7 +22,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.regex.Pattern;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailService {
@@ -110,14 +111,14 @@ public class EmailService {
                     .getSubject();
 
             EmailAuth emailAuth = emailAuthRepository.findAuthByEmail(email)
-                    .orElseThrow(() -> new IllegalArgumentException("인증 토큰이 잘못되었습니다."));
+                    .orElseThrow(() -> new RuntimeException("인증 토큰이 잘못되었습니다."));
 
             if (emailAuth.getEmailExpireDate().isBefore(LocalDateTime.now())) {
-                throw new IllegalArgumentException("인증 토큰이 만료되었습니다.");
+                throw new RuntimeException("인증 토큰이 만료되었습니다.");
             }
 
             Member member = memberRepository.findByEmailAuth(emailAuth)
-                    .orElseThrow(() -> new IllegalArgumentException("멤버 정보를 찾을 수 없습니다."));
+                    .orElseThrow(() -> new RuntimeException("멤버 정보를 찾을 수 없습니다."));
 
             member.setEmailUserVerified(true);
 
@@ -129,6 +130,7 @@ public class EmailService {
 
             return true;
         } catch (Exception e) {
+            log.error("이메일 링크 확인 중 에러 발생", e);
             return false;
         }
     }

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -5,11 +5,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
-import leaguehub.leaguehubbackend.entity.member.BaseRole;
 import leaguehub.leaguehubbackend.entity.member.Member;
 
-import leaguehub.leaguehubbackend.exception.member.exception.DuplicateEmailException;
-import leaguehub.leaguehubbackend.exception.member.exception.InvalidEmailAddressException;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
@@ -21,9 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.Authentication;
 
 import java.util.Optional;
-import java.util.regex.Pattern;
 
-import static leaguehub.leaguehubbackend.exception.member.MemberExceptionCode.INVALID_EMAIL_ADDRESS;
 
 @Service
 @RequiredArgsConstructor
@@ -66,8 +61,8 @@ public class MemberService {
     }
 
     public String getVerifiedEmail(Member member) {
-        if (member.getEmail() != null && member.isEmailUserVerified()) {
-            return member.getEmail();
+        if (member.getEmailAuth() != null && member.isEmailUserVerified()) {
+            return member.getEmailAuth().getEmail();
         }
         return "N/A";
     }
@@ -89,29 +84,6 @@ public class MemberService {
         }
     }
 
-    @Transactional
-    public void updateEmail(String email, String personalId) {
 
-        if (!isValidEmailFormat(email)) {
-            throw new InvalidEmailAddressException();
-        }
-
-        if (memberRepository.findMemberByEmail(email).isPresent()) {
-            throw new DuplicateEmailException();
-        }
-
-        Member member = memberRepository.findMemberByPersonalId(personalId)
-                .orElseThrow(MemberNotFoundException::new);
-        member.updateEmail(email);
-        member.updateRole(BaseRole.USER);
-
-        memberRepository.save(member);
-    }
-
-    public static boolean isValidEmailFormat(String email) {
-        String emailRegex = "^[A-Za-z0-9+_.-]+@(.+)$";
-        Pattern pat = Pattern.compile(emailRegex);
-        return pat.matcher(email).matches();
-    }
 }
 

--- a/src/main/resources/static/invalidPage.html
+++ b/src/main/resources/static/invalidPage.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Invalid Email</title>
+    <meta charset="UTF-8">
+    <script>
+        window.onload = function() {
+            alert("인증이 만료되었거나 올바른 인증이 아닙니다. 다시 요청해주세요");
+            window.close();
+        }
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/src/main/resources/static/verifiedPage.html
+++ b/src/main/resources/static/verifiedPage.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>User Verified</title>
+    <meta charset="UTF-8">
+    <script>
+        window.onload = function() {
+            alert("인증이 완료되었습니다.");
+            window.close();
+        }
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/src/test/java/leaguehub/leaguehubbackend/controller/MemberControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/MemberControllerTest.java
@@ -3,8 +3,6 @@ package leaguehub.leaguehubbackend.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
-import leaguehub.leaguehubbackend.exception.member.exception.DuplicateEmailException;
-import leaguehub.leaguehubbackend.exception.member.exception.InvalidEmailAddressException;
 import leaguehub.leaguehubbackend.fixture.ProfileResponseFixture;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import leaguehub.leaguehubbackend.util.SecurityUtils;
@@ -104,57 +102,5 @@ class MemberControllerTest {
         );
     }
 
-    @Test
-    @DisplayName("이메일 업데이트 성공")
-    public void whenUpdateEmail_thenReturnSuccessMessage() throws Exception {
 
-        String newEmail = "newEmail@example.com";
-
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
-
-        doNothing().when(memberService).updateEmail(newEmail, userDetails.getUsername());
-
-        mockMvc.perform(post("/api/member/email")
-                        .param("email", newEmail))
-                .andExpect(status().isOk())
-                .andExpect(content().string(newEmail));
-
-        verify(memberService).updateEmail(newEmail, userDetails.getUsername());
-    }
-
-    @Test
-    @DisplayName("이메일 형식이 잘못되었을 때 에러 반환")
-    public void whenUpdateEmailInvalidFormat_thenReturnErrorMessage() throws Exception {
-
-        String newEmail = "newEmailexample.com";
-
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
-
-        doThrow(new InvalidEmailAddressException()).when(memberService).updateEmail(newEmail, userDetails.getUsername());
-
-        mockMvc.perform(post("/api/member/email")
-                        .param("email", newEmail))
-                .andExpect(status().isBadRequest())
-                .andExpect(result -> Assertions.assertTrue(result.getResolvedException() instanceof InvalidEmailAddressException));
-
-        verify(memberService).updateEmail(newEmail, userDetails.getUsername());
-    }
-
-    @Test
-    @DisplayName("이메일이 중복될 경우 에러 반환")
-    public void whenUpdateEmailDuplicate_thenReturnErrorMessage() throws Exception {
-
-        String newEmail = "duplicate@example.com";
-
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
-
-        doThrow(new DuplicateEmailException()).when(memberService).updateEmail(newEmail, userDetails.getUsername());
-
-        mockMvc.perform(post("/api/member/email")
-                        .param("email", newEmail))
-                .andExpect(status().isConflict())
-                .andExpect(result -> Assertions.assertTrue(result.getResolvedException() instanceof DuplicateEmailException));
-
-        verify(memberService).updateEmail(newEmail, userDetails.getUsername());
-    }
 }

--- a/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
+++ b/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
@@ -1,6 +1,7 @@
 package leaguehub.leaguehubbackend.fixture;
 
 import leaguehub.leaguehubbackend.dto.member.LoginMemberResponse;
+import leaguehub.leaguehubbackend.entity.email.EmailAuth;
 import leaguehub.leaguehubbackend.entity.member.BaseRole;
 import leaguehub.leaguehubbackend.entity.member.LoginProvider;
 import leaguehub.leaguehubbackend.entity.member.Member;
@@ -17,7 +18,7 @@ public class UserFixture {
         Member member = Member.builder()
                 .personalId("id").profileImageUrl("url")
                 .nickname("id").refreshToken("refreshToken")
-                .email("id@example.com")
+                .emailAuth(new EmailAuth("id@example.com", "authToken"))
                 .loginProvider(LoginProvider.KAKAO).baseRole(BaseRole.USER)
                 .build();
 

--- a/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
@@ -5,8 +5,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
 import leaguehub.leaguehubbackend.entity.member.Member;
-import leaguehub.leaguehubbackend.exception.member.exception.DuplicateEmailException;
-import leaguehub.leaguehubbackend.exception.member.exception.InvalidEmailAddressException;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 import leaguehub.leaguehubbackend.fixture.KakaoUserDtoFixture;
 import leaguehub.leaguehubbackend.fixture.UserFixture;
@@ -156,41 +154,6 @@ class MemberServiceTest {
 
     }
 
-    @Test
-    @DisplayName("유효한 이메일로 멤버 이메일 업데이트")
-    void updateEmailWithValidEmail() {
-        String testEmail = "test@example.com";
-        String testId = "12345678";
-
-        Member testMember = UserFixture.createMember();
-        when(memberRepository.findMemberByEmail(testEmail)).thenReturn(Optional.empty());
-        when(memberRepository.findMemberByPersonalId(testId)).thenReturn(Optional.of(testMember));
-
-        assertDoesNotThrow(() -> memberService.updateEmail(testEmail, testId));
-        verify(memberRepository, times(1)).save(any(Member.class));
-    }
-
-    @Test
-    @DisplayName("유효하지 않은 이메일로 멤버 이메일 업데이트 시도")
-    void updateEmailWithInvalidEmail() {
-        String testEmail = "invalidemail";
-        String testId = "12345678";
-
-        assertThrows(InvalidEmailAddressException.class, () -> memberService.updateEmail(testEmail, testId));
-    }
-
-    @Test
-    @DisplayName("중복된 이메일로 멤버 이메일 업데이트 시도")
-    void updateEmailWithDuplicateEmail() {
-        String testEmail = "id@example.com";
-        String testId = "12345678";
-
-        Member duplicateMember = UserFixture.createMember();
-
-        when(memberRepository.findMemberByEmail(testEmail)).thenReturn(Optional.of(duplicateMember));
-
-        assertThrows(DuplicateEmailException.class, () -> memberService.updateEmail(testEmail, testId));
-    }
 
 
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#94 

## 📝 Description

이메일 인증 기능을 구현했습니다. 
Member의 컨트롤러, 서비스, 예외처리에서 Email과 관련된 기능은 따로 빼서
Email 컨트롤러, 서비스, 예외처리로 이동했습니다.

Email 인증 성공시 유저는 Guest 권한에서 User 로 바꿉니다.
User는 게임 참가, 생성을 할 수 있습니다.

SecurityUtils를 사용하여 사용자가 User인지 Guest인지 알 수 있습니다.

## ✨ Feature
1. 이메일 중복이 없으면 인증 url을 사용자에게 보낸다
2. 생성한 url의 만료기간이 지나지 않았고 유효하다면 유저를 일반유저를 바꾼다

![Animation2](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/779daba4-d4b7-4b5b-8293-2381d40cd068)

## 👌 Review Change

This closes #94