### PR TITLE
Refactor#112: 티어 룰 반환, 티어 추출 리팩터링

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/dto/channel/CreateChannelDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/channel/CreateChannelDto.java
@@ -37,8 +37,6 @@ public class CreateChannelDto {
     @JsonProperty("tierMax")
     private String tierMax;
 
-    @JsonProperty("gradeMax")
-    private String gradeMax;
 
     @JsonProperty("channelImageUrl")
     private String channelImageUrl;
@@ -52,7 +50,7 @@ public class CreateChannelDto {
 
     @Builder
     public CreateChannelDto(int game, Integer tournament, String title,
-                            Integer participationNum, Boolean tier, String tierMax, String gradeMax,
+                            Integer participationNum, Boolean tier, String tierMax,
                             Boolean playCount, Integer playCountMin) {
         this.game = game;
         this.tournament = tournament;
@@ -60,7 +58,6 @@ public class CreateChannelDto {
         this.participationNum = participationNum;
         this.tier = tier;
         this.tierMax = tierMax;
-        this.gradeMax = gradeMax;
         this.playCount = playCount;
         this.playCountMin = playCountMin;
     }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/channel/UpdateChannelDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/channel/UpdateChannelDto.java
@@ -20,9 +20,6 @@ public class UpdateChannelDto {
     @JsonProperty("tierMax")
     private String tierMax;
 
-    @JsonProperty("gradeMax")
-    private String gradeMax;
-
     @JsonProperty("channelImageUrl")
     private String channelImageUrl;
 

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
@@ -53,7 +53,7 @@ public class Channel extends BaseTimeEntity {
 
     public static Channel createChannel(String title, Integer category, int maxPlayer,
                                         Integer matchFormat, String channelImageUrl,
-                                        boolean tier, String tierMax, String gradeMax,
+                                        boolean tier, String tierMax,
                                         boolean playCount, Integer playCountMin) {
         Channel channel = new Channel();
         String uuid = UUID.randomUUID().toString();
@@ -66,7 +66,6 @@ public class Channel extends BaseTimeEntity {
         channel.channelLink = channel.createParticipationLink(uuid);
         channel.channelImageUrl = channel.validateChannelImageUrl(channelImageUrl);
         channel.channelRule = ChannelRule.createChannelRule(tierMax
-                , gradeMax
                 , tier
                 , playCount
                 , playCountMin);
@@ -118,8 +117,8 @@ public class Channel extends BaseTimeEntity {
         this.channelImageUrl = channelImageUrl;
     }
 
-    public void updateChannelTierRule(boolean tier, String tierMax, String gradeMax) {
-        this.channelRule.updateTierRule(tier, tierMax, gradeMax);
+    public void updateChannelTierRule(boolean tier, String tierMax) {
+        this.channelRule.updateTierRule(tier, tierMax);
     }
 
     public void updateChannelTierRule(boolean tier) {

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelRule.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelRule.java
@@ -21,8 +21,6 @@ public class ChannelRule extends BaseTimeEntity {
 
     private String limitedTier;
 
-    private String limitedGrade;
-
     private Boolean tier;
 
     private Boolean playCount;
@@ -32,7 +30,7 @@ public class ChannelRule extends BaseTimeEntity {
     @JoinColumn(name = "channel_id")
     private Channel channel;
 
-    public static ChannelRule createChannelRule(String tierMax, String gradeMax, Boolean tier,
+    public static ChannelRule createChannelRule(String tierMax,  Boolean tier,
                                                 Boolean playCount, Integer playCountMin) {
         ChannelRule channelRule = new ChannelRule();
 
@@ -41,10 +39,8 @@ public class ChannelRule extends BaseTimeEntity {
 
         if (tier == true) {
             channelRule.limitedTier = tierMax;
-            channelRule.limitedGrade = gradeMax;
         } else {
             channelRule.limitedTier = GlobalConstant.NO_DATA.getData();
-            channelRule.limitedGrade = GlobalConstant.NO_DATA.getData();
         }
 
         if (playCount == true) {
@@ -56,10 +52,9 @@ public class ChannelRule extends BaseTimeEntity {
         return channelRule;
     }
 
-    public void updateTierRule(boolean tier, String tierMax, String gradeMax) {
+    public void updateTierRule(boolean tier, String tierMax) {
         this.tier = tier;
         this.limitedTier = tierMax;
-        this.limitedGrade = gradeMax;
     }
 
     public void updatePlayCountMin(boolean playCount, Integer playCountMin) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -45,7 +45,7 @@ public class ChannelService {
         Channel channel = Channel.createChannel(createChannelDto.getTitle(),
                 createChannelDto.getGame(), createChannelDto.getParticipationNum(),
                 createChannelDto.getTournament(), createChannelDto.getChannelImageUrl(),
-                createChannelDto.getTier(), createChannelDto.getTierMax(), createChannelDto.getGradeMax(),
+                createChannelDto.getTier(), createChannelDto.getTierMax(),
                 createChannelDto.getPlayCount(),
                 createChannelDto.getPlayCountMin());
         channelRepository.save(channel);
@@ -105,8 +105,8 @@ public class ChannelService {
         Optional<Boolean> tierOpt = Optional.ofNullable(updateChannelDto.getTier());
         if (tierOpt.isPresent()) {
             if (tierOpt.get() == true) {
-                validateTier(updateChannelDto.getTierMax(), updateChannelDto.getGradeMax());
-                channel.updateChannelTierRule(true, updateChannelDto.getTierMax(), updateChannelDto.getGradeMax());
+                validateTier(updateChannelDto.getTierMax());
+                channel.updateChannelTierRule(true, updateChannelDto.getTierMax());
             } else {
                 channel.updateChannelTierRule(false);
             }
@@ -149,8 +149,8 @@ public class ChannelService {
         }
     }
 
-    private void validateTier(String tierMax, String gradeMax) {
-        if(tierMax == null || gradeMax == null) {
+    private void validateTier(String tierMax) {
+        if(tierMax == null) {
             throw new ChannelUpdateException();
         }
     }

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -17,6 +17,7 @@ import leaguehub.leaguehubbackend.service.member.MemberService;
 import leaguehub.leaguehubbackend.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -311,8 +312,14 @@ public class ParticipantService {
 
 
     private static void rankRuleCheck(ChannelRule channelRule, GameRankDto tier) {
+
         if (channelRule.getTier()) {
-            int limitedRankScore = GameTier.rankToScore(channelRule.getLimitedTier(), channelRule.getLimitedGrade());
+            String[] s = channelRule.getLimitedTier().split(" ");
+            System.out.println("s = " + s[0].toString());
+            System.out.println("s = " + s[1].toString());
+            String ruleTier = s[0];
+            String ruleGrade = s[1];
+            int limitedRankScore = GameTier.rankToScore(ruleTier, ruleGrade);
             int userRankScore = GameTier.rankToScore(tier.getGameRank().toString(), tier.getGameGrade());
             if (userRankScore > limitedRankScore)
                 throw new ParticipantInvalidRankException();
@@ -349,7 +356,12 @@ public class ParticipantService {
 
         checkRule(channelRule, userDetail, tier);
 
-        participant.updateParticipantStatus(responseDto.getGameId(), tier.getGameRank().toString(), responseDto.getNickname());
+        participant.updateParticipantStatus(responseDto.getGameId(), getGameTier(tier), responseDto.getNickname());
+    }
+
+    @NotNull
+    private static String getGameTier(GameRankDto tier) {
+        return tier.getGameRank().toString() + " " + tier.getGameGrade();
     }
 
     /**

--- a/src/test/java/leaguehub/leaguehubbackend/controller/MatchControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/MatchControllerTest.java
@@ -48,7 +48,7 @@ public class MatchControllerTest {
     @DisplayName("경기 결과 생성 테스트 - 성공")
     public void createMatchRankSuccessTest() throws Exception{
         //given
-        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver", "iv", 100);
+        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", 100);
         channelRepository.save(channel);
         Match match = Match.createMatch(16, channel);
         matchRepository.save(match);
@@ -69,7 +69,7 @@ public class MatchControllerTest {
     @DisplayName("경기 결과 생성 테스트 - 실패")
     public void createMatchRankFailTest() throws Exception{
         //given
-        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver", "iv", 100);
+        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", 100);
         channelRepository.save(channel);
         Match match = Match.createMatch(16, channel);
         matchRepository.save(match);

--- a/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
@@ -68,7 +68,7 @@ class ParticipantControllerTest {
     @Autowired
     ObjectMapper mapper;
 
-    Channel createCustomChannel(Boolean tier, Boolean playCount, String tierMax, String gradeMax, int playCountMin) throws Exception {
+    Channel createCustomChannel(Boolean tier, Boolean playCount, String tierMax, int playCountMin) throws Exception {
         Member member = memberRepository.save(UserFixture.createMember());
         Member ironMember = memberRepository.save(UserFixture.createCustomeMember("썹맹구"));
         Member unrankedMember = memberRepository.save(UserFixture.createCustomeMember("서초임"));
@@ -81,11 +81,11 @@ class ParticipantControllerTest {
         Member observer1 = memberRepository.save(UserFixture.createCustomeMember("관전자1"));
         Member observer2 = memberRepository.save(UserFixture.createCustomeMember("관전자2"));
 
-        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, gradeMax, playCountMin);
+        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, playCountMin);
         Channel channel = Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
         channelRepository.save(channel);
@@ -103,10 +103,10 @@ class ParticipantControllerTest {
         Participant doneParticipant1 = participantRepository.save(Participant.participateChannel(doneMember1, channel));
         Participant doneParticipant2 = participantRepository.save(Participant.participateChannel(doneMember2, channel));
 
-        alreadyParticipant.updateParticipantStatus("participantGameId1", "bronze", "participantNickname1");
+        alreadyParticipant.updateParticipantStatus("participantGameId1", "bronze ii", "participantNickname1");
         rejectedParticipant.rejectParticipantRequest();
-        doneParticipant1.updateParticipantStatus("participantGameId2", "platinum", "participantNickname2");
-        doneParticipant2.updateParticipantStatus("participantGameId3", "iron", "participantNickname3");
+        doneParticipant1.updateParticipantStatus("participantGameId2", "platinum ii", "participantNickname2");
+        doneParticipant2.updateParticipantStatus("participantGameId3", "iron ii", "participantNickname3");
         doneParticipant1.approveParticipantMatch();
         doneParticipant2.approveParticipantMatch();
 
@@ -145,7 +145,7 @@ class ParticipantControllerTest {
     @Test
     @DisplayName("참여 여부 테스트 - 성공")
     void participateMatchSuccessTest() throws Exception {
-        Channel channel = createCustomChannel(false, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(false, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("서초임");
         mockMvc.perform(get(("/api/participant/") + channel.getChannelLink()))
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -156,7 +156,7 @@ class ParticipantControllerTest {
     @Test
     @DisplayName("참여 여부 테스트 (관리자) - 실패")
     void participateMatchFailTest() throws Exception {
-        Channel channel = createCustomChannel(false, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(false, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("id");
 
         mockMvc.perform(get(("/api/participant/") + channel.getChannelLink()))
@@ -169,7 +169,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어, 판수 제한 x) - 성공")
     void participateDefaultMatchSuccessTest() throws Exception {
 
-        Channel channel = createCustomChannel(false, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(false, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("썹맹구");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "썹맹구");
@@ -186,7 +186,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (판수 제한 o) - 성공")
     void participateLimitedPlayCountMatchSuccessTest() throws Exception {
 
-        Channel channel = createCustomChannel(false, true, "Silver", "iv", 20);
+        Channel channel = createCustomChannel(false, true, "Silver iv", 100);
         UserFixture.setUpCustomAuth("손성한");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "손성한");
@@ -203,7 +203,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (마스터 10000점 이하, 판수 제한 o) - 성공")
     void participateLimitedMasterMatchSuccessTest() throws Exception {
 
-        Channel channel = createCustomChannel(true, true, "master", "10000", 20);
+        Channel channel = createCustomChannel(true, true, "master 100000", 20);
         UserFixture.setUpCustomAuth("채수채수밭");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "채수채수밭");
@@ -221,7 +221,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (중복) - 실패")
     public void participateDuplicatedMatchFailTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(false, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("서초임");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "participantGameId3");
@@ -239,7 +239,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (참가된사람) - 실패")
     public void participantDoneMatchFailTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(true, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(true, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("참가된사람1");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "참가된사람1");
@@ -256,7 +256,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (이미참가요청한사람) - 실패")
     public void participantAlreadyMatchFailTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(true, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(true, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("요청한사람");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "요청한사람");
@@ -273,7 +273,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (거절된사람) - 실패")
     public void participantRejectedMatchFailTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(true, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(true, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("거절된사람");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "거절된사람");
@@ -290,7 +290,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어 제한) - 실패")
     void participateLimitedTierMatchFailTest() throws Exception {
 
-        Channel channel = createCustomChannel(true, false, "Silver", "iv", 20);
+        Channel channel = createCustomChannel(true, false, "Silver iv", 20);
         UserFixture.setUpCustomAuth("손성한");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "손성한");
@@ -307,7 +307,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (횟수 제한) - 실패")
     void participateLimitedPlayCountMatchFailTest() throws Exception {
 
-        Channel channel = createCustomChannel(true, true, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(true, true, "Silver iv", 100);
         UserFixture.setUpCustomAuth("서초임");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "서초임");
@@ -324,7 +324,7 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (마스터 100점 이하, 횟수 제한) - 실패")
     void participateLimitedMasterMatchFailTest() throws Exception {
 
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         UserFixture.setUpCustomAuth("채수채수밭");
 
         ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "채수채수밭");
@@ -341,7 +341,7 @@ class ParticipantControllerTest {
     @DisplayName("채널 경기 참여자 조회 테스트")
     void loadPlayerTest() throws Exception {
 
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("id");
 
         mockMvc.perform(get("/api/profile/player?channelLink=" + channel.getChannelLink()))
@@ -359,7 +359,7 @@ class ParticipantControllerTest {
     @DisplayName("요청된사람 조회 테스트 (관리자 x) - 실패")
     public void loadRequestStatusPlayerListFailTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("참가된사람1");
 
         mockMvc.perform(get("/api/profile/request?channelLink=" + channel.getChannelLink()))
@@ -371,14 +371,13 @@ class ParticipantControllerTest {
     @DisplayName("요청된사람 조회 테스트 (관리자 o) - 성공")
     public void loadRequestStatusPlayerListSuccessTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("id");
 
         mockMvc.perform(get("/api/profile/request?channelLink=" + channel.getChannelLink()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("[0].nickname").value("participantNickname1"))
-                .andExpect(jsonPath("[0].gameId").value("participantGameId1"))
-                .andExpect(jsonPath("[0].tier").value("bronze"));
+                .andExpect(jsonPath("[0].gameId").value("participantGameId1"));
 
     }
 
@@ -387,7 +386,7 @@ class ParticipantControllerTest {
     @DisplayName("요청한사람 승인 테스트 (관리자 o) - 성공")
     public void approveParticipantSuccessTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("id");
 
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
@@ -402,7 +401,7 @@ class ParticipantControllerTest {
     @DisplayName("요청한사람 승인 테스트 (관리자 x) - 실패")
     public void approveParticipantFailTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("참가된사람1");
 
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
@@ -416,7 +415,7 @@ class ParticipantControllerTest {
     @DisplayName("요청한사람 거절 테스트 (관리자 o) - 성공")
     public void rejectedParticipantSuccessTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("id");
 
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
@@ -430,7 +429,7 @@ class ParticipantControllerTest {
     @DisplayName("요청한사람 거절 테스트 (관리자 x) - 실패")
     public void rejectedParticipantFailTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("참가된사람1");
 
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
@@ -444,7 +443,7 @@ class ParticipantControllerTest {
     @DisplayName("참가한사람 거절 테스트 (관리자 o) - 성공")
     public void rejectedPlayerSuccessTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("id");
 
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
@@ -459,7 +458,7 @@ class ParticipantControllerTest {
     @DisplayName("참가한사람 거절 테스트 (관리자 o) - 실패")
     public void rejectedPlayerFailTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("참가된사람1");
 
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
@@ -474,7 +473,7 @@ class ParticipantControllerTest {
     @DisplayName("관리자 부여 테스트 (관리자 o) - 성공")
     public void updateHostSuccessTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("id");
 
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
@@ -488,7 +487,7 @@ class ParticipantControllerTest {
     @DisplayName("관리자 부여 테스트 (관리자 x) - 실패")
     public void updateHostFailTest() throws Exception {
         //given
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("참가된사람1");
 
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
@@ -503,7 +502,7 @@ class ParticipantControllerTest {
     @DisplayName("채널 관전자 조회 테스트 (관전자 o) - 성공")
     void loadObserverSuccessTest() throws Exception {
 
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("id");
 
         mockMvc.perform(get("/api/profile/observer?channelLink=" + channel.getChannelLink()))
@@ -518,7 +517,7 @@ class ParticipantControllerTest {
     @DisplayName("채널 관전자 조회 테스트 (관전자 x) - 실패")
     void loadObserverFailTest() throws Exception {
 
-        Channel channel = createCustomChannel(false, false, "master", "100", 20);
+        Channel channel = createCustomChannel(false, false, "master 100", 20);
         UserFixture.setUpCustomAuth("참가된사람1");
 
         mockMvc.perform(get("/api/profile/observer?channelLink=" + channel.getChannelLink()))
@@ -530,7 +529,7 @@ class ParticipantControllerTest {
     public void approveParticipantCountFailTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("id");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         String[] nickName = new String[13];
 
         for (int i = 0; i < nickName.length; i++) {

--- a/src/test/java/leaguehub/leaguehubbackend/controller/channel/ChannelBoardControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/channel/ChannelBoardControllerTest.java
@@ -68,17 +68,17 @@ class ChannelBoardControllerTest {
 
     }
 
-    Channel createCustomChannel(Boolean tier, Boolean playCount, String tierMax, String gradeMax, int playCountMin) throws Exception {
+    Channel createCustomChannel(Boolean tier, Boolean playCount, String tierMax, int playCountMin) throws Exception {
         Member member = memberRepository.save(UserFixture.createMember());
         Member ironMember = memberRepository.save(UserFixture.createCustomeMember("1"));
         Member unrankedMember = memberRepository.save(UserFixture.createCustomeMember("2"));
         Member platinumMember = memberRepository.save(UserFixture.createCustomeMember("3"));
         Member masterMember = memberRepository.save(UserFixture.createCustomeMember("4"));
-        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, gradeMax, playCountMin);
+        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, playCountMin);
         Channel channel = Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
         channelRepository.save(channel);
@@ -113,7 +113,7 @@ class ChannelBoardControllerTest {
     @Test
     @DisplayName("게시판 만들기 - 실패(권한없음)")
     void 트FailCreateChannelBoard() throws Exception {
-        Channel customChannel = createCustomChannel(false, false, "Silver", "i", 100);
+        Channel customChannel = createCustomChannel(false, false, "Silver i", 100);
         Channel findChannel = channelRepository.save(customChannel);
 
         Member test = UserFixture.createCustomeMember("test231");
@@ -186,7 +186,7 @@ class ChannelBoardControllerTest {
     @Test
     @DisplayName("게시판 업데이트 - 실패(권한없음)")
     void failUpdateChannelBoard_NoAuth() throws Exception {
-        Channel customChannel = createCustomChannel(false, false, "Silver", "i", 100);
+        Channel customChannel = createCustomChannel(false, false, "Silver i", 100);
         Channel findChannel = channelRepository.save(customChannel);
 
         Member test = UserFixture.createCustomeMember("test231");

--- a/src/test/java/leaguehub/leaguehubbackend/entity/channel/ChannelBoardTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/channel/ChannelBoardTest.java
@@ -36,11 +36,11 @@ class ChannelBoardTest {
 
     public Channel createChannel() {
         Member member = memberRepository.save(UserFixture.createMember());
-        CreateChannelDto channelDto = createAllPropertiesCustomChannelDto(true, true, "Silver", "iv",100);
+        CreateChannelDto channelDto = createAllPropertiesCustomChannelDto(true, true, "Silver iv",100);
         Channel channel = Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(),channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
         channelRepository.save(channel);

--- a/src/test/java/leaguehub/leaguehubbackend/entity/channel/ChannelRuleTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/channel/ChannelRuleTest.java
@@ -24,7 +24,7 @@ class ChannelRuleTest {
     @DisplayName("채널 룰 생성 테스트")
     public void createChannelRule() throws Exception {
         CreateChannelDto channelDto = ChannelFixture.createChannelDto();
-        ChannelRule channelRule = ChannelRule.createChannelRule(channelDto.getTierMax(), channelDto.getGradeMax(), channelDto.getTier(),
+        ChannelRule channelRule = ChannelRule.createChannelRule(channelDto.getTierMax(), channelDto.getTier(),
                 channelDto.getPlayCount(), channelDto.getPlayCountMin());
 
         ChannelRule save = channelRuleRepository.save(channelRule);

--- a/src/test/java/leaguehub/leaguehubbackend/entity/channel/ChannelTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/channel/ChannelTest.java
@@ -49,7 +49,7 @@ class ChannelTest {
         Channel channel = Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
         channelRepository.save(channel);
@@ -75,11 +75,11 @@ class ChannelTest {
     public void 채널_생성_테스트_제한() throws Exception {
         //given
         Member member = memberRepository.save(UserFixture.createMember());
-        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(true, true, "Silver", "iv",100);
+        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(true, true, "Silver iv",100);
         Channel channel = Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
         channelRepository.save(channel);
@@ -99,7 +99,6 @@ class ChannelTest {
         assertThat(channelBoardList.size()).isEqualTo(3);
         assertThat(channelBoardList.get(0).getChannel()).isEqualTo(channel);
         assertThat(findChannel.get().getChannelLink()).isEqualTo(channel.getChannelLink());
-        assertThat(findChannel.get().getAccessCode()).isEqualTo(channel.getAccessCode());
     }
 
     @Test
@@ -109,7 +108,7 @@ class ChannelTest {
         assertThatThrownBy(() -> Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin()))
                 .isInstanceOf(ChannelCreateException.class);
@@ -122,7 +121,7 @@ class ChannelTest {
         assertThatThrownBy(() -> Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin()))
                 .isInstanceOf(ChannelCreateException.class);

--- a/src/test/java/leaguehub/leaguehubbackend/entity/match/MatchRankTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/match/MatchRankTest.java
@@ -26,7 +26,7 @@ class MatchRankTest {
     @Test
     @DisplayName("순위 생성 테스트")
     void createMatchRankTest() throws Exception {
-        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver", "iv", 100);
+        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", 100);
         Match match = Match.createMatch(16, channel);
         MatchResult matchResult = MatchResult.createMatchResult("ab12345", match);
         MatchRank matchRank = MatchRank.createMatchRank("가나다", "1등", matchResult);

--- a/src/test/java/leaguehub/leaguehubbackend/entity/match/MatchResultTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/match/MatchResultTest.java
@@ -25,7 +25,7 @@ class MatchResultTest {
     @DisplayName("순위 결과 생성 테스트")
     void createMatchResultTest() throws Exception {
         //given
-        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver", "iv", 100);
+        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", 100);
         Match match = Match.createMatch(16, channel);
         MatchResult matchResult = MatchResult.createMatchResult("svkos12d0kr", match);
         MatchResult save = matchResultRepository.save(matchResult);

--- a/src/test/java/leaguehub/leaguehubbackend/entity/participant/ParticipantTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/participant/ParticipantTest.java
@@ -39,11 +39,11 @@ class ParticipantTest {
     public void createHostTest() throws Exception {
 
         Member member = memberRepository.save(UserFixture.createMember());
-        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(true, true, "Silver", "i",100);
+        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(true, true, "Silver iv",100);
         Channel channel = Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
         channelRepository.save(channel);

--- a/src/test/java/leaguehub/leaguehubbackend/fixture/ChannelFixture.java
+++ b/src/test/java/leaguehub/leaguehubbackend/fixture/ChannelFixture.java
@@ -22,7 +22,7 @@ public class ChannelFixture {
 
 
     public static CreateChannelDto createAllPropertiesCustomChannelDto(Boolean tier, Boolean playCount,
-                                                                       String tierMax, String gradeMax, int playCountMin) {
+                                                                       String tierMax, int playCountMin) {
         CreateChannelDto createChannelDto = CreateChannelDto.builder()
                 .game(0)
                 .title("test")
@@ -30,7 +30,6 @@ public class ChannelFixture {
                 .participationNum(16)
                 .tier(tier)
                 .tierMax(tierMax)
-                .gradeMax(gradeMax)
                 .playCount(playCount)
                 .playCountMin(playCountMin)
                 .build();
@@ -91,13 +90,13 @@ public class ChannelFixture {
         return channelBoardDto;
     }
 
-    public static Channel createDummyChannel(Boolean tier, Boolean playCount, String tierMax, String gradeMax, int playCountMin){
-        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, gradeMax, playCountMin);
+    public static Channel createDummyChannel(Boolean tier, Boolean playCount, String tierMax, int playCountMin){
+        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, playCountMin);
 
         return Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
     }

--- a/src/test/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardServiceTest.java
@@ -54,17 +54,17 @@ class ChannelBoardServiceTest {
 
     private String channelLink;
 
-    Channel createCustomChannel(Boolean tier, Boolean playCount, String tierMax, String gradeMax, int playCountMin) throws Exception {
+    Channel createCustomChannel(Boolean tier, Boolean playCount, String tierMax, int playCountMin) throws Exception {
         Member member = memberRepository.save(UserFixture.createMember());
         Member ironMember = memberRepository.save(UserFixture.createCustomeMember("썹맹구"));
         Member unrankedMember = memberRepository.save(UserFixture.createCustomeMember("서초임"));
         Member platinumMember = memberRepository.save(UserFixture.createCustomeMember("손성한"));
         Member masterMember = memberRepository.save(UserFixture.createCustomeMember("채수채수밭"));
-        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, gradeMax, playCountMin);
+        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, playCountMin);
         Channel channel = Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
         channelRepository.save(channel);
@@ -102,7 +102,7 @@ class ChannelBoardServiceTest {
     @Test
     @DisplayName("게시판 만들기 테스트 - 실패 (권한 없음)")
     void invalidMemberChannelBoard() throws Exception {
-        Channel customChannel = createCustomChannel(false, false, "Silver", "iv", 100);
+        Channel customChannel = createCustomChannel(false, false, "Silver iv", 100);
         Channel findChannel = channelRepository.save(customChannel);
 
         Member test = UserFixture.createCustomeMember("test231");
@@ -137,7 +137,7 @@ class ChannelBoardServiceTest {
         channelBoardService.createChannelBoard(channel.get().getChannelLink(), ChannelFixture.createChannelBoardDto());
         memberRepository.save(UserFixture.createCustomeMember("test2"));
         UserFixture.setUpCustomAuth("test2");
-        Channel customChannel = createCustomChannel(false, false, "Silver", "iv", 100);
+        Channel customChannel = createCustomChannel(false, false, "Silver iv", 100);
         Channel findChannel = channelRepository.save(customChannel);
 
         List<ChannelBoard> channelBoards = channelBoardRepository.findAllByChannel_Id(findChannel.getId());

--- a/src/test/java/leaguehub/leaguehubbackend/service/match/MatchRankServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/match/MatchRankServiceTest.java
@@ -49,7 +49,7 @@ class MatchRankServiceTest {
     @DisplayName("경기 검색 테스트 - 성공")
     void searchMatchSuccessTest() throws Exception {
         //given
-        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver", "iv", 100);
+        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", 100);
         channelRepository.save(channel);
         Match match = Match.createMatch(16, channel);
         matchRepository.save(match);
@@ -65,7 +65,7 @@ class MatchRankServiceTest {
     @DisplayName("경기 검색 테스트 - 실패")
     void searchMatchFailTest() throws Exception {
         //given
-        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver", "iv", 100);
+        Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", 100);
         channelRepository.save(channel);
         Match match = Match.createMatch(16, channel);
         matchRepository.save(match);

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -79,7 +79,7 @@ class ParticipantServiceTest {
     }
 
 
-    Channel createCustomChannel(Boolean tier, Boolean playCount, String tierMax, String gradeMax, int playCountMin) throws Exception {
+    Channel createCustomChannel(Boolean tier, Boolean playCount, String tierMax, int playCountMin) throws Exception {
         Member member = memberRepository.save(UserFixture.createMember());
         Member ironMember = memberRepository.save(UserFixture.createCustomeMember("썹맹구"));
         Member unrankedMember = memberRepository.save(UserFixture.createCustomeMember("서초임"));
@@ -90,11 +90,11 @@ class ParticipantServiceTest {
         Member doneMember1 = memberRepository.save(UserFixture.createCustomeMember("참가된사람1"));
         Member doneMember2 = memberRepository.save(UserFixture.createCustomeMember("참가된사람2"));
 
-        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, gradeMax, playCountMin);
+        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, playCountMin);
         Channel channel = Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
         channelRepository.save(channel);
@@ -157,15 +157,13 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어, 판수 제한 x) - 성공")
     void participateDefaultMatchSuccessTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(false, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(false, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("서초임");
 
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
         responseDto.setGameId("서초임");
 
-        ChannelRule channelRule = channelRuleRepository.findChannelRuleByChannel_ChannelLink(responseDto.getChannelLink());
-        System.out.println("chnnelRule = " + channelRule);
         participantService.participateMatch(responseDto);
 
         //when
@@ -176,7 +174,7 @@ class ParticipantServiceTest {
                         responseDto.getChannelLink()).get();
 
         //then
-        assertThat(participant.getGameTier()).isEqualToIgnoringCase("unranked");
+        assertThat(participant.getGameTier()).isEqualToIgnoringCase("unranked none");
         assertThat(participant.getRole()).isEqualTo(Role.OBSERVER);
         assertThat(participant.getRequestStatus()).isEqualTo(RequestStatus.REQUEST);
     }
@@ -185,7 +183,7 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의  경기 참가 테스트 (티어, 판수 제한 o) - 성공")
     void participatelimitedMatchSuccessTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, true, "diamond", "iv", 100);
+        Channel channel = createCustomChannel(true, true, "diamond iii", 100);
         UserFixture.setUpCustomAuth("손성한");
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
@@ -201,7 +199,6 @@ class ParticipantServiceTest {
                         responseDto.getChannelLink()).get();
 
         //then
-        assertThat(participant.getGameTier()).isEqualToIgnoringCase("platinum");
         assertThat(participant.getRole()).isEqualTo(Role.OBSERVER);
         assertThat(participant.getRequestStatus()).isEqualTo(RequestStatus.REQUEST);
     }
@@ -210,7 +207,7 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어 마스터 20000점 이하, 판수 제한 o) - 성공")
     void participatelimitedMatchMasterSuccessTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, true, "master", "20000", 20);
+        Channel channel = createCustomChannel(true, true, "master 20000", 20);
         UserFixture.setUpCustomAuth("채수채수밭");
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
@@ -226,7 +223,6 @@ class ParticipantServiceTest {
                         responseDto.getChannelLink()).get();
 
         //then
-        assertThat(participant.getGameTier()).isEqualToIgnoringCase("challenger");
         assertThat(participant.getRole()).isEqualTo(Role.OBSERVER);
         assertThat(participant.getRequestStatus()).isEqualTo(RequestStatus.REQUEST);
     }
@@ -235,7 +231,7 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (중복) - 실패")
     void participateDuplicatedMatchFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(false, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(false, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("서초임");
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
@@ -250,7 +246,7 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (참가된사람) - 실패")
     void participateDoneMatchFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(true, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("참가된사람1");
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
@@ -265,7 +261,7 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (이미참가요청한사람) - 실패")
     void participateAlreadyMatchFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(true, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("요청한사람");
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
@@ -280,7 +276,7 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (거절된사람) - 실패")
     void participateRejectedMatchFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(true, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("거절된사람");
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
@@ -295,7 +291,7 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어 제한 o) - 실패")
     void participatelimitedTierMatchFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, false, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(true, false, "Silver iv", 100);
         UserFixture.setUpCustomAuth("손성한");
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
@@ -311,7 +307,7 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (판수 제한 o) - 실패")
     void participateLimitedPlayCountMatchFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(false, true, "Silver", "iv", 100);
+        Channel channel = createCustomChannel(false, true, "Silver iv", 100);
         UserFixture.setUpCustomAuth("서초임");
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
@@ -326,7 +322,7 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어 마스터 100점 이하, 판수 제한 o) - 실패")
     void participatelimitedMatchMasterFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         UserFixture.setUpCustomAuth("채수채수밭");
         ParticipantResponseDto responseDto = new ParticipantResponseDto();
         responseDto.setChannelLink(channel.getChannelLink());
@@ -349,7 +345,7 @@ class ParticipantServiceTest {
         Channel channel = Channel.createChannel(channelDto.getTitle(),
                 channelDto.getGame(), channelDto.getParticipationNum(),
                 channelDto.getTournament(), channelDto.getChannelImageUrl(),
-                channelDto.getTier(), channelDto.getTierMax(), channelDto.getGradeMax(),
+                channelDto.getTier(), channelDto.getTierMax(),
                 channelDto.getPlayCount(),
                 channelDto.getPlayCountMin());
         channelRepository.save(channel);
@@ -359,8 +355,8 @@ class ParticipantServiceTest {
         Participant part2 = participantRepository.save(Participant.participateChannel(platinumMember, channel));
         Participant part3 = participantRepository.save(Participant.participateChannel(ironMember, channel));
 
-        part2.updateParticipantStatus("손성한", "platinum", "손성한");
-        part3.updateParticipantStatus("썹맹구", "iron", "썹맹구");
+        part2.updateParticipantStatus("손성한", "platinum III", "손성한");
+        part3.updateParticipantStatus("썹맹구", "iron III", "썹맹구");
 
         part2.approveParticipantMatch();
         part3.approveParticipantMatch();
@@ -387,15 +383,15 @@ class ParticipantServiceTest {
     public void loadRequestStatusPlayerListFailTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("서초임");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("DummyName1"));
         Member dummyMember2 = memberRepository.save(UserFixture.createCustomeMember("DummyName2"));
 
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
         Participant dummy2 = participantRepository.save(Participant.participateChannel(dummyMember2, channel));
 
-        dummy1.updateParticipantStatus("DummyGameId1", "platinum", "DummyNickname1");
-        dummy2.updateParticipantStatus("DummyGameId2", "iron", "DummyNickname2");
+        dummy1.updateParticipantStatus("DummyGameId1", "platinum III", "DummyNickname1");
+        dummy2.updateParticipantStatus("DummyGameId2", "iron III", "DummyNickname2");
 
         //when
         assertThatThrownBy(() -> participantService.loadRequestStatusPlayerList(channel.getChannelLink()))
@@ -408,14 +404,14 @@ class ParticipantServiceTest {
     public void loadRequestStatusPlayerListTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("id");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("DummyName1"));
         Member dummyMember2 = memberRepository.save(UserFixture.createCustomeMember("DummyName2"));
 
         Participant dummy1 = participantRepository.save(Participant.participateChannel(dummyMember1, channel));
         Participant dummy2 = participantRepository.save(Participant.participateChannel(dummyMember2, channel));
 
-        dummy1.updateParticipantStatus("DummyGameId1", "platinum", "DummyNickname1");
+        dummy1.updateParticipantStatus("DummyGameId1", "platinum III", "DummyNickname1");
 
         //when
         List<ResponseStatusPlayerDto> DtoList = participantService.loadRequestStatusPlayerList(channel.getChannelLink());
@@ -436,7 +432,7 @@ class ParticipantServiceTest {
     public void approveParticipantSuccessTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("id");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
 
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
@@ -460,7 +456,7 @@ class ParticipantServiceTest {
     public void approveParticipantFailTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("서초임");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
         assertThatThrownBy(() -> participantService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId()))
@@ -473,7 +469,7 @@ class ParticipantServiceTest {
     public void rejectedParticipantSuccessTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("id");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
         //when
@@ -493,7 +489,7 @@ class ParticipantServiceTest {
     public void rejectedParticipantFailTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("서초임");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
 
@@ -508,7 +504,7 @@ class ParticipantServiceTest {
     public void rejectedPlayerSuccessTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("id");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
         dummy1.approveParticipantMatch();
 
@@ -529,7 +525,7 @@ class ParticipantServiceTest {
     public void rejectedPlayerFailTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("서초임");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
         assertThatThrownBy(() -> participantService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId()))
@@ -542,7 +538,7 @@ class ParticipantServiceTest {
     public void loadObserverListTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("id");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("DummyName1"));
         Member dummyMember2 = memberRepository.save(UserFixture.createCustomeMember("DummyName2"));
 
@@ -573,7 +569,7 @@ class ParticipantServiceTest {
     public void loadObserverListFailTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("서초임");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("DummyName1"));
         Member dummyMember2 = memberRepository.save(UserFixture.createCustomeMember("DummyName2"));
 
@@ -591,7 +587,7 @@ class ParticipantServiceTest {
     public void updateHostParticipantSuccessTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("id");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Member dummyMember1 = memberRepository.save(UserFixture.createCustomeMember("DummyName1"));
         Member dummyMember2 = memberRepository.save(UserFixture.createCustomeMember("DummyName2"));
 
@@ -622,7 +618,7 @@ class ParticipantServiceTest {
     public void updateHostParticipantFailTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("서초임");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
         assertThatThrownBy(() -> participantService.updateHostRole(channel.getChannelLink(), dummy1.getId()))
@@ -635,7 +631,7 @@ class ParticipantServiceTest {
     public void approveParticipantCountFailTest() throws Exception {
         //given
         UserFixture.setUpCustomAuth("id");
-        Channel channel = createCustomChannel(true, true, "master", "100", 20);
+        Channel channel = createCustomChannel(true, true, "master 100", 20);
         String[] nickName = new String[13];
 
         for (int i = 0; i < nickName.length; i++) {


### PR DESCRIPTION
## 🙆‍♂️ Issue

#112 

## 📝 Description

채널 룰 엔티티, 클라이언트에서 티어 값을 받아오는 서비스를 수정하였어요
채널 룰에서 tier, grade 변수를 하나의 변수로 합치고
룰 제한을 check 할 때 룰을 받아오는 서비스를 변경하였어요

해당 dto와 테스트코드도 함께 변경하였어요
파일 변경이 많아서 커밋별로 보는 걸 추천할게요

## ✨ Feature

channel관련 엔티티 리팩터링
participantService 티어 룰 제한 리팩터링
해당 테스트 코드 리팩터링

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.
This closes #112 