### PR TITLE
Feat#158 : 닉네임 수정 기능 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/MemberController.java
@@ -8,17 +8,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import leaguehub.leaguehubbackend.dto.member.MypageResponseDto;
+import leaguehub.leaguehubbackend.dto.member.NicknameRequestDto;
 import leaguehub.leaguehubbackend.dto.member.ProfileDto;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -60,6 +59,18 @@ public class MemberController {
         memberService.logoutMember(request, response);
 
         return ResponseEntity.ok("Logout Success!");
+    }
+
+
+    @Operation(summary = "사용자 닉네임 변경", description = "사용자 닉네임 변경")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 변경 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProfileDto.class))),
+            @ApiResponse(responseCode = "404", description = "MB-C-001 PA-C-015 멤버 또는 참가자를 찾을 수 없음", content = @Content(mediaType = "application/json")),
+    })
+    @PostMapping("/change/nickname")
+    public ProfileDto changeNickName(@RequestBody @Valid NicknameRequestDto nicknameRequestDto) {
+
+        return memberService.changeMemberParticipantNickname(nicknameRequestDto);
     }
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/member/NicknameRequestDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/member/NicknameRequestDto.java
@@ -1,0 +1,14 @@
+package leaguehub.leaguehubbackend.dto.member;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class NicknameRequestDto {
+
+    @NotBlank
+    @Size(max = 20, message = "닉네임은 20자 이하여야 합니다")
+    private String nickName;
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -5,6 +5,7 @@ import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.entity.BaseTimeEntity;
 import leaguehub.leaguehubbackend.entity.email.EmailAuth;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 
 
 @Getter
@@ -12,6 +13,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @Entity
+@DynamicUpdate
 public class Member extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -21,6 +21,7 @@ public class Member extends BaseTimeEntity {
 
     private String personalId;
 
+    @Column(length = 20)
     private String nickname;
 
     private String profileImageUrl;
@@ -64,4 +65,5 @@ public class Member extends BaseTimeEntity {
     public void unverifyEmail() {
         this.emailUserVerified = false;
     }
+    public void updateNickname(String newNickname) { this.nickname = newNickname; }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
@@ -123,4 +123,6 @@ public class Participant extends BaseTimeEntity {
     public void updateCustomChannelIndex(Integer index) {
         this.index = index;
     }
+
+    public void updateNickname(String newNickname) { this.nickname = newNickname; }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
@@ -32,4 +32,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     Optional<Integer> findMaxIndexByParticipant(@Param("memberId") Long memberId);
 
     List<Participant> findAllByMemberIdAndAndIndexGreaterThan(Long memberId, int deleteIndex);
+
+    Optional<Participant> findByNickname(String nickname);
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
@@ -33,6 +33,4 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     List<Participant> findAllByMemberIdAndAndIndexGreaterThan(Long memberId, int deleteIndex);
 
-    Optional<Participant> findByNickname(String nickname);
-
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -21,6 +21,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -106,14 +107,15 @@ public class MemberService {
     public ProfileDto changeMemberParticipantNickname(NicknameRequestDto nicknameRequestDto) {
 
         Member member = findCurrentMember();
+
         member.updateNickname(nicknameRequestDto.getNickName());
-        memberRepository.save(member);
 
-        Participant participant = participantRepository.findByNickname(member.getNickname())
-                .orElseThrow(ParticipantNotFoundException::new);
+        List<Participant> participants = participantRepository.findAllByMemberId(member.getId());
+        if (participants.isEmpty()) {
+            throw new ParticipantNotFoundException();
+        }
 
-        participant.updateNickname(nicknameRequestDto.getNickName());
-        participantRepository.save(participant);
+        participants.forEach(participant -> participant.updateNickname(member.getNickname()));
 
         return getProfile();
     }

--- a/src/test/java/leaguehub/leaguehubbackend/controller/MemberControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/MemberControllerTest.java
@@ -1,9 +1,12 @@
 package leaguehub.leaguehubbackend.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import leaguehub.leaguehubbackend.dto.member.MypageResponseDto;
+import leaguehub.leaguehubbackend.dto.member.NicknameRequestDto;
 import leaguehub.leaguehubbackend.dto.member.ProfileDto;
+import leaguehub.leaguehubbackend.exception.participant.exception.ParticipantNotFoundException;
 import leaguehub.leaguehubbackend.fixture.MypageResponseFixture;
 import leaguehub.leaguehubbackend.fixture.ProfileFixture;
 import leaguehub.leaguehubbackend.service.member.MemberService;
@@ -42,6 +45,10 @@ class MemberControllerTest {
 
     @MockBean
     private MemberService memberService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
 
     @BeforeEach
     void setUp() throws IOException {
@@ -110,6 +117,24 @@ class MemberControllerTest {
                 any(HttpServletResponse.class)
         );
     }
+    @Test
+    @DisplayName("닉네임 변경 요청시 프로필 정보 반환")
+    public void whenChangeNickname_thenReturnProfile() throws Exception {
 
+        NicknameRequestDto nicknameRequest = new NicknameRequestDto();
+        nicknameRequest.setNickName("NewNickname");
+
+        ProfileDto mockProfileResponse = ProfileFixture.createProfile();
+        mockProfileResponse.setNickName("NewNickname");
+
+        when(memberService.changeMemberParticipantNickname(nicknameRequest))
+                .thenReturn(mockProfileResponse);
+
+        mockMvc.perform(post("/api/change/nickname")
+                        .contentType("application/json")
+                        .content(new ObjectMapper().writeValueAsString(nicknameRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickName").value("NewNickname"));
+    }
 
 }

--- a/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
@@ -7,6 +7,7 @@ import leaguehub.leaguehubbackend.dto.member.MypageResponseDto;
 import leaguehub.leaguehubbackend.dto.member.NicknameRequestDto;
 import leaguehub.leaguehubbackend.dto.member.ProfileDto;
 import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 import leaguehub.leaguehubbackend.exception.participant.exception.ParticipantNotFoundException;
 import leaguehub.leaguehubbackend.fixture.KakaoUserDtoFixture;
@@ -30,6 +31,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -195,8 +198,9 @@ class MemberServiceTest {
         nicknameRequestDto.setNickName("newNickname");
 
         when(memberRepository.findMemberByPersonalId("id")).thenReturn(Optional.of(member));
-        when(participantRepository.findByNickname(member.getNickname())).thenReturn(Optional.empty());
+        when(participantRepository.findAllByMemberId(member.getId())).thenReturn(Collections.emptyList());
 
         assertThrows(ParticipantNotFoundException.class, () -> memberService.changeMemberParticipantNickname(nicknameRequestDto));
     }
+
 }

--- a/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/member/MemberServiceTest.java
@@ -4,12 +4,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import leaguehub.leaguehubbackend.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.dto.member.MypageResponseDto;
+import leaguehub.leaguehubbackend.dto.member.NicknameRequestDto;
 import leaguehub.leaguehubbackend.dto.member.ProfileDto;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
+import leaguehub.leaguehubbackend.exception.participant.exception.ParticipantNotFoundException;
 import leaguehub.leaguehubbackend.fixture.KakaoUserDtoFixture;
 import leaguehub.leaguehubbackend.fixture.UserFixture;
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
+import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,6 +45,8 @@ import static org.mockito.Mockito.when;
 class MemberServiceTest {
     @Mock
     private MemberRepository memberRepository;
+    @Mock
+    private ParticipantRepository participantRepository;
     @InjectMocks
     private MemberService memberService;
     private Member member;
@@ -170,4 +175,28 @@ class MemberServiceTest {
         verify(memberRepository).save(any(Member.class));
     }
 
+    @Test
+    @DisplayName("존재하지 않는 멤버의 닉네임 변경 시 예외 발생")
+    void changeMemberParticipantNickname_NotFoundMember() {
+
+        NicknameRequestDto nicknameRequestDto = new NicknameRequestDto();
+        nicknameRequestDto.setNickName("newNickname");
+
+        when(memberRepository.findMemberByPersonalId("id")).thenReturn(Optional.empty());
+
+        assertThrows(MemberNotFoundException.class, () -> memberService.changeMemberParticipantNickname(nicknameRequestDto));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 참가자의 닉네임 변경 시 예외 발생")
+    void changeMemberParticipantNickname_NotFoundParticipant() {
+
+        NicknameRequestDto nicknameRequestDto = new NicknameRequestDto();
+        nicknameRequestDto.setNickName("newNickname");
+
+        when(memberRepository.findMemberByPersonalId("id")).thenReturn(Optional.of(member));
+        when(participantRepository.findByNickname(member.getNickname())).thenReturn(Optional.empty());
+
+        assertThrows(ParticipantNotFoundException.class, () -> memberService.changeMemberParticipantNickname(nicknameRequestDto));
+    }
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#158 

## 📝 Description

Member, Participant 닉네임을 변경하는 기능을 구현했습니다.
테스트 코드 또한 구현했습니다.

## ✨ Feature

1. 닉네임의 길이가 유효하다면 Member와 Participant의 이름을 바꾼다
2. 테스트 코드 구현

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

- 멤버 ID를 활용하여 참가자를 조회하는 방식으로 로직을 수정
- jpa의 더티체킹으로 인한 불필요 코드 삭제

This closes #158 