### PR TITLE
Refactor#148: 중복 메서드 삭제

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
@@ -7,9 +7,7 @@ import leaguehub.leaguehubbackend.entity.channel.ChannelBoard;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.exception.channel.exception.ChannelBoardNotFoundException;
-import leaguehub.leaguehubbackend.exception.participant.exception.InvalidParticipantAuthException;
 import leaguehub.leaguehubbackend.repository.channel.ChannelBoardRepository;
-import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,14 +24,13 @@ public class ChannelBoardService {
     private final ChannelService channelService;
     private final ChannelBoardRepository channelBoardRepository;
     private final MemberService memberService;
-    private final ParticipantRepository participantRepository;
 
     @Transactional
     public ChannelBoardLoadDto createChannelBoard(String channelLink, ChannelBoardDto request) {
 
         Member member = memberService.findCurrentMember();
         Channel channel = channelService.validateChannel(channelLink);
-        Participant participant = getParticipant(channel.getId(), member.getId());
+        Participant participant = channelService.getParticipant(channel.getId(), member.getId());
         channelService.checkRoleHost(participant.getRole());
 
         Integer maxIndexByChannel = channelBoardRepository.findMaxIndexByChannel(channel);
@@ -81,7 +78,7 @@ public class ChannelBoardService {
         Member member = memberService.findCurrentMember();
 
         Channel channel = channelService.validateChannel(channelLink);
-        Participant participant = getParticipant(channel.getId(), member.getId());
+        Participant participant = channelService.getParticipant(channel.getId(), member.getId());
         channelService.checkRoleHost(participant.getRole());
 
         ChannelBoard channelBoard = validateChannelBoard(boardId, channel.getId());
@@ -95,7 +92,7 @@ public class ChannelBoardService {
         Member member = memberService.findCurrentMember();
 
         Channel channel = channelService.validateChannel(channelLink);
-        Participant participant = getParticipant(channel.getId(), member.getId());
+        Participant participant = channelService.getParticipant(channel.getId(), member.getId());
 
         channelService.checkRoleHost(participant.getRole());
 
@@ -114,7 +111,7 @@ public class ChannelBoardService {
         Member member = memberService.findCurrentMember();
 
         Channel channel = channelService.validateChannel(channelLink);
-        Participant participant = getParticipant(channel.getId(), member.getId());
+        Participant participant = channelService.getParticipant(channel.getId(), member.getId());
 
         channelService.checkRoleHost(participant.getRole());
 
@@ -126,12 +123,6 @@ public class ChannelBoardService {
                     .findFirst()
                     .ifPresent(channelBoard -> channelBoard.updateIndex(channelBoardLoadDto.getBoardIndex()));
         });
-    }
-
-    private Participant getParticipant(Long channelId, Long memberId) {
-        Participant participant = participantRepository.findParticipantByMemberIdAndChannel_Id(memberId, channelId)
-                .orElseThrow(() -> new InvalidParticipantAuthException());
-        return participant;
     }
 
     public ChannelBoard validateChannelBoard(Long channelBoardId, Long channelId) {


### PR DESCRIPTION
## 🙆‍♂️ Issue

#148 

## 📝 Description

getPartcipant를 channelService에 있는 것을 쓰게 하고 중복 코드를 추출했어요. 나머지 validateTier 같은 Dto 검증 메서드도 추출하려고 했는데 channelService에서 생성 메서드가 사용해서 순환 참조 문제때문에 하지 못했어요. 채널 룰 값 검증이라 채널 룰에 있는게 좋다고 생각하고, 채널에 있는 메서드를 public으로 여는 건 적절하지 않은 것 같아 그냥 두 서비스 모두에 private로 사용하도록 했어요.

## ✨ Feature

중복 코드 상위 서비스에 있는 메서드를 사용

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #148 