### PR TITLE
Test#131: #128, 이메일 인증관련 테스트코드 작성

### DIFF
--- a/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
@@ -559,5 +559,50 @@ class ParticipantControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("채널 참여 - 성공")
+    void participantChannelSuccess() throws Exception {
+        //given
+        memberRepository.save(UserFixture.createCustomeMember("참가할사람"));
+        UserFixture.setUpCustomAuth("참가할사람");
+        Channel channel = createCustomChannel(true, true, "master 100", null, 20);
+
+        mockMvc.perform(post("/api/participant/" + channel.getChannelLink()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("채널 중복 참여 - 실패")
+    void participantChannelDuplicateFail() throws Exception {
+        //given
+        UserFixture.setUpCustomAuth("서초임");
+        Channel channel = createCustomChannel(true, true, "master 100", null, 20);
+
+        //then
+        mockMvc.perform(post("/api/participant/" + channel.getChannelLink()))
+                .andExpect(status().isBadRequest());
+
+    }
+
+    @Test
+    @DisplayName("해당 채널의 경기 참가 테스트 (이메일 미인증) - 실패")
+    void participateUnAuthMatchFailTest() throws Exception {
+        //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
+        Member guestMember = memberRepository.save(UserFixture.createGuestMember());
+        UserFixture.setUpCustomGuest("idGuest");
+
+        Channel channel = createCustomChannel(false, false, "Silver iv", null, 100);
+
+        ParticipantResponseDto participantResponseDto = ParticipantFixture.createParticipantResponseDto(channel.getChannelLink(), "손성한");
+        String dtoToJson = mapper.writeValueAsString(participantResponseDto);
+
+        mockMvc.perform(post("/api/participant/match")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(dtoToJson))
+                .andExpect(status().isUnauthorized());
+
+
+    }
+
 
 }

--- a/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
+++ b/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
@@ -82,4 +82,18 @@ public class UserFixture {
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
+
+    public static void setUpCustomGuest(String name) {
+        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                .username(name)
+                .password("id")
+                .roles("GUEST")
+                .build();
+
+        GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetailsUser, null
+                , authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#131 

## 📝 Description

#128 의 테스트 코드를 구현하였어요
이메일 인증 기능이 추가되면서 경기에 참가할 때 이메일 인증에 대한 테스트 코드도 작성하였어요

![image](https://github.com/TheUpperPart/leaguehub-backend/assets/87762815/612a40d5-1fb7-4d3b-92bc-caf41e3e75f5)


## ✨ Feature

participantService 테스트 코드 작성
participantController 테스트 코드 작성


## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #131 