### PR TITLE
Refactor#117: 채널 업데이트 API 분리

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/Controller/channel/ChannelRuleController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/channel/ChannelRuleController.java
@@ -1,0 +1,34 @@
+package leaguehub.leaguehubbackend.controller.channel;
+
+import leaguehub.leaguehubbackend.dto.channel.ChannelRuleDto;
+import leaguehub.leaguehubbackend.service.channel.ChannelRuleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ChannelRuleController {
+
+    private final ChannelRuleService channelRuleService;
+
+    @GetMapping("/channel/{channelLink}/rule")
+    public ResponseEntity getChannelRule(@PathVariable("channelLink") String channelLink) {
+        ChannelRuleDto channelRule = channelRuleService.getChannelRule(channelLink);
+
+        return new ResponseEntity<>(channelRule, OK);
+    }
+
+    @PostMapping("/channel/{channelLink}/rule")
+    public ResponseEntity updateChannelRule(@PathVariable("channelLink") String channelLink,
+                                            @RequestBody ChannelRuleDto channelRuleDto) {
+        ChannelRuleDto channelRule = channelRuleService.updateChannelRule(channelLink, channelRuleDto);
+
+        return new ResponseEntity(channelRule, OK);
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/channel/ChannelRuleDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/channel/ChannelRuleDto.java
@@ -1,0 +1,35 @@
+package leaguehub.leaguehubbackend.dto.channel;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChannelRuleDto {
+
+    @JsonProperty("tier")
+    private Boolean tier;
+
+    @JsonProperty("tierMax")
+    private String tierMax;
+
+    @JsonProperty("tierMin")
+    private String tierMin;
+
+    @JsonProperty("playCount")
+    private Boolean playCount;
+
+    @JsonProperty("playCountMin")
+    private Integer playCountMin;
+
+    @Builder
+    public ChannelRuleDto(Boolean tier, String tierMax, String tierMin, Boolean playCount, Integer playCountMin) {
+        this.tier = tier;
+        this.tierMax = tierMax;
+        this.tierMin = tierMin;
+        this.playCount = playCount;
+        this.playCountMin = playCountMin;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/channel/UpdateChannelDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/channel/UpdateChannelDto.java
@@ -14,21 +14,7 @@ public class UpdateChannelDto {
     @JsonProperty("maxPlayer")
     private Integer participationNum;
 
-    @JsonProperty("tier")
-    private Boolean tier;
-
-    @JsonProperty("tierMax")
-    private String tierMax;
-
-    @JsonProperty("tierMin")
-    private String tierMin;
-
     @JsonProperty("channelImageUrl")
     private String channelImageUrl;
 
-    @JsonProperty("playCount")
-    private Boolean playCount;
-
-    @JsonProperty("playCountMin")
-    private Integer playCountMin;
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
@@ -106,19 +106,4 @@ public class Channel extends BaseTimeEntity {
         this.channelImageUrl = channelImageUrl;
     }
 
-    public void updateChannelTierRule(boolean tier, String tierMax, String tierMin) {
-        this.channelRule.updateTierRule(tier, tierMax, tierMin);
-    }
-
-    public void updateChannelTierRule(boolean tier) {
-        this.channelRule.updateTierRule(tier);
-    }
-
-    public void updateChannelPlayCountRule(boolean playCount, Integer playCountMin) {
-        this.channelRule.updatePlayCountMin(playCount, playCountMin);
-    }
-
-    public void updateChannelPlayCountRule(boolean playCount) {
-        this.channelRule.updatePlayCountMin(playCount);
-    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelRuleService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelRuleService.java
@@ -1,0 +1,75 @@
+package leaguehub.leaguehubbackend.service.channel;
+
+import leaguehub.leaguehubbackend.dto.channel.ChannelRuleDto;
+import leaguehub.leaguehubbackend.dto.channel.CreateChannelDto;
+import leaguehub.leaguehubbackend.entity.channel.Channel;
+import leaguehub.leaguehubbackend.entity.channel.ChannelRule;
+import leaguehub.leaguehubbackend.exception.channel.exception.ChannelRequestException;
+import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
+import leaguehub.leaguehubbackend.repository.channel.ChannelRuleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ChannelRuleService {
+
+    private final ChannelRuleRepository channelRuleRepository;
+    private final ChannelService channelService;
+
+    @Transactional
+    public ChannelRuleDto updateChannelRule(String channelLink, ChannelRuleDto channelRuleDto) {
+        channelService.validateChannel(channelLink);
+        ChannelRule channelRule = channelRuleRepository.findChannelRuleByChannel_ChannelLink(channelLink);
+
+        Optional.ofNullable(channelRuleDto.getTier())
+                .ifPresent(tier -> {
+                    if (tier) {
+                        validateTier(channelRuleDto.getTierMax(), channelRuleDto.getTierMin());
+                        channelRule.updateTierRule(true, channelRuleDto.getTierMax(), channelRuleDto.getTierMin());
+                    } else {
+                        channelRule.updateTierRule(false);
+                    }
+                });
+
+        Optional.ofNullable(channelRuleDto.getPlayCount())
+                .ifPresent(playCount -> {
+                    if (playCount) {
+                        validatePlayCount(channelRuleDto.getPlayCountMin());
+                        channelRule.updatePlayCountMin(true, channelRuleDto.getPlayCountMin());
+                    } else {
+                        channelRule.updatePlayCountMin(false);
+                    }
+                });
+
+        return new ChannelRuleDto().builder().tier(channelRule.getTier()).tierMax(channelRule.getTierMax())
+                .tierMin(channelRule.getTierMin()).playCount(channelRule.getPlayCount())
+                .playCountMin(channelRule.getLimitedPlayCount()).build();
+    }
+
+    @Transactional
+    public ChannelRuleDto getChannelRule(String channelLink) {
+        channelService.validateChannel(channelLink);
+        ChannelRule channelRule = channelRuleRepository.findChannelRuleByChannel_ChannelLink(channelLink);
+
+        return new ChannelRuleDto().builder().tier(channelRule.getTier()).tierMax(channelRule.getTierMax())
+                .tierMin(channelRule.getTierMin()).playCount(channelRule.getPlayCount())
+                .playCountMin(channelRule.getLimitedPlayCount()).build();
+    }
+
+
+    private void validateTier(String tierMax, String tierMin) {
+        if (tierMax == null && tierMin == null) {
+            throw new ChannelRequestException();
+        }
+    }
+
+    private void validatePlayCount(Integer playCountMin) {
+        if (playCountMin == null) {
+            throw new ChannelRequestException();
+        }
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -100,26 +100,6 @@ public class ChannelService {
         Optional.ofNullable(updateChannelDto.getTitle()).ifPresent(channel::updateTitle);
         Optional.ofNullable(updateChannelDto.getParticipationNum()).ifPresent(channel::updateMaxPlayer);
         Optional.ofNullable(updateChannelDto.getChannelImageUrl()).ifPresent(channel::updateChannelImageUrl);
-
-        Optional.ofNullable(updateChannelDto.getTier())
-                .ifPresent(tier -> {
-                    if (tier) {
-                        validateTier(updateChannelDto.getTierMax(), updateChannelDto.getTierMin());
-                        channel.updateChannelTierRule(true, updateChannelDto.getTierMax(), updateChannelDto.getTierMin());
-                    } else {
-                        channel.updateChannelTierRule(false);
-                    }
-                });
-
-        Optional.ofNullable(updateChannelDto.getPlayCount())
-                .ifPresent(playCount -> {
-                    if (playCount) {
-                        validatePlayCount(updateChannelDto.getPlayCountMin());
-                        channel.updateChannelPlayCountRule(true, updateChannelDto.getPlayCountMin());
-                    } else {
-                        channel.updateChannelPlayCountRule(false);
-                    }
-                });
     }
 
     public Channel validateChannel(String channelLink) {


### PR DESCRIPTION
## 🙆‍♂️ Issue

#117 

## 📝 Description

채널 업데이트할 때 채널 룰 부분과 채널 부분을 나누었어요. 하는김에 채널 룰도 추후에 커스텀 룰이 추가되고 로직이 커질 것에 대비해 조금 분리해놓았어요.

## ✨ Feature

채널 관련 엔티티 업데이트, 채널 룰 관련 엔티티 업데이트

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.
This is closes #117 