### PR TITLE
Refactor#190: 경기 배정 및 매치 엔티티 수정

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import leaguehub.leaguehubbackend.dto.match.MatchRankResultDto;
 import leaguehub.leaguehubbackend.dto.match.MatchResponseDto;
+import leaguehub.leaguehubbackend.dto.match.MatchRoundListDto;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.match.MatchRankService;
+import leaguehub.leaguehubbackend.service.match.MatchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +25,7 @@ import java.util.List;
 public class MatchController {
 
     private final MatchRankService matchRankService;
+    private final MatchService matchService;
 
     @Operation(summary = "매치 결과 조회 및 저장")
     @ApiResponses(value = {
@@ -49,5 +52,19 @@ public class MatchController {
         List<MatchRankResultDto> resultDto = matchRankService.getMatchDetail(matchCode);
 
         return new ResponseEntity<>(resultDto, HttpStatus.OK);
+    }
+
+    @Operation(summary = "라운드 수(몇 강) 리스트 반환")
+    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "라운드(몇 강) 리스트 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MatchRoundListDto.class))),
+            @ApiResponse(responseCode = "403", description = "매치 결과를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/match/{channelLink}")
+    public ResponseEntity loadMatchRoundList(@PathVariable("channelLink") String channelLink){
+
+        MatchRoundListDto roundList = matchService.getRoundList(channelLink);
+
+        return new ResponseEntity<>(roundList, HttpStatus.OK);
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/channel/CreateChannelDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/channel/CreateChannelDto.java
@@ -30,7 +30,7 @@ public class CreateChannelDto {
     private String title;
 
     @NotNull
-    @Min(1)
+    @Min(8)
     @JsonProperty("maxPlayer")
     @Schema(description = "매치 최대 참가자 수", example = "8, 16, 32, 64")
     private Integer maxPlayer;

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchRoundListDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchRoundListDto.java
@@ -1,0 +1,12 @@
+package leaguehub.leaguehubbackend.dto.match;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MatchRoundListDto {
+
+
+    List<Integer> roundList;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -31,6 +31,10 @@ public class Match extends BaseTimeEntity {
 
     private String matchPasswd;
 
+    private Integer roundMaxCount;
+
+    private Integer roundRealCount;
+
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "channel_id")
     private Channel channel;
@@ -51,6 +55,8 @@ public class Match extends BaseTimeEntity {
         match.matchLink = uuid.substring(16);
         match.matchName = matchName;
         match.matchPasswd = GlobalConstant.NO_DATA.getData();
+        match.roundMaxCount = 1;
+        match.roundRealCount = 0;
         match.channel = channel;
 
         return match;

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -16,6 +16,7 @@ import leaguehub.leaguehubbackend.exception.participant.exception.InvalidPartici
 import leaguehub.leaguehubbackend.repository.channel.ChannelBoardRepository;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
 import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
+import leaguehub.leaguehubbackend.service.match.MatchService;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import leaguehub.leaguehubbackend.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class ChannelService {
     private final MemberService memberService;
     private final ChannelBoardRepository channelBoardRepository;
     private final ParticipantRepository participantRepository;
+    private final MatchService matchService;
 
     @Transactional
     public ParticipantChannelDto createChannel(CreateChannelDto createChannelDto) {
@@ -63,6 +65,9 @@ public class ChannelService {
 
         participantRepository.save(participant);
         ParticipantChannelDto participantChannelDto = convertParticipantChannelDto(participant);
+
+        matchService.createSubMatches(channel, createChannelDto.getMaxPlayer());
+
         return participantChannelDto;
     }
 

--- a/src/test/java/leaguehub/leaguehubbackend/service/match/MatchServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/match/MatchServiceTest.java
@@ -1,0 +1,126 @@
+package leaguehub.leaguehubbackend.service.match;
+
+import jakarta.transaction.Transactional;
+import leaguehub.leaguehubbackend.dto.channel.CreateChannelDto;
+import leaguehub.leaguehubbackend.dto.match.MatchRoundListDto;
+import leaguehub.leaguehubbackend.entity.channel.Channel;
+import leaguehub.leaguehubbackend.entity.channel.ChannelBoard;
+import leaguehub.leaguehubbackend.entity.match.Match;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.entity.participant.Participant;
+import leaguehub.leaguehubbackend.fixture.ChannelFixture;
+import leaguehub.leaguehubbackend.fixture.UserFixture;
+import leaguehub.leaguehubbackend.repository.channel.ChannelBoardRepository;
+import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchRepository;
+import leaguehub.leaguehubbackend.repository.member.MemberRepository;
+import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(locations = "classpath:application-test.properties")
+class MatchServiceTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    ChannelRepository channelRepository;
+
+    @Autowired
+    ChannelBoardRepository channelBoardRepository;
+
+    @Autowired
+    ParticipantRepository participantRepository;
+
+    @Autowired
+    MatchRepository matchRepository;
+
+    @Autowired
+    MatchService matchService;
+
+    Channel createCustomChannel(Boolean tier, Boolean playCount, Integer tierMax, Integer tierMin, int playCountMin) throws Exception {
+        Member member = memberRepository.save(UserFixture.createMember());
+        Member ironMember = memberRepository.save(UserFixture.createCustomeMember("썹맹구"));
+        Member unrankedMember = memberRepository.save(UserFixture.createCustomeMember("서초임"));
+        Member platinumMember = memberRepository.save(UserFixture.createCustomeMember("손성한"));
+        Member masterMember = memberRepository.save(UserFixture.createCustomeMember("채수채수밭"));
+        Member alreadyMember = memberRepository.save(UserFixture.createCustomeMember("요청한사람"));
+        Member rejectedMember = memberRepository.save(UserFixture.createCustomeMember("거절된사람"));
+        Member doneMember1 = memberRepository.save(UserFixture.createCustomeMember("참가된사람1"));
+        Member doneMember2 = memberRepository.save(UserFixture.createCustomeMember("참가된사람2"));
+
+        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(tier, playCount, tierMax, tierMin, playCountMin);
+        Channel channel = Channel.createChannel(channelDto.getTitle(),
+                channelDto.getGameCategory(), channelDto.getMaxPlayer(),
+                channelDto.getMatchFormat(), channelDto.getChannelImageUrl(),
+                channelDto.getTier(), channelDto.getTierMax(),
+                channelDto.getTierMin(),
+                channelDto.getPlayCount(),
+                channelDto.getPlayCountMin());
+        channelRepository.save(channel);
+        channelBoardRepository.saveAll(ChannelBoard.createDefaultBoard(channel));
+        participantRepository.save(Participant.createHostChannel(member, channel));
+        participantRepository.save(Participant.participateChannel(unrankedMember, channel));
+        participantRepository.save(Participant.participateChannel(ironMember, channel));
+        participantRepository.save(Participant.participateChannel(platinumMember, channel));
+        participantRepository.save(Participant.participateChannel(masterMember, channel));
+
+        Participant alreadyParticipant = participantRepository.save(Participant.participateChannel(alreadyMember, channel));
+        Participant rejectedParticipant = participantRepository.save(Participant.participateChannel(rejectedMember, channel));
+        Participant doneParticipant1 = participantRepository.save(Participant.participateChannel(doneMember1, channel));
+        Participant doneParticipant2 = participantRepository.save(Participant.participateChannel(doneMember2, channel));
+
+        alreadyParticipant.updateParticipantStatus("participantGameId1", "bronze", "participantNickname1");
+        rejectedParticipant.rejectParticipantRequest();
+        doneParticipant1.updateParticipantStatus("participantGameId2", "platinum", "participantNickname2");
+        doneParticipant2.updateParticipantStatus("participantGameId3", "iron", "participantNickname3");
+        doneParticipant1.approveParticipantMatch();
+        doneParticipant2.approveParticipantMatch();
+
+        return channel;
+    }
+
+    @Test
+    @DisplayName("매치 생성 테스트 - 성공")
+    public void matchCreateSuccessTest() throws Exception {
+        //given
+        UserFixture.setUpCustomAuth("id");
+        Channel channel = createCustomChannel(false, false, 2400, null, 20);
+
+        matchService.createSubMatches(channel, channel.getMaxPlayer());
+
+        List<Match> findMatchRound16 = matchRepository.findAllByChannel_ChannelLinkAndMatchRound(channel.getChannelLink(), 16);
+        List<Match> findMatchRound8 = matchRepository.findAllByChannel_ChannelLinkAndMatchRound(channel.getChannelLink(), 8);
+
+        assertThat(findMatchRound16.size()).isEqualTo(2);
+        assertThat(findMatchRound8.size()).isEqualTo(1);
+        assertThat(findMatchRound16.get(0).getMatchName()).isEqualTo("Group A");
+
+    }
+
+
+    @Test
+    @DisplayName("라운드 리스트 조회 테스트 - 성공")
+    public void matchListSuccessTest() throws Exception {
+        //given
+        UserFixture.setUpCustomAuth("id");
+        Channel channel = createCustomChannel(false, false, 2400, null, 20);
+
+        MatchRoundListDto roundList = matchService.getRoundList(channel.getChannelLink());
+
+        assertThat(roundList.getRoundList().size()).isEqualTo(2);
+    }
+
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue

#190 

## 📝 Description

팀원들과 회의를 통하여 예선전 ~ 결승전의 경기 횟수가 동일하다는 점이 부적절하여 관리자가 각 라운드에 대한 경기 횟수를 설정하도록 매치 엔티티에 경기 횟수라는 필드 명을 추가했어요
또한 버튼을 눌러 매치를 생성하는 것이 아닌 채널을 생성할 때 매치를 생성 하도록 채널 서비스에 추가로 넣었어요
배정이 안된 빈 값인 매치를 생성하도록 리팩터링하였어요
마지막으로 해당 채널의 대진표를 누르면 몇 강부터 있는지 리스트를 반환해주는 서비스를 만들었어요

코드를 수정하면서 누락된 테스트 코드도 넣었어요

## ✨ Feature

Match 엔티티에 매치 당 경기 횟수 필드 명 추가
참가자가 있는 Match 생성 서비스  -> 빈 값인 Match 생성 서비스로 변경
Match 생성이 일어나는 기점: 버튼을 누를 때 -> 채널이 생성될 때로 변경
필드 명 추가에 따른 테스트 코드 수정

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #190 