### PR TITLE
Test#146: 채널 커스텀 정렬, 분리된 채널보드 가져오기 API 테스트 추가

### DIFF
--- a/src/test/java/leaguehub/leaguehubbackend/controller/channel/ChannelBoardControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/channel/ChannelBoardControllerTest.java
@@ -333,4 +333,18 @@ class ChannelBoardControllerTest {
 
     }
 
+    @Test
+    @DisplayName("채널 보드 불러오기 테스트 - 화면 구성")
+    void loadChannelBoards() throws Exception {
+        CreateChannelDto createChannelDto = ChannelFixture.createChannelDto();
+        ParticipantChannelDto participantChannelDto = channelService.createChannel(createChannelDto);
+        Optional<Channel> channel = channelRepository.findByChannelLink(participantChannelDto.getChannelLink());
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/channel/"
+                                + channel.get().getChannelLink() + "/boards")
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(print());
+    }
+
+
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#146 

## 📝 Description

채널 커스텀 정렬 및 채널 컨트롤러 계층에서 분리된 채널 보드 가져오기 API 테스트를 추가했어요.

<img width="1187" alt="image" src="https://github.com/TheUpperPart/leaguehub-backend/assets/102659136/0db1bcf4-43af-4a3c-9cdc-9ffff4754759">


## ✨ Feature

loadChannelBoards 및 updateChannelCustomIndex 테스트 추가

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #146 