### PR TITLE
Feat#48: 경기 참가자 랜덤 배정 처리

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/Controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/Controller/MatchController.java
@@ -10,6 +10,7 @@ import leaguehub.leaguehubbackend.dto.match.MatchRankResultDto;
 import leaguehub.leaguehubbackend.dto.match.MatchResponseDto;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.match.MatchRankService;
+import leaguehub.leaguehubbackend.service.match.MatchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,12 +18,15 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static org.springframework.http.HttpStatus.*;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class MatchController {
 
     private final MatchRankService matchRankService;
+    private final MatchService matchService;
 
     @Operation(summary = "매치 결과 조회 및 저장")
     @ApiResponses(value = {
@@ -34,7 +38,7 @@ public class MatchController {
 
         matchRankService.setMatchRank(matchResponseDto);
 
-        return new ResponseEntity<>("매치 결과가 생성되었습니다.", HttpStatus.CREATED);
+        return new ResponseEntity<>("매치 결과가 생성되었습니다.", CREATED);
     }
 
     @Operation(summary = "저장된 매치 결과 출력")
@@ -48,6 +52,14 @@ public class MatchController {
 
         List<MatchRankResultDto> resultDto = matchRankService.getMatchDetail(matchCode);
 
-        return new ResponseEntity<>(resultDto, HttpStatus.OK);
+        return new ResponseEntity<>(resultDto, OK);
+    }
+
+    @PostMapping("/match/{channelLink}")
+    public ResponseEntity matchAssignmnet(@PathVariable("channelLink") String channelLink){
+
+        matchService.matchAssignment(channelLink);
+
+        return new ResponseEntity<>("create subMatch", OK);
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -42,13 +42,14 @@ public class Match extends BaseTimeEntity {
         this.matchName = matchName;
         this.matchPasswd = matchPasswd;
     }
-    public static Match createMatch(Integer matchRound, Channel channel){
+
+    public static Match createMatch(Integer matchRound, Channel channel, String matchName){
         Match match = new Match();
         String uuid = UUID.randomUUID().toString();
         match.matchStatus = MatchStatus.READY;
         match.matchRound = matchRound;
         match.matchLink = uuid.substring(16);
-        match.matchName = GlobalConstant.NO_DATA.getData();
+        match.matchName = matchName;
         match.matchPasswd = GlobalConstant.NO_DATA.getData();
         match.channel = channel;
 

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
@@ -28,4 +28,13 @@ public class MatchPlayer extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "match_id")
     private Match match;
+
+    public static MatchPlayer createMatchPlayer(Participant participant, Match match){
+        MatchPlayer matchPlayer = new MatchPlayer();
+        matchPlayer.playerStatus = PlayerStatus.WAITING;
+        matchPlayer.participant = participant;
+        matchPlayer.match = match;
+
+        return matchPlayer;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
@@ -12,7 +13,8 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public enum MatchExceptionCode implements ExceptionCode {
 
     MATCH_NOT_FOUND(NOT_FOUND, "MA-C-001", "유효하지 않은 경기입니다."),
-    MATCH_RESULT_NOT_FOUNT(NOT_FOUND, "MA-C-002", "매치 결과를 찾을 수 없습니다.");
+    MATCH_RESULT_NOT_FOUNT(NOT_FOUND, "MA-C-002", "매치 결과를 찾을 수 없습니다."),
+    MATCH_NOT_ENOUGH_PLAYER(BAD_REQUEST, "MA-C-003", "매치 인원수가 충분하지 않습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionHandler.java
@@ -2,6 +2,7 @@ package leaguehub.leaguehubbackend.exception.match;
 
 import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.exception.match.exception.MatchNotEnoughPlayerException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchNotFoundException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchResultIdNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,19 @@ public class MatchExceptionHandler {
     @ExceptionHandler(MatchResultIdNotFoundException.class)
     public ResponseEntity<ExceptionResponse> matchResultIdNotFoundException(
             MatchResultIdNotFoundException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(MatchNotEnoughPlayerException.class)
+    public ResponseEntity<ExceptionResponse> matchNotEnoughPlayerException(
+            MatchNotEnoughPlayerException e
     ) {
         ExceptionCode exceptionCode = e.getExceptionCode();
         log.error("{}", exceptionCode.getMessage());

--- a/src/main/java/leaguehub/leaguehubbackend/exception/match/exception/MatchNotEnoughPlayerException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/match/exception/MatchNotEnoughPlayerException.java
@@ -1,0 +1,19 @@
+package leaguehub.leaguehubbackend.exception.match.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.match.MatchExceptionCode.MATCH_NOT_ENOUGH_PLAYER;
+
+public class MatchNotEnoughPlayerException extends RuntimeException{
+
+    private final ExceptionCode exceptionCode;
+
+    public MatchNotEnoughPlayerException(){
+        super(MATCH_NOT_ENOUGH_PLAYER.getMessage());
+        this.exceptionCode = MATCH_NOT_ENOUGH_PLAYER;
+    }
+
+    public ExceptionCode getExceptionCode(){
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -3,5 +3,9 @@ package leaguehub.leaguehubbackend.repository.match;
 import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> {
+
+    List<MatchPlayer> findAllByMatch_MatchLinkAndMatch_MatchName(String matchLink, String matchName);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
@@ -3,9 +3,12 @@ package leaguehub.leaguehubbackend.repository.match;
 import leaguehub.leaguehubbackend.entity.match.Match;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
 
     Optional<Match> findByMatchLink(String matchLink);
+
+    List<Match> findAllByChannel_ChannelLinkAndMatchRound(String channelLink, Integer matchRound);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -1,0 +1,81 @@
+package leaguehub.leaguehubbackend.service.match;
+
+import leaguehub.leaguehubbackend.entity.channel.Channel;
+import leaguehub.leaguehubbackend.entity.match.Match;
+import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
+import leaguehub.leaguehubbackend.entity.match.MatchStatus;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.entity.participant.Participant;
+import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundException;
+import leaguehub.leaguehubbackend.exception.match.exception.MatchNotEnoughPlayerException;
+import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchRepository;
+import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
+import leaguehub.leaguehubbackend.service.channel.ChannelService;
+import leaguehub.leaguehubbackend.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+import static leaguehub.leaguehubbackend.entity.participant.RequestStatus.DONE;
+import static leaguehub.leaguehubbackend.entity.participant.Role.PLAYER;
+
+@Service
+@RequiredArgsConstructor
+public class MatchService {
+
+    private final ChannelRepository channelRepository;
+    private final ParticipantRepository participantRepository;
+    private final MatchRepository matchRepository;
+    private final MatchPlayerRepository matchPlayerRepository;
+    private final ChannelService channelService;
+    private final MemberService memberService;
+
+    public void matchAssignment(String channelLink) {
+        Member member = memberService.findCurrentMember();
+        Channel findChannel = channelRepository.findByChannelLink(channelLink)
+                .orElseThrow(() -> new ChannelNotFoundException());
+
+        Participant participant = channelService.getParticipant(findChannel.getId(), member.getId());
+        channelService.checkRoleHost(participant.getRole());
+
+        List<Participant> playerList = participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, PLAYER, DONE);
+
+
+        if (playerList.size() < findChannel.getMaxPlayer() * 0.75) throw new MatchNotEnoughPlayerException();
+
+
+        createSubMatch(findChannel, playerList);
+    }
+
+    private void createSubMatch(Channel findChannel, List<Participant> playerList) {
+        Collections.shuffle(playerList);
+
+        int maxPlayer = findChannel.getMaxPlayer();
+        int tableCount = findChannel.getMaxPlayer() / 8;
+        int playerCount = findChannel.getRealPlayer() / tableCount;
+        int remainingPlayer = findChannel.getRealPlayer() % tableCount;
+
+        int index = 0;
+
+
+        for (int tableIndex = 1; tableIndex <= tableCount; tableIndex++) {
+            Match match = Match.createMatch(maxPlayer, findChannel, "Group " + (char)(64 + tableIndex));
+            matchRepository.save(match);
+
+            for (int playerIndex = 0; playerIndex < playerCount; playerIndex++) {
+                MatchPlayer matchPlayer = MatchPlayer.createMatchPlayer(playerList.get(index), match);
+                matchPlayerRepository.save(matchPlayer);
+                index++;
+            }
+
+            if (remainingPlayer > 0) {
+                index++;
+                remainingPlayer--;
+            }
+        }
+    }
+}

--- a/src/test/java/leaguehub/leaguehubbackend/controller/MatchControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/MatchControllerTest.java
@@ -49,7 +49,7 @@ public class MatchControllerTest {
         //given
         Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", null, 100);
         channelRepository.save(channel);
-        Match match = Match.createMatch(16, channel);
+        Match match = Match.createMatch(16, channel, "테스트매치 이름");
         matchRepository.save(match);
 
         MatchResponseDto matchResponseDto = new MatchResponseDto();
@@ -70,7 +70,7 @@ public class MatchControllerTest {
         //given
         Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", null, 100);
         channelRepository.save(channel);
-        Match match = Match.createMatch(16, channel);
+        Match match = Match.createMatch(16, channel, "테스트매치 이름");
         matchRepository.save(match);
 
         MatchResponseDto matchResponseDto = new MatchResponseDto();

--- a/src/test/java/leaguehub/leaguehubbackend/entity/match/MatchRankTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/match/MatchRankTest.java
@@ -26,7 +26,7 @@ class MatchRankTest {
     @DisplayName("순위 생성 테스트")
     void createMatchRankTest() throws Exception {
         Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", null, 100);
-        Match match = Match.createMatch(16, channel);
+        Match match = Match.createMatch(16, channel, "테스트매치 이름");
         MatchResult matchResult = MatchResult.createMatchResult("ab12345", match);
         MatchRank matchRank = MatchRank.createMatchRank("가나다", "1등", matchResult);
         MatchRank save = matchRankRepository.save(matchRank);

--- a/src/test/java/leaguehub/leaguehubbackend/entity/match/MatchResultTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/match/MatchResultTest.java
@@ -25,7 +25,7 @@ class MatchResultTest {
     void createMatchResultTest() throws Exception {
         //given
         Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", null, 100);
-        Match match = Match.createMatch(16, channel);
+        Match match = Match.createMatch(16, channel, "테스트매치 이름");
         MatchResult matchResult = MatchResult.createMatchResult("svkos12d0kr", match);
         MatchResult save = matchResultRepository.save(matchResult);
 

--- a/src/test/java/leaguehub/leaguehubbackend/service/match/MatchRankServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/match/MatchRankServiceTest.java
@@ -47,7 +47,7 @@ class MatchRankServiceTest {
         //given
         Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", null, 100);
         channelRepository.save(channel);
-        Match match = Match.createMatch(16, channel);
+        Match match = Match.createMatch(16, channel, "테스트매치 이름");
         matchRepository.save(match);
         MatchResponseDto matchResponseDto = MatchFixture.createMatchResponseDto(match.getMatchLink());
         List<MatchRankResultDto> save = matchRankService.setMatchRank(matchResponseDto);
@@ -63,7 +63,7 @@ class MatchRankServiceTest {
         //given
         Channel channel = ChannelFixture.createDummyChannel(false, false, "Silver iv", null, 100);
         channelRepository.save(channel);
-        Match match = Match.createMatch(16, channel);
+        Match match = Match.createMatch(16, channel, "테스트매치 이름");
         matchRepository.save(match);
         MatchResponseDto matchResponseDto = MatchFixture.createFailResponseDto(match.getMatchLink());
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#48 

## 📝 Description

채널에서 경기 참가자들을 랜덤으로 배정하는 로직을 만들었어요
배정 서비스에 대한 예외처리로는 관리자를 확인하고, 경기 참여자 수가 75%를 넘어야 경기를 배정할 수 있게 만들었어요

대진표 조회는 프론트엔드와 상의해서 필요한 정보만 추출해서 넘길 것같아요

경기가 끝난 후 다음 경기를 배정하는 서비스는 해당 코드를 재활용하여 만들려고해요


## ✨ Feature

경기 참가자 랜덤 배정 서비스 구현

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #48 