### PR TITLE
Feat#104 이메일 인증 관련 경기 참여 서비스 수정

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/exception/email/EmailExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/email/EmailExceptionCode.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @RequiredArgsConstructor
 public enum EmailExceptionCode implements ExceptionCode {
 
     INVALID_EMAIL_ADDRESS(BAD_REQUEST, "MB-C-003", "유효하지 않은 이메일 형식입니다."),
-    DUPLICATE_EMAIL_EXCEPTION(CONFLICT, "MB-C-004", "중복되는 이메일입니다.");
+    DUPLICATE_EMAIL_EXCEPTION(CONFLICT, "MB-C-004", "중복되는 이메일입니다."),
+    UNAUTHORIZED_EMAIL_EXCEPTION(UNAUTHORIZED, "MB-C-005", "이메일이 인증되지 않은 사용자입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/leaguehub/leaguehubbackend/exception/email/EmailExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/email/EmailExceptionHandler.java
@@ -2,6 +2,7 @@ package leaguehub.leaguehubbackend.exception.email;
 
 import leaguehub.leaguehubbackend.exception.email.exception.DuplicateEmailException;
 import leaguehub.leaguehubbackend.exception.email.exception.InvalidEmailAddressException;
+import leaguehub.leaguehubbackend.exception.email.exception.UnauthorizedEmailException;
 import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,19 @@ public class EmailExceptionHandler {
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<ExceptionResponse> invalidEmailAddress(
             DuplicateEmailException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(UnauthorizedEmailException.class)
+    public ResponseEntity<ExceptionResponse> UnauthorizedEmailException(
+            UnauthorizedEmailException e
     ) {
         ExceptionCode exceptionCode = e.getExceptionCode();
         log.error("{}", exceptionCode.getMessage());

--- a/src/main/java/leaguehub/leaguehubbackend/exception/email/exception/UnauthorizedEmailException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/email/exception/UnauthorizedEmailException.java
@@ -1,0 +1,23 @@
+package leaguehub.leaguehubbackend.exception.email.exception;
+
+import leaguehub.leaguehubbackend.exception.email.EmailExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import org.springframework.security.core.AuthenticationException;
+
+import static leaguehub.leaguehubbackend.exception.email.EmailExceptionCode.UNAUTHORIZED_EMAIL_EXCEPTION;
+
+
+public class UnauthorizedEmailException extends AuthenticationException {
+    private final EmailExceptionCode exceptionCode;
+
+    public UnauthorizedEmailException() {
+
+        super(UNAUTHORIZED_EMAIL_EXCEPTION.getMessage());
+        this.exceptionCode = UNAUTHORIZED_EMAIL_EXCEPTION;
+
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -9,6 +9,7 @@ import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.entity.participant.RequestStatus;
 import leaguehub.leaguehubbackend.entity.participant.Role;
 import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundException;
+import leaguehub.leaguehubbackend.exception.email.exception.UnauthorizedEmailException;
 import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
 import leaguehub.leaguehubbackend.exception.participant.exception.*;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
@@ -46,6 +47,15 @@ public class ParticipantService {
     private final ChannelRepository channelRepository;
     @Value("${riot-api-key-1}")
     private String riot_api_key;
+
+    private static void rankRuleCheck(ChannelRule channelRule, GameRankDto tier) {
+        if (channelRule.getTier()) {
+            int limitedRankScore = GameTier.rankToScore(channelRule.getLimitedTier(), channelRule.getLimitedGrade());
+            int userRankScore = GameTier.rankToScore(tier.getGameRank().toString(), tier.getGameGrade());
+            if (userRankScore > limitedRankScore)
+                throw new ParticipantInvalidRankException();
+        }
+    }
 
     public int findParticipantPermission(String channelLink) {
 
@@ -97,6 +107,8 @@ public class ParticipantService {
 
     public Participant getParticipant(String channelLink) {
         UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+
+        checkEmail(userDetails);
 
         if (userDetails == null) {
             throw new ParticipantInvalidLoginException();
@@ -309,17 +321,6 @@ public class ParticipantService {
         }
     }
 
-
-    private static void rankRuleCheck(ChannelRule channelRule, GameRankDto tier) {
-        if (channelRule.getTier()) {
-            int limitedRankScore = GameTier.rankToScore(channelRule.getLimitedTier(), channelRule.getLimitedGrade());
-            int userRankScore = GameTier.rankToScore(tier.getGameRank().toString(), tier.getGameGrade());
-            if (userRankScore > limitedRankScore)
-                throw new ParticipantInvalidRankException();
-        }
-    }
-
-
     public void checkDuplicateNickname(String gameId, String channelLink) {
         List<Participant> participantList = participantRepository.findAllByChannel_ChannelLink(channelLink);
 
@@ -467,6 +468,11 @@ public class ParticipantService {
                     return responsePlayerDto;
                 })
                 .collect(Collectors.toList());
+    }
+
+    public void checkEmail(UserDetails userDetails) {
+        if (!userDetails.getAuthorities().toString().equals("[ROLE_USER]"))
+            throw new UnauthorizedEmailException();
     }
 
 

--- a/src/test/java/leaguehub/leaguehubbackend/entity/channel/ChannelTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/channel/ChannelTest.java
@@ -99,7 +99,6 @@ class ChannelTest {
         assertThat(channelBoardList.size()).isEqualTo(3);
         assertThat(channelBoardList.get(0).getChannel()).isEqualTo(channel);
         assertThat(findChannel.get().getChannelLink()).isEqualTo(channel.getChannelLink());
-        assertThat(findChannel.get().getAccessCode()).isEqualTo(channel.getAccessCode());
     }
 
     @Test


### PR DESCRIPTION
## 🙆‍♂️ Issue

#104 

## 📝 Description

사용자에 이메일 인증 기능을 추가함에 따라 경기에 참여하는 서비스에도 이메일 인증이 된 사용자만 받을 수 있게 코드를 변경하였어요 
테스트를 할 때에는 이메일 인증이 안된 사용자를 이용하여 실패 케이스를 만들 예정이에요

추가적으로 테스트 코드에서 사용되지않으며 컴파일 오류를 불러오는 코드도 함께 삭제했어요

## ✨ Feature

이메일 인증 기능 구현에 따른 추가적인 경기 참여 제한 추가
테스트 코드 내 삭제 못한 컴파일오류를 불러오는 코드 삭제 

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.
This closes #104 