### PR TITLE
Feat#150: 채널 관련 email 인증및 Enum 리팩터링

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/Category.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/Category.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 public enum Category {
     TFT(0);
 
-    private int num;
+    private final int num;
 
     Category(int num) {
         this.num = num;

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/MatchFormat.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/MatchFormat.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 public enum MatchFormat {
     SINGLE_ELIMINATION(1), FREE_FOR_ALL(0);
 
-    private int num;
+    private final int num;
 
     MatchFormat(int num) {
         this.num = num;

--- a/src/main/java/leaguehub/leaguehubbackend/entity/constant/GlobalConstant.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/constant/GlobalConstant.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public enum GlobalConstant {
     NO_DATA("NO_DATA");
 
-    private String data;
+    private final String data;
 
     GlobalConstant(String data) {
         this.data = data;

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/BaseRole.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/BaseRole.java
@@ -11,4 +11,7 @@ public enum BaseRole {
     GUEST("ROLE_GUEST");
     private final String key;
 
+    public String convertBaseRole() {
+        return "[" + this.key + "]";
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/GameTier.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/GameTier.java
@@ -13,7 +13,7 @@ public enum GameTier {
     IV(0), III(100), II(200), I(300);
 
 
-    private int score;
+    private final int score;
 
     GameTier(int score){
         this.score = score;

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
@@ -58,7 +58,7 @@ public class Participant extends BaseTimeEntity {
         participant.channel = channel;
 
 
-        participant.requestStatus = RequestStatus.NOREQUEST;
+        participant.requestStatus = RequestStatus.NO_REQUEST;
 
         participant.gameId = GlobalConstant.NO_DATA.getData();
         participant.gameTier = GlobalConstant.NO_DATA.getData();
@@ -74,7 +74,7 @@ public class Participant extends BaseTimeEntity {
         participant.member = member;
         participant.channel = channel;
 
-        participant.requestStatus = RequestStatus.NOREQUEST;
+        participant.requestStatus = RequestStatus.NO_REQUEST;
 
         participant.gameId = GlobalConstant.NO_DATA.getData();
         participant.gameTier = GlobalConstant.NO_DATA.getData();
@@ -110,7 +110,7 @@ public class Participant extends BaseTimeEntity {
     }
 
     public Participant updateHostRole() {
-        this.requestStatus = RequestStatus.NOREQUEST;
+        this.requestStatus = RequestStatus.NO_REQUEST;
         this.role = Role.HOST;
 
         return this;

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/RequestStatus.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/RequestStatus.java
@@ -2,9 +2,9 @@ package leaguehub.leaguehubbackend.entity.participant;
 
 public enum RequestStatus {
 
-    NOREQUEST(0), REQUEST(1), DONE(2), REJECT(3);
+    NO_REQUEST(0), REQUEST(1), DONE(2), REJECT(3);
 
-    private int num;
+    private final int num;
 
     RequestStatus(int num) {
         this.num = num;

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/Role.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/Role.java
@@ -3,7 +3,7 @@ package leaguehub.leaguehubbackend.entity.participant;
 public enum Role {
     HOST(0), MANAGER(1), PLAYER(2), OBSERVER(3);
 
-    private int num;
+    private final int num;
 
     Role(int num) {
         this.num = num;

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -3,23 +3,29 @@ package leaguehub.leaguehubbackend.service.channel;
 import leaguehub.leaguehubbackend.dto.channel.*;
 import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.entity.channel.ChannelBoard;
+import leaguehub.leaguehubbackend.entity.member.BaseRole;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.entity.participant.Role;
 import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundException;
 import leaguehub.leaguehubbackend.exception.channel.exception.ChannelRequestException;
+import leaguehub.leaguehubbackend.exception.email.exception.UnauthorizedEmailException;
 import leaguehub.leaguehubbackend.exception.participant.exception.InvalidParticipantAuthException;
 import leaguehub.leaguehubbackend.repository.channel.ChannelBoardRepository;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
 import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
 import leaguehub.leaguehubbackend.service.member.MemberService;
+import leaguehub.leaguehubbackend.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static leaguehub.leaguehubbackend.entity.member.BaseRole.*;
 
 
 @Service
@@ -58,7 +64,10 @@ public class ChannelService {
 
     @Transactional
     public List<ParticipantChannelDto> findParticipantChannelList() {
+
         Member member = memberService.findCurrentMember();
+
+        checkEmail(SecurityUtils.getAuthenticatedUser());
 
         List<Participant> allByParticipantList = participantRepository.findAllByMemberId(member.getId());
 
@@ -144,6 +153,11 @@ public class ChannelService {
         if (createChannelDto.getPlayCount()) {
             validatePlayCount(createChannelDto.getPlayCountMin());
         }
+    }
+
+    private void checkEmail(UserDetails userDetails) {
+        if (!userDetails.getAuthorities().toString().equals(USER.convertBaseRole()))
+            throw new UnauthorizedEmailException();
     }
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static leaguehub.leaguehubbackend.entity.member.BaseRole.*;
 import static leaguehub.leaguehubbackend.entity.participant.RequestStatus.*;
 import static leaguehub.leaguehubbackend.entity.participant.Role.*;
 
@@ -126,7 +127,7 @@ public class ParticipantService {
 
         checkRoleHost(channelLink);
 
-        List<Participant> findParticipants = participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, OBSERVER, NOREQUEST);
+        List<Participant> findParticipants = participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, OBSERVER, NO_REQUEST);
 
         return findParticipants.stream()
                 .map(participant -> mapToResponseStatusPlayerDto(participant))
@@ -342,7 +343,7 @@ public class ParticipantService {
      * @param userDetails
      */
     public void checkEmail(UserDetails userDetails) {
-        if (!userDetails.getAuthorities().toString().equals("[ROLE_USER]"))
+        if (!userDetails.getAuthorities().toString().equals(USER.convertBaseRole()))
             throw new UnauthorizedEmailException();
     }
 

--- a/src/test/java/leaguehub/leaguehubbackend/entity/participant/ParticipantTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/participant/ParticipantTest.java
@@ -56,7 +56,7 @@ class ParticipantTest {
         assertThat(participant.getMember()).isEqualTo(member);
         assertThat(participant.getRole()).isEqualTo(Role.HOST);
 
-        assertThat(participant.getRequestStatus()).isEqualTo(RequestStatus.NOREQUEST);
+        assertThat(participant.getRequestStatus()).isEqualTo(RequestStatus.NO_REQUEST);
         assertThat(participant.getGameId()).isEqualTo(GlobalConstant.NO_DATA.getData());
     }
 

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -571,13 +571,13 @@ class ParticipantServiceTest {
         assertThat(dummy1.getNickname()).isEqualTo(DtoList.get(0).getNickname());
         assertThat(dummy1.getGameId()).isEqualTo(DtoList.get(0).getGameId());
         assertThat(dummy1.getGameTier()).isEqualTo(DtoList.get(0).getTier());
-        assertThat(dummy1.getRequestStatus()).isEqualTo(RequestStatus.NOREQUEST);
+        assertThat(dummy1.getRequestStatus()).isEqualTo(RequestStatus.NO_REQUEST);
 
         assertThat(dummy2.getId()).isEqualTo(DtoList.get(1).getPk());
         assertThat(dummy2.getNickname()).isEqualTo(DtoList.get(1).getNickname());
         assertThat(dummy2.getGameId()).isEqualTo(DtoList.get(1).getGameId());
         assertThat(dummy2.getGameTier()).isEqualTo(DtoList.get(1).getTier());
-        assertThat(dummy2.getRequestStatus()).isEqualTo(RequestStatus.NOREQUEST);
+        assertThat(dummy2.getRequestStatus()).isEqualTo(RequestStatus.NO_REQUEST);
 
     }
 
@@ -622,11 +622,11 @@ class ParticipantServiceTest {
         //then
         assertThat(updateDummy1.getId()).isEqualTo(dummy1.getId());
         assertThat(updateDummy1.getRole().getNum()).isEqualTo(Role.HOST.getNum());
-        assertThat(updateDummy1.getRequestStatus().getNum()).isEqualTo(RequestStatus.NOREQUEST.getNum());
+        assertThat(updateDummy1.getRequestStatus().getNum()).isEqualTo(RequestStatus.NO_REQUEST.getNum());
 
         assertThat(updateDummy2.getId()).isEqualTo(dummy2.getId());
         assertThat(updateDummy2.getRole().getNum()).isEqualTo(Role.HOST.getNum());
-        assertThat(updateDummy2.getRequestStatus().getNum()).isEqualTo(RequestStatus.NOREQUEST.getNum());
+        assertThat(updateDummy2.getRequestStatus().getNum()).isEqualTo(RequestStatus.NO_REQUEST.getNum());
 
     }
 
@@ -680,7 +680,7 @@ class ParticipantServiceTest {
         //then
 
         assertThat(participant.getChannel().getChannelLink()).isEqualTo(channel.getChannelLink());
-        assertThat(participant.getRequestStatus()).isEqualTo(RequestStatus.NOREQUEST);
+        assertThat(participant.getRequestStatus()).isEqualTo(RequestStatus.NO_REQUEST);
         assertThat(participant.getRole()).isEqualTo(Role.OBSERVER);
     }
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#150 

## 📝 Description

Enum에 필드 요소들을 final을 붙여주고 [ROLE_USER] 라고 직접 스트링으로 비교하던 것을 BaseRole에서 convertBaseRole이라는 메서드를 통해 양쪽 괄호를 붙여주도록 했어요. 그리고 채널 생성시 메일 인증 체크를 했어요.

## ✨ Feature

Enum 필드 상수화, 스트링 변환 메서드, 채널 생성시 메일 인증 체크, 코드 변경에 따른 리팩터링

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #150 