### PR TITLE
Fix: 이메일 체크하는 메서드 위치 이동

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -42,6 +42,8 @@ public class ChannelService {
 
         Member member = memberService.findCurrentMember();
 
+        checkEmail(SecurityUtils.getAuthenticatedUser());
+
         validateChannelRule(createChannelDto);
 
         Channel channel = Channel.createChannel(createChannelDto.getTitle(),
@@ -67,7 +69,6 @@ public class ChannelService {
 
         Member member = memberService.findCurrentMember();
 
-        checkEmail(SecurityUtils.getAuthenticatedUser());
 
         List<Participant> allByParticipantList = participantRepository
                 .findAllByMemberIdOrderByIndex(member.getId());


### PR DESCRIPTION
## 🙆‍♂️ Issue

#163 

## 📝 Description

이메일인증 체크관련 메서드가 잘못된 위치(채널 조회)에 있어 삭제했어요
삭제한 이메일 인증 체크는 필요한곳(채널 생성)에 다시 넣어 수정하였어요

## ✨ Feature

채널 조회시 이메일 체크하는 메서드 삭제
채널 생성시 이메일 체크하는 메서드 추가

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #163 