### PR TITLE
Feat#127 사용자 프로필과 마이페이지 API를 분리

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController  {
     @GetMapping("/profile")
     public ProfileDto getProfile() {
         UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
-        return memberService.getProfile(userDetails.getUsername());
+        return memberService.getProfile();
     }
 
     @Operation(summary = "사용자 마이페이지 조회", description = "사용자의 이미지 URL, 닉네임, 이메일, 이메일 인증 상태를 조회")
@@ -50,8 +50,7 @@ public class MemberController  {
     })
     @GetMapping("/mypage")
     public MypageResponseDto getMypage() {
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
-        return memberService.getMypageProfile(userDetails.getUsername());
+        return memberService.getMypageProfile();
     }
 
     @Operation(summary = "앱 로그아웃", description = "앱에서 사용자를 로그아웃")
@@ -62,9 +61,8 @@ public class MemberController  {
     })
     @PostMapping("/app/logout")
     public ResponseEntity<String> handleKakaoLogout(HttpServletRequest request, HttpServletResponse response) {
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
 
-        memberService.logoutMember(userDetails.getUsername(), userDetails, request, response);
+        memberService.logoutMember( request, response);
 
         return ResponseEntity.ok("Logout Success!");
     }

--- a/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
@@ -10,7 +10,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
+import leaguehub.leaguehubbackend.dto.member.MypageResponseDto;
+import leaguehub.leaguehubbackend.dto.member.ProfileDto;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import leaguehub.leaguehubbackend.util.SecurityUtils;
@@ -29,18 +30,28 @@ public class MemberController  {
 
     private final MemberService memberService;
 
-    @Operation(summary = "사용자 프로필 조회", description = "사용자 id, 이름, 이미지 url 조회")
+    @Operation(summary = "사용자 프로필 조회", description = "사용자의 이미지 URL과 닉네임을 조회")
     @Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "Bearer {Access-Token}", required = true)
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용자 프로필 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProfileResponseDto.class))),
+            @ApiResponse(responseCode = "200", description = "사용자 프로필 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProfileDto.class))),
             @ApiResponse(responseCode = "404", description = "MB-C-001 존재하지 않는 회원입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
     })
     @GetMapping("/profile")
-    public ProfileResponseDto getProfile() {
-
+    public ProfileDto getProfile() {
         UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+        return memberService.getProfile(userDetails.getUsername());
+    }
 
-        return memberService.getMemberProfile(userDetails.getUsername());
+    @Operation(summary = "사용자 마이페이지 조회", description = "사용자의 이미지 URL, 닉네임, 이메일, 이메일 인증 상태를 조회")
+    @Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "Bearer {Access-Token}", required = true)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 마이페이지 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MypageResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "MB-C-001 존재하지 않는 회원입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))),
+    })
+    @GetMapping("/mypage")
+    public MypageResponseDto getMypage() {
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+        return memberService.getMypageProfile(userDetails.getUsername());
     }
 
     @Operation(summary = "앱 로그아웃", description = "앱에서 사용자를 로그아웃")

--- a/src/main/java/leaguehub/leaguehubbackend/dto/member/MypageResponseDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/member/MypageResponseDto.java
@@ -1,0 +1,17 @@
+package leaguehub.leaguehubbackend.dto.member;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MypageResponseDto {
+
+    private String profileImageUrl;
+
+    private String nickName;
+
+    private String email;
+
+    private boolean userEmailVerified;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/member/ProfileDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/member/ProfileDto.java
@@ -1,0 +1,13 @@
+package leaguehub.leaguehubbackend.dto.member;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ProfileDto {
+
+    private String profileImageUrl;
+
+    private String nickName;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -56,29 +56,22 @@ public class MemberService {
     }
 
     public void logoutMember(HttpServletRequest request, HttpServletResponse response) {
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
 
-        Member member = memberRepository.findMemberByPersonalId(userDetails.getUsername())
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = findCurrentMember();
 
-        if (member.getPersonalId().equals(userDetails.getUsername())) {
-            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-            if (auth != null){
-                new SecurityContextLogoutHandler().logout(request, response, auth);
-                member.updateRefreshToken(null);
-                SecurityContextHolder.clearContext();
-                memberRepository.save(member);
-            }
-        } else {
-            throw new MemberNotFoundException();
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth != null){
+            new SecurityContextLogoutHandler().logout(request, response, auth);
+            member.updateRefreshToken(null);
+            SecurityContextHolder.clearContext();
+            memberRepository.save(member);
         }
     }
 
     public ProfileDto getProfile() {
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
 
-        Member member = memberRepository.findMemberByPersonalId(userDetails.getUsername())
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = findCurrentMember();
 
         return ProfileDto.builder()
                 .profileImageUrl(member.getProfileImageUrl())
@@ -87,10 +80,8 @@ public class MemberService {
     }
 
     public MypageResponseDto getMypageProfile() {
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
 
-        Member member = memberRepository.findMemberByPersonalId(userDetails.getUsername())
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = findCurrentMember();
 
         return MypageResponseDto.builder()
                 .profileImageUrl(member.getProfileImageUrl())
@@ -99,5 +90,11 @@ public class MemberService {
                 .userEmailVerified(member.isEmailUserVerified())
                 .build();
     }
+    public Member findCurrentMember() {
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+
+        return validateMember(userDetails.getUsername());
+    }
+
 }
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -4,13 +4,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
-import leaguehub.leaguehubbackend.dto.member.ProfileResponseDto;
+import leaguehub.leaguehubbackend.dto.member.MypageResponseDto;
+import leaguehub.leaguehubbackend.dto.member.ProfileDto;
 import leaguehub.leaguehubbackend.entity.member.Member;
-
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
-
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Service;
@@ -47,19 +47,6 @@ public class MemberService {
         return member;
     }
 
-    public ProfileResponseDto getMemberProfile(String personalId) {
-        Member member = memberRepository.findMemberByPersonalId(personalId)
-                .orElseThrow(MemberNotFoundException::new);
-
-        return ProfileResponseDto.builder()
-                .profileId(member.getPersonalId())
-                .profileImageUrl(member.getProfileImageUrl())
-                .nickName(member.getNickname())
-                .email(getVerifiedEmail(member))
-                .userEmailVerified(member.isEmailUserVerified())
-                .build();
-    }
-
     public String getVerifiedEmail(Member member) {
         if (member.getEmailAuth() != null && member.isEmailUserVerified()) {
             return member.getEmailAuth().getEmail();
@@ -84,6 +71,27 @@ public class MemberService {
         }
     }
 
+    public ProfileDto getProfile(String personalId) {
+        Member member = memberRepository.findMemberByPersonalId(personalId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        return ProfileDto.builder()
+                .profileImageUrl(member.getProfileImageUrl())
+                .nickName(member.getNickname())
+                .build();
+    }
+
+    public MypageResponseDto getMypageProfile(String personalId) {
+        Member member = memberRepository.findMemberByPersonalId(personalId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        return MypageResponseDto.builder()
+                .profileImageUrl(member.getProfileImageUrl())
+                .nickName(member.getNickname())
+                .email(getVerifiedEmail(member))
+                .userEmailVerified(member.isEmailUserVerified())
+                .build();
+    }
 
 }
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -9,6 +9,7 @@ import leaguehub.leaguehubbackend.dto.member.ProfileDto;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
+import leaguehub.leaguehubbackend.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.security.core.userdetails.UserDetails;
@@ -54,8 +55,10 @@ public class MemberService {
         return "N/A";
     }
 
-    public void logoutMember(String personalId, UserDetails userDetails, HttpServletRequest request, HttpServletResponse response) {
-        Member member = memberRepository.findMemberByPersonalId(personalId)
+    public void logoutMember(HttpServletRequest request, HttpServletResponse response) {
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+
+        Member member = memberRepository.findMemberByPersonalId(userDetails.getUsername())
                 .orElseThrow(MemberNotFoundException::new);
 
         if (member.getPersonalId().equals(userDetails.getUsername())) {
@@ -71,8 +74,10 @@ public class MemberService {
         }
     }
 
-    public ProfileDto getProfile(String personalId) {
-        Member member = memberRepository.findMemberByPersonalId(personalId)
+    public ProfileDto getProfile() {
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+
+        Member member = memberRepository.findMemberByPersonalId(userDetails.getUsername())
                 .orElseThrow(MemberNotFoundException::new);
 
         return ProfileDto.builder()
@@ -81,8 +86,10 @@ public class MemberService {
                 .build();
     }
 
-    public MypageResponseDto getMypageProfile(String personalId) {
-        Member member = memberRepository.findMemberByPersonalId(personalId)
+    public MypageResponseDto getMypageProfile() {
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+
+        Member member = memberRepository.findMemberByPersonalId(userDetails.getUsername())
                 .orElseThrow(MemberNotFoundException::new);
 
         return MypageResponseDto.builder()
@@ -92,6 +99,5 @@ public class MemberService {
                 .userEmailVerified(member.isEmailUserVerified())
                 .build();
     }
-
 }
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#127 

## 📝 Description

사용자 프로필과 마이페이지 API를 분리하였습니다

## ✨ Feature

1. /profile 엔드포인트 추가 사용자의 프로필 이미지 URL과 닉네임 조회
2. /mypage 엔드포인트 추가 사용자의 프로필 이미지 URL, 닉네임, 이메일, 이메일 인증 상태 조회

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.