### PR TITLE
Test: Dto 값 변경에 따른 참가자 관련 테스트 코드 변경

### DIFF
--- a/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
@@ -352,7 +352,7 @@ class ParticipantControllerTest {
         UserFixture.setUpCustomAuth("참가된사람1");
 
         mockMvc.perform(get("/api/profile/request?channelLink=" + channel.getChannelLink()))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
 
     }
 
@@ -396,7 +396,7 @@ class ParticipantControllerTest {
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
 
         mockMvc.perform(post("/api/player/approve/" + channel.getChannelLink() + "/" + dummy1.getId()))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
 
     }
 
@@ -424,7 +424,7 @@ class ParticipantControllerTest {
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
 
         mockMvc.perform(post("/api/player/reject/" + channel.getChannelLink() + "/" + dummy1.getId()))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
 
     }
 
@@ -444,7 +444,7 @@ class ParticipantControllerTest {
     }
 
     @Test
-    @DisplayName("참가한사람 거절 테스트 (관리자 o) - 실패")
+    @DisplayName("참가한사람 거절 테스트 (관리자 x) - 실패")
     public void rejectedPlayerFailTest() throws Exception {
         //given
         Channel channel = createCustomChannel(false, false, "master 100", null, 20);
@@ -454,7 +454,7 @@ class ParticipantControllerTest {
         dummy1.approveParticipantMatch();
 
         mockMvc.perform(post("/api/player/reject/" + channel.getChannelLink() + "/" + dummy1.getId()))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
 
     }
 
@@ -482,7 +482,7 @@ class ParticipantControllerTest {
         Participant dummy1 = getParticipant("DummyName", channel, "DummyGameId", "DummyNickname");
 
         mockMvc.perform(post("/api/player/host/" + channel.getChannelLink() + "/" + dummy1.getId()))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
 
     }
 
@@ -510,7 +510,7 @@ class ParticipantControllerTest {
         UserFixture.setUpCustomAuth("참가된사람1");
 
         mockMvc.perform(get("/api/profile/observer?channelLink=" + channel.getChannelLink()))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/test/java/leaguehub/leaguehubbackend/fixture/ParticipantFixture.java
+++ b/src/test/java/leaguehub/leaguehubbackend/fixture/ParticipantFixture.java
@@ -8,6 +8,7 @@ public class ParticipantFixture {
         ParticipantDto participantResponseDto = new ParticipantDto();
         participantResponseDto.setChannelLink(channelLink);
         participantResponseDto.setGameId(nickname);
+        participantResponseDto.setNickname(nickname);
 
         return participantResponseDto;
     }

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -412,7 +412,7 @@ class ParticipantServiceTest {
 
         //when
         assertThatThrownBy(() -> participantService.loadRequestStatusPlayerList(channel.getChannelLink()))
-                .isInstanceOf(ParticipantNotGameHostException.class);
+                .isInstanceOf(InvalidParticipantAuthException.class);
 
     }
 
@@ -477,7 +477,7 @@ class ParticipantServiceTest {
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
         assertThatThrownBy(() -> participantService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId()))
-                .isInstanceOf(ParticipantNotGameHostException.class);
+                .isInstanceOf(InvalidParticipantAuthException.class);
 
     }
 
@@ -511,7 +511,7 @@ class ParticipantServiceTest {
 
 
         assertThatThrownBy(() -> participantService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId()))
-                .isInstanceOf(ParticipantNotGameHostException.class);
+                .isInstanceOf(InvalidParticipantAuthException.class);
 
 
     }
@@ -546,7 +546,7 @@ class ParticipantServiceTest {
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
         assertThatThrownBy(() -> participantService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId()))
-                .isInstanceOf(ParticipantNotGameHostException.class);
+                .isInstanceOf(InvalidParticipantAuthException.class);
 
     }
 
@@ -595,7 +595,7 @@ class ParticipantServiceTest {
 
         //when
         assertThatThrownBy(() -> participantService.loadObserverPlayerList(channel.getChannelLink()))
-                .isInstanceOf(ParticipantNotGameHostException.class);
+                .isInstanceOf(InvalidParticipantAuthException.class);
 
     }
 
@@ -639,7 +639,7 @@ class ParticipantServiceTest {
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
         assertThatThrownBy(() -> participantService.updateHostRole(channel.getChannelLink(), dummy1.getId()))
-                .isInstanceOf(ParticipantNotGameHostException.class);
+                .isInstanceOf(InvalidParticipantAuthException.class);
 
     }
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#170 

## 📝 Description

Dto에 Valid 어노테이션을 추가함에 따라 Null값을 넣은 테스트 코드에 추가적으로 데이터를 넣었으며
이메일을 체크하는 메서드의 예외처리 클래스가 수정함에 따라 테스트코드에 사용되는 예외처리 클래스도 수정했어요

추가적으로
이메일, jwt토큰 관련 테스트 코드도 수정해야할것 같아요

![image](https://github.com/TheUpperPart/leaguehub-backend/assets/87762815/a1349b2c-0fee-40ba-88a8-edf486075ffb)


## ✨ Feature

#157 #147 수정에 따른 테스트 코드 변경

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #170 