### PR TITLE
Fix#138 : JwtFilter 토큰과 관련 없는 에러 수정

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/JwtAuthenticationEntryPoint.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import static leaguehub.leaguehubbackend.exception.auth.AuthExceptionCode.AUTH_MEMBER_NOT_FOUND;
+import static leaguehub.leaguehubbackend.exception.auth.AuthExceptionCode.*;
 
 
 @Component
@@ -22,16 +22,22 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         String exception = (String) request.getAttribute("exception");
-        AuthExceptionCode errorCode;
 
-
+        /**
+         * 잘못된 요청
+         */
+        if (exception == null) {
+            log.info("잘못된 요청");
+            setResponse(response, BAD_REQUEST_EXCEPTION);
+            return;
+        }
 
         /**
          * 토큰 없는 경우
          */
-        if (exception == null) {
-            errorCode = AuthExceptionCode.REQUEST_TOKEN_NOT_FOUND;
-            setResponse(response, errorCode);
+        if (exception.equals(REQUEST_TOKEN_NOT_FOUND.getCode())) {
+            log.info("AccessToken이 없음");
+            setResponse(response, REQUEST_TOKEN_NOT_FOUND);
             return;
         }
 
@@ -39,25 +45,23 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
          *  해당 멤버가 데이터베이스에 없을 경우
          */
         if (exception.equals(AUTH_MEMBER_NOT_FOUND.getCode())) {
-            errorCode = AUTH_MEMBER_NOT_FOUND;
-            setResponse(response, errorCode);
+            setResponse(response, AUTH_MEMBER_NOT_FOUND);
             return;
         }
 
         /**
          * 토큰 만료된 경우
          */
-        if (exception.equals(AuthExceptionCode.EXPIRED_TOKEN.getCode())) {
-            errorCode = AuthExceptionCode.EXPIRED_TOKEN;
-            setResponse(response, errorCode);
+        if (exception.equals(EXPIRED_TOKEN.getCode())) {
+            setResponse(response, EXPIRED_TOKEN);
             return;
         }
+
         /**
          * 유효하지 않은 토큰일 경우
          */
-        if (exception.equals(AuthExceptionCode.INVALID_TOKEN.getCode())) {
-            errorCode = AuthExceptionCode.INVALID_TOKEN;
-            setResponse(response, errorCode);
+        if (exception.equals(INVALID_TOKEN.getCode())) {
+            setResponse(response, INVALID_TOKEN);
         }
 
     }

--- a/src/main/java/leaguehub/leaguehubbackend/config/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/JwtAuthenticationProcessingFilter.java
@@ -67,6 +67,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
                                                   FilterChain filterChain) throws ServletException, IOException {
+
         Optional<String> optionalToken = jwtService.extractAccessToken(request);
 
         if (optionalToken.isEmpty()) {

--- a/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/auth/AuthExceptionCode.java
@@ -15,7 +15,6 @@ public enum AuthExceptionCode implements ExceptionCode {
      * JWT
      * 001 ~ 099
      */
-
     INVALID_TOKEN(UNAUTHORIZED, "AT-C-001", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(UNAUTHORIZED, "AT-C-002", "만료된 토큰입니다."),
     NOT_EXPIRED_TOKEN(BAD_REQUEST, "AT-C-003", "만료되지 않은 토큰입니다."),
@@ -35,14 +34,17 @@ public enum AuthExceptionCode implements ExceptionCode {
     INVALID_REDIRECT_URI(UNAUTHORIZED, "AT-C-104", "허용되지 않은 리다이렉션 URI 입니다."),
     AUTH_MEMBER_NOT_FOUND(NOT_FOUND, "AT-C-105", "존재하지 않는 회원입니다."),
 
-
     /**
      * Common Exception
      * 200 ~
      */
     AUTHENTICATION_ERROR(UNAUTHORIZED, "AT-C-200", "Authentication exception."),
-    INTERNAL_AUTHENTICATION_SERVICE_EXCEPTION(INTERNAL_SERVER_ERROR, "AT-S-200", "Internal authentication service exception.");
 
+    /**
+     *  Exception
+     * 400 ~
+     */
+    BAD_REQUEST_EXCEPTION(BAD_REQUEST, "AT-S-400", "Bad Request");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/leaguehub/leaguehubbackend/util/UserUtil.java
+++ b/src/main/java/leaguehub/leaguehubbackend/util/UserUtil.java
@@ -67,7 +67,7 @@ public class UserUtil {
             String accessToken = jwtService.createAccessToken(member.getPersonalId());
             System.out.println("--------------------------");
             System.out.printf("해당 멤버 : '%s':%n", member.getNickname());
-            System.out.printf("Access Token : %s%n", accessToken);
+            System.out.printf("Access Token : Bearer %s%n", accessToken);
             System.out.println("--------------------------");
             System.out.println();
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#138 

## 📝 Description

토큰과 관련없는 에러일시 401에러를 출력하는 대신 400 BadRequest를 반환합니다.

## ✨ Feature

1. 토큰과 관련안된 에러일시 400 BadRequest 반환

## 👌 Review Change
리뷰를 통해 수정한 부분을 나열해주세요.

This closes #138 