### PR TITLE
Feat#186: 참가자 첫 배정 및 대진표 조회 서비스 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -2,10 +2,13 @@ package leaguehub.leaguehubbackend.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import leaguehub.leaguehubbackend.dto.match.MatchInfoDto;
 import leaguehub.leaguehubbackend.dto.match.MatchRankResultDto;
 import leaguehub.leaguehubbackend.dto.match.MatchResponseDto;
 import leaguehub.leaguehubbackend.dto.match.MatchRoundListDto;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Match-Controller", description = "대회 경기자 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -27,7 +31,7 @@ public class MatchController {
     private final MatchRankService matchRankService;
     private final MatchService matchService;
 
-    @Operation(summary = "매치 결과 조회 및 저장")
+    @Operation(summary = "매치 결과 조회 및 저장 - 사용 x")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "매치 결과가 생성되었습니다."),
             @ApiResponse(responseCode = "403", description = "매치 결과를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
@@ -40,7 +44,7 @@ public class MatchController {
         return new ResponseEntity<>("매치 결과가 생성되었습니다.", HttpStatus.CREATED);
     }
 
-    @Operation(summary = "저장된 매치 결과 출력")
+    @Operation(summary = "저장된 매치 결과 출력 - 사용 x")
     @Parameter(name = "matchCode", description = "조회할 라이엇 매치코드", example = "KR_6519793792")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "매치 결과 리스트 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MatchRankResultDto.class))),
@@ -67,4 +71,40 @@ public class MatchController {
 
         return new ResponseEntity<>(roundList, HttpStatus.OK);
     }
+
+    @Operation(summary = "해당 채널의 경기 첫 배정")
+    @Parameters(value = {
+            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
+            @Parameter(name = "matchRound", description = "배정 싶은 매치의 라운드(64강, 32강)", example = "64, 32, 16, 8")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "참가자들이 첫 매치에 배정되었습니다."),
+            @ApiResponse(responseCode = "403", description = "권한이 관리자가 아님,채널을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/match/{channelLink}/{matchRound}")
+    public ResponseEntity assignmentMatches(@PathVariable("channelLink") String channelLink, @PathVariable("matchRound") Integer matchRound){
+
+        matchService.matchAssignment(channelLink, matchRound);
+
+        return new ResponseEntity<>("참가자들이 첫 매치에 배정되었습니다.", HttpStatus.OK);
+    }
+
+    @Operation(summary = "해당 채널의 (32, 16, 8)강에 대한 매치 조회")
+    @Parameters(value = {
+            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
+            @Parameter(name = "matchRound", description = "조회하고 싶은 매치의 라운드(64강, 32강)", example = "64, 32, 16, 8")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "매치가 조회되었습니다. - 배열로 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MatchInfoDto.class))),
+            @ApiResponse(responseCode = "403", description = "권한이 관리자가 아님,채널을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/match/{channelLink}/{matchRound}")
+    public ResponseEntity loadMatchInfo(@PathVariable("channelLink") String channelLink, @PathVariable("matchRound") Integer matchRound){
+
+        List<MatchInfoDto> matchInfoDtoList = matchService.loadMatchPlayerList(channelLink, matchRound);
+
+        return new ResponseEntity<>(matchInfoDtoList, HttpStatus.OK);
+    }
+
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/controller/ParticipantController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/ParticipantController.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import static org.springframework.http.HttpStatus.OK;
 
-@Tag(name = "Participants", description = "참가자 관련 API")
+@Tag(name = "Participants-Controller", description = "참가자 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchInfoDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchInfoDto.java
@@ -1,0 +1,32 @@
+package leaguehub.leaguehubbackend.dto.match;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import leaguehub.leaguehubbackend.entity.match.MatchStatus;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MatchInfoDto {
+
+    @Schema(description = "매치 이름", example = "Group A")
+    private String matchName;
+
+    @Schema(description = "해당 매치의 상세보기 or 체크인하기 위한 매치 링크", example = "adpdpa123")
+    private String matchLink;
+
+    @Schema(description = "매치 상태", example = "대기 | 경기 중 | 경기 종료")
+    private MatchStatus matchStatus;
+
+    @Schema(description = "몇 강", example = "64(강), 32(강), 16(강)")
+    private Integer matchRound;
+
+    @Schema(description = "해당 매치 경기 현재 횟수", example = "1(회)")
+    private Integer matchRoundCount;
+
+    @Schema(description = "해당 매치 최대 경기 횟수", example = "3(회)")
+    private Integer matchRoundMaxCount;
+
+    @Schema(description = "매치에 속해있는 플레이어의 정보", example = "배열로 반환")
+    private List<MatchPlayerInfo> matchPlayerInfoList;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerInfo.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerInfo.java
@@ -1,0 +1,21 @@
+package leaguehub.leaguehubbackend.dto.match;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import leaguehub.leaguehubbackend.entity.match.PlayerStatus;
+import lombok.Data;
+
+@Data
+public class MatchPlayerInfo {
+
+    @Schema(description = "플레이어의 채널 닉네임", example = "채널안의 닉네임")
+    private String nickName;
+
+    @Schema(description = "플레이어의 게임 티어", example = "Diamond II")
+    private String gameTier;
+
+    @Schema(description = "플레이어의 경기 상태", example = "대기 | 경기 중 | 실격 | 탈락 | 승급 | 우승")
+    private PlayerStatus playerStatus;
+
+    @Schema(description = "참가자 점수", example = "8(점), 5(점), ...")
+    private Integer Score;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
@@ -33,6 +33,7 @@ public class MatchPlayer extends BaseTimeEntity {
         MatchPlayer matchPlayer = new MatchPlayer();
         matchPlayer.playerStatus = PlayerStatus.WAITING;
         matchPlayer.participant = participant;
+        matchPlayer.playerScore = 0;
         matchPlayer.match = match;
 
         return matchPlayer;

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -8,4 +8,8 @@ import java.util.List;
 public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> {
 
     List<MatchPlayer> findAllByMatch_MatchLinkAndMatch_MatchName(String matchLink, String matchName);
+
+    List<MatchPlayer> findAllByMatch_MatchNameAndMatch_MatchRound(String matchName, Integer matchRound);
+
+    List<MatchPlayer> findAllByMatch_Id(Long matchId);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
@@ -10,5 +10,5 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 
     Optional<Match> findByMatchLink(String matchLink);
 
-    List<Match> findAllByChannel_ChannelLinkAndMatchRound(String channelLink, Integer matchRound);
+    List<Match> findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(String channelLink, Integer matchRound);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
@@ -29,7 +29,7 @@ public class ChannelBoardService {
     public ChannelBoardLoadDto createChannelBoard(String channelLink, ChannelBoardDto request) {
 
         Member member = memberService.findCurrentMember();
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
         Participant participant = channelService.getParticipant(channel.getId(), member.getId());
         channelService.checkRoleHost(participant.getRole());
 
@@ -52,7 +52,7 @@ public class ChannelBoardService {
      */
     @Transactional
     public List<ChannelBoardLoadDto> loadChannelBoards(String channelLink) {
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
 
         List<ChannelBoard> channelBoards = channelBoardRepository.findAllByChannel_IdOrderByIndex(channel.getId());
 
@@ -65,7 +65,7 @@ public class ChannelBoardService {
 
     @Transactional
     public ChannelBoardDto getChannelBoard(String channelLink, Long boardId) {
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
         ChannelBoard channelBoard = validateChannelBoard(boardId, channel.getId());
 
 
@@ -77,7 +77,7 @@ public class ChannelBoardService {
 
         Member member = memberService.findCurrentMember();
 
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
         Participant participant = channelService.getParticipant(channel.getId(), member.getId());
         channelService.checkRoleHost(participant.getRole());
 
@@ -91,7 +91,7 @@ public class ChannelBoardService {
     public void deleteChannelBoard(String channelLink, Long boardId) {
         Member member = memberService.findCurrentMember();
 
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
         Participant participant = channelService.getParticipant(channel.getId(), member.getId());
 
         channelService.checkRoleHost(participant.getRole());
@@ -110,7 +110,7 @@ public class ChannelBoardService {
     public void updateChannelBoardIndex(String channelLink, List<ChannelBoardLoadDto> channelBoardLoadDtoList) {
         Member member = memberService.findCurrentMember();
 
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
         Participant participant = channelService.getParticipant(channel.getId(), member.getId());
 
         channelService.checkRoleHost(participant.getRole());

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelRuleService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelRuleService.java
@@ -24,7 +24,7 @@ public class ChannelRuleService {
 
     @Transactional
     public ChannelRuleDto updateChannelRule(String channelLink, ChannelRuleDto channelRuleDto) {
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
         Member member = memberService.findCurrentMember();
         Participant participant = channelService.getParticipant(channel.getId(), member.getId());
         channelService.checkRoleHost(participant.getRole());
@@ -58,7 +58,7 @@ public class ChannelRuleService {
 
     @Transactional
     public ChannelRuleDto getChannelRule(String channelLink) {
-        channelService.validateChannel(channelLink);
+        channelService.getChannel(channelLink);
         ChannelRule channelRule = channelRuleRepository.findChannelRuleByChannel_ChannelLink(channelLink);
 
         return new ChannelRuleDto().builder().tier(channelRule.getTier()).tierMax(channelRule.getTierMax())

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -104,7 +104,7 @@ public class ChannelService {
     @Transactional
     public void updateChannel(String channelLink, UpdateChannelDto updateChannelDto) {
         Member member = memberService.findCurrentMember();
-        Channel channel = validateChannel(channelLink);
+        Channel channel = getChannel(channelLink);
         Participant participant = getParticipant(channel.getId(), member.getId());
         checkRoleHost(participant.getRole());
 
@@ -114,7 +114,7 @@ public class ChannelService {
         Optional.ofNullable(updateChannelDto.getChannelImageUrl()).ifPresent(channel::updateChannelImageUrl);
     }
 
-    public Channel validateChannel(String channelLink) {
+    public Channel getChannel(String channelLink) {
         Channel channel = channelRepository.findByChannelLink(channelLink)
                 .orElseThrow(ChannelNotFoundException::new);
         return channel;

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -1,30 +1,47 @@
 package leaguehub.leaguehubbackend.service.match;
 
+import leaguehub.leaguehubbackend.dto.match.MatchInfoDto;
+import leaguehub.leaguehubbackend.dto.match.MatchPlayerInfo;
 import leaguehub.leaguehubbackend.dto.match.MatchRoundListDto;
 import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.entity.match.Match;
+import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.entity.participant.Participant;
+import leaguehub.leaguehubbackend.entity.participant.Role;
 import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundException;
+import leaguehub.leaguehubbackend.exception.match.exception.MatchNotEnoughPlayerException;
+import leaguehub.leaguehubbackend.exception.participant.exception.InvalidParticipantAuthException;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
 import leaguehub.leaguehubbackend.repository.match.MatchRepository;
 import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
+import leaguehub.leaguehubbackend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
+import static leaguehub.leaguehubbackend.entity.participant.RequestStatus.DONE;
+import static leaguehub.leaguehubbackend.entity.participant.Role.PLAYER;
 
 @Service
 @RequiredArgsConstructor
 public class MatchService {
 
+    private static final int MIN_PLAYERS_FOR_SUB_MATCH = 8;
     private final MatchRepository matchRepository;
+    private final MatchPlayerRepository matchPlayerRepository;
     private final ChannelRepository channelRepository;
     private final ParticipantRepository participantRepository;
+    private final MemberService memberService;
 
-    private static final int MIN_PLAYERS_FOR_SUB_MATCH = 8;
 
     /**
      * 채널을 만들 때 빈 값인 매치를 만듦
+     *
      * @param channel
      * @param maxPlayers
      */
@@ -38,14 +55,14 @@ public class MatchService {
 
     /**
      * 해당 채널의 매치 라운드를 보여줌(64, 32, 16, 8)
+     *
      * @param channelLink
      * @return
      */
     public MatchRoundListDto getRoundList(String channelLink) {
-        Channel channel = channelRepository.findByChannelLink(channelLink)
-                .orElseThrow(() -> new ChannelNotFoundException());
+        Channel findChannel = getChannel(channelLink);
 
-        int maxPlayers = channel.getMaxPlayer();
+        int maxPlayers = findChannel.getMaxPlayer();
         List<Integer> roundList = calculateRoundList(maxPlayers);
 
         MatchRoundListDto roundListDto = new MatchRoundListDto();
@@ -54,6 +71,57 @@ public class MatchService {
         return roundListDto;
     }
 
+    /**
+     * 경기 첫 배정
+     * @param channelLink
+     * @param matchRound
+     */
+    public void matchAssignment(String channelLink, Integer matchRound) {
+        Channel findChannel = channelRepository.findByChannelLink(channelLink)
+                .orElseThrow(() -> new ChannelNotFoundException());
+
+        Member member = memberService.findCurrentMember();
+        Participant participant = getParticipant(findChannel.getId(), member.getId());
+        checkRoleHost(participant.getRole());
+
+        List<Match> matchList = matchRepository.findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(channelLink, matchRound);
+
+        List<Participant> playerList = participantRepository
+                .findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, PLAYER, DONE);
+
+        if (playerList.size() < matchRound * 0.75) throw new MatchNotEnoughPlayerException();
+
+        assignSubMatches(findChannel, matchList, playerList);
+    }
+
+    public List<MatchInfoDto> loadMatchPlayerList(String channelLink, Integer matchRound) {
+        List<Match> matchList = matchRepository.findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(channelLink, matchRound);
+        List<MatchInfoDto> matchInfoDtoList = new ArrayList<>();
+
+        for (Match match : matchList) {
+            MatchInfoDto matchInfoDto = createMatchInfoDto(match);
+            matchInfoDtoList.add(matchInfoDto);
+        }
+
+        return matchInfoDtoList;
+    }
+
+    private Channel getChannel(String channelLink) {
+        Channel findChannel = channelRepository.findByChannelLink(channelLink)
+                .orElseThrow(() -> new ChannelNotFoundException());
+        return findChannel;
+    }
+
+    private List<Integer> calculateRoundList(int maxPlayers) {
+        List<Integer> roundList = new ArrayList<>();
+
+        while (maxPlayers >= MIN_PLAYERS_FOR_SUB_MATCH) {
+            roundList.add(maxPlayers);
+            maxPlayers /= 2;
+        }
+
+        return roundList;
+    }
 
     private int createSubMatchesForRound(Channel channel, int maxPlayers) {
         int currentPlayers = maxPlayers;
@@ -68,14 +136,69 @@ public class MatchService {
         return currentPlayers / 2;
     }
 
-    private List<Integer> calculateRoundList(int maxPlayers) {
-        List<Integer> roundList = new ArrayList<>();
+    private Participant getParticipant(Long channelId, Long memberId) {
+        Participant participant = participantRepository.findParticipantByMemberIdAndChannel_Id(memberId, channelId)
+                .orElseThrow(() -> new InvalidParticipantAuthException());
+        return participant;
+    }
 
-        while (maxPlayers >= MIN_PLAYERS_FOR_SUB_MATCH) {
-            roundList.add(maxPlayers);
-            maxPlayers /= 2;
+    private void checkRoleHost(Role role) {
+        if (role != Role.HOST) {
+            throw new InvalidParticipantAuthException();
+        }
+    }
+
+    private void assignSubMatches(Channel channel, List<Match> matchList, List<Participant> playerList) {
+        Collections.shuffle(playerList);
+
+        int totalPlayers = channel.getRealPlayer();
+        int matchCount = matchList.size();
+        int playersPerMatch = totalPlayers / matchCount;
+        int remainingPlayers = totalPlayers % matchCount;
+        int playerIndex = 0;
+
+        for (Match match : matchList) {
+            int currentPlayerCount = playersPerMatch + (remainingPlayers > 0 ? 1 : 0);
+
+            for (int i = 0; i < currentPlayerCount; i++) {
+                Participant player = playerList.get(playerIndex);
+                MatchPlayer matchPlayer = MatchPlayer.createMatchPlayer(player, match);
+                matchPlayerRepository.save(matchPlayer);
+
+                playerIndex++;
+                remainingPlayers--;
+            }
+        }
+    }
+
+    private MatchInfoDto createMatchInfoDto(Match match) {
+        MatchInfoDto matchInfoDto = new MatchInfoDto();
+        matchInfoDto.setMatchName(match.getMatchName());
+        matchInfoDto.setMatchLink(match.getMatchLink());
+        matchInfoDto.setMatchStatus(match.getMatchStatus());
+        matchInfoDto.setMatchRound(match.getMatchRound());
+        matchInfoDto.setMatchRoundCount(match.getRoundRealCount());
+        matchInfoDto.setMatchRoundMaxCount(match.getRoundMaxCount());
+
+        List<MatchPlayer> playerList = matchPlayerRepository.findAllByMatch_Id(match.getId());
+        List<MatchPlayerInfo> matchPlayerInfoList = createMatchPlayerInfoList(playerList);
+        matchInfoDto.setMatchPlayerInfoList(matchPlayerInfoList);
+
+        return matchInfoDto;
+    }
+
+    private List<MatchPlayerInfo> createMatchPlayerInfoList(List<MatchPlayer> playerList) {
+        List<MatchPlayerInfo> matchPlayerInfoList = new ArrayList<>();
+
+        for (MatchPlayer matchPlayer : playerList) {
+            MatchPlayerInfo matchPlayerInfo = new MatchPlayerInfo();
+            matchPlayerInfo.setNickName(matchPlayer.getParticipant().getNickname());
+            matchPlayerInfo.setGameTier(matchPlayer.getParticipant().getGameTier());
+            matchPlayerInfo.setPlayerStatus(matchPlayer.getPlayerStatus());
+            matchPlayerInfo.setScore(matchPlayer.getPlayerScore());
+            matchPlayerInfoList.add(matchPlayerInfo);
         }
 
-        return roundList;
+        return matchPlayerInfoList;
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -6,7 +6,6 @@ import leaguehub.leaguehubbackend.dto.participant.ResponseStatusPlayerDto;
 import leaguehub.leaguehubbackend.dto.participant.ResponseUserGameInfoDto;
 import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.entity.channel.ChannelRule;
-import leaguehub.leaguehubbackend.entity.constant.GlobalConstant;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.entity.participant.GameTier;
 import leaguehub.leaguehubbackend.entity.participant.Participant;
@@ -57,7 +56,7 @@ public class ParticipantService {
 
 
     public int findParticipantPermission(String channelLink) {
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
         UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
         if(userDetails == null) return OBSERVER.getNum();
         Member member = memberService.validateMember(userDetails.getUsername());
@@ -86,7 +85,7 @@ public class ParticipantService {
 
         Member member = memberService.findCurrentMember();
 
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
 
         //중복 검사 추가
         duplicateParticipant(member, channelLink);
@@ -181,7 +180,7 @@ public class ParticipantService {
      * @param participantId
      */
     public void approveParticipantRequest(String channelLink, Long participantId) {
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
 
         checkRoleHost(channelLink);
 
@@ -318,7 +317,7 @@ public class ParticipantService {
     }
 
     private void checkRealPlayerCount(String channelLink) {
-        Channel channel = channelService.validateChannel(channelLink);
+        Channel channel = channelService.getChannel(channelLink);
 
         if (channel.getRealPlayer() >= channel.getMaxPlayer())
             throw new ParticipantRealPlayerIsMaxException();

--- a/src/test/java/leaguehub/leaguehubbackend/service/match/MatchServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/match/MatchServiceTest.java
@@ -101,8 +101,8 @@ class MatchServiceTest {
 
         matchService.createSubMatches(channel, channel.getMaxPlayer());
 
-        List<Match> findMatchRound16 = matchRepository.findAllByChannel_ChannelLinkAndMatchRound(channel.getChannelLink(), 16);
-        List<Match> findMatchRound8 = matchRepository.findAllByChannel_ChannelLinkAndMatchRound(channel.getChannelLink(), 8);
+        List<Match> findMatchRound16 = matchRepository.findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(channel.getChannelLink(), 16);
+        List<Match> findMatchRound8 = matchRepository.findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(channel.getChannelLink(), 8);
 
         assertThat(findMatchRound16.size()).isEqualTo(2);
         assertThat(findMatchRound8.size()).isEqualTo(1);


### PR DESCRIPTION
## 🙆‍♂️ Issue

#186 

## 📝 Description

관리자가 원하는 라운드(몇 강)를 선택하여 참가자 배정을 호출하면 무작위로 참가자들이 배정되는 서비스를 만들었어요
해당 서비스는 채널을 만들었을 때 미리 생성되어있는 빈 값인 매치에 참가자들을 넣는 서비스에요
또한 배정을 하였을 때 라운드(몇 강)를 선택하여 조회할 수 있는 기능을 만들었어요
조회 서비스는 List형태인 Dto를 반환하도록 하였어요 자세한건 스웨거에서 확인할 수 있어요

테스트 코드는 따로 이슈를 파서 만들게요

## ✨ Feature

해당 채널의 첫 배정 때 무작위로 배정하는 기능 구현
원하는 라운드(몇 강)의 매치들을 조회할 수 있는 기능 구현

## 👌 Review Change

람다 스트림으로 변경 및 메소드 추출
ChannelService validateChannel 메서드 명 변경
repository 이름 수정에 따른 리팩터링

This closes #186 