### PR TITLE
Refactor#209: JPA 성능 튜닝을 위한 리팩터링

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelBoardRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelBoardRepository.java
@@ -11,9 +11,13 @@ import java.util.Optional;
 
 public interface ChannelBoardRepository extends JpaRepository<ChannelBoard, Long> {
 
-    List<ChannelBoard> findAllByChannel_IdOrderByIndex(Long channelId);
+    List<ChannelBoard> findAllByChannel_ChannelLinkOrderByIndex(String channelLink);
+
+    Optional<ChannelBoard> findChannelBoardsByIdAndChannel_ChannelLink(Long boardId, String channelLink);
 
     Optional<ChannelBoard> findChannelBoardsByIdAndChannel_Id(Long boardId, Long channelId);
+
+    List<ChannelBoard> findAllByChannel_IdOrderByIndex(Long channelId);
 
     List<ChannelBoard> findAllByChannelAndIndexGreaterThan(Channel channel, int deleteIndex);
 

--- a/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelRuleRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelRuleRepository.java
@@ -5,5 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChannelRuleRepository extends JpaRepository<ChannelRule, Long> {
 
+    ChannelRule findChannelRuleByChannel_Id(Long channelId);
+
     ChannelRule findChannelRuleByChannel_ChannelLink(String channelLink);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
@@ -16,11 +16,11 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     List<Participant> findAllByMemberIdOrderByIndex(Long memberId);
 
-    @Query("select p from Participant p join fetch p.channel")
-    Optional<Participant> findParticipantByMemberIdAndChannel_ChannelLink(Long memberId, String channelLink);
+    @Query("select p from Participant p join fetch p.channel where p.channel.channelLink = :channelLink and p.member.id = :memberId")
+    Optional<Participant> findParticipantByMemberIdAndChannel_ChannelLink(@Param("memberId") Long memberId, @Param("channelLink") String channelLink);
 
-    @Query("select p from Participant p join fetch p.channel")
-    Optional<Participant> findParticipantByIdAndChannel_ChannelLink(Long participantId, String channelLink);
+    @Query("select p from Participant p join fetch p.channel where p.channel.channelLink = :channelLink and p.id = :participantId")
+    Optional<Participant> findParticipantByIdAndChannel_ChannelLink(@Param("participantId") Long participantId, @Param("channelLink") String channelLink);
 
     List<Participant> findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(String channelLink, Role role, RequestStatus requestStatus);
 

--- a/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
@@ -16,8 +16,10 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     List<Participant> findAllByMemberIdOrderByIndex(Long memberId);
 
+    @Query("select p from Participant p join fetch p.channel")
     Optional<Participant> findParticipantByMemberIdAndChannel_ChannelLink(Long memberId, String channelLink);
 
+    @Query("select p from Participant p join fetch p.channel")
     Optional<Participant> findParticipantByIdAndChannel_ChannelLink(Long participantId, String channelLink);
 
     List<Participant> findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(String channelLink, Role role, RequestStatus requestStatus);

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
@@ -29,8 +29,8 @@ public class ChannelBoardService {
     public ChannelBoardLoadDto createChannelBoard(String channelLink, ChannelBoardDto request) {
 
         Member member = memberService.findCurrentMember();
-        Channel channel = channelService.getChannel(channelLink);
-        Participant participant = channelService.getParticipant(channel.getId(), member.getId());
+        Participant participant = channelService.getParticipant(member.getId(), channelLink);
+        Channel channel = participant.getChannel();
         channelService.checkRoleHost(participant.getRole());
 
         Integer maxIndexByChannel = channelBoardRepository.findMaxIndexByChannel(channel);
@@ -52,9 +52,8 @@ public class ChannelBoardService {
      */
     @Transactional
     public List<ChannelBoardLoadDto> loadChannelBoards(String channelLink) {
-        Channel channel = channelService.getChannel(channelLink);
 
-        List<ChannelBoard> channelBoards = channelBoardRepository.findAllByChannel_IdOrderByIndex(channel.getId());
+        List<ChannelBoard> channelBoards = channelBoardRepository.findAllByChannel_ChannelLinkOrderByIndex(channelLink);
 
         List<ChannelBoardLoadDto> channelBoardLoadDtoList = channelBoards.stream()
                 .map(channelBoard -> new ChannelBoardLoadDto(channelBoard.getId(), channelBoard.getTitle(), channelBoard.getIndex()))
@@ -65,9 +64,7 @@ public class ChannelBoardService {
 
     @Transactional
     public ChannelBoardDto getChannelBoard(String channelLink, Long boardId) {
-        Channel channel = channelService.getChannel(channelLink);
-        ChannelBoard channelBoard = validateChannelBoard(boardId, channel.getId());
-
+        ChannelBoard channelBoard = validateChannelBoard(boardId, channelLink);
 
         return new ChannelBoardDto(channelBoard.getTitle(), channelBoard.getContent());
     }
@@ -77,8 +74,9 @@ public class ChannelBoardService {
 
         Member member = memberService.findCurrentMember();
 
-        Channel channel = channelService.getChannel(channelLink);
-        Participant participant = channelService.getParticipant(channel.getId(), member.getId());
+        Participant participant = channelService.getParticipant(member.getId(), channelLink);
+
+        Channel channel = participant.getChannel();
         channelService.checkRoleHost(participant.getRole());
 
         ChannelBoard channelBoard = validateChannelBoard(boardId, channel.getId());
@@ -91,8 +89,8 @@ public class ChannelBoardService {
     public void deleteChannelBoard(String channelLink, Long boardId) {
         Member member = memberService.findCurrentMember();
 
-        Channel channel = channelService.getChannel(channelLink);
-        Participant participant = channelService.getParticipant(channel.getId(), member.getId());
+        Participant participant = channelService.getParticipant(member.getId(), channelLink);
+        Channel channel = participant.getChannel();
 
         channelService.checkRoleHost(participant.getRole());
 
@@ -110,8 +108,9 @@ public class ChannelBoardService {
     public void updateChannelBoardIndex(String channelLink, List<ChannelBoardLoadDto> channelBoardLoadDtoList) {
         Member member = memberService.findCurrentMember();
 
-        Channel channel = channelService.getChannel(channelLink);
-        Participant participant = channelService.getParticipant(channel.getId(), member.getId());
+        Participant participant = channelService.getParticipant(member.getId(), channelLink);
+
+        Channel channel = participant.getChannel();
 
         channelService.checkRoleHost(participant.getRole());
 
@@ -123,6 +122,11 @@ public class ChannelBoardService {
                     .findFirst()
                     .ifPresent(channelBoard -> channelBoard.updateIndex(channelBoardLoadDto.getBoardIndex()));
         });
+    }
+
+    public ChannelBoard validateChannelBoard(Long channelBoardId, String channelLink) {
+        return channelBoardRepository.findChannelBoardsByIdAndChannel_ChannelLink(channelBoardId, channelLink)
+                .orElseThrow(() -> new ChannelBoardNotFoundException());
     }
 
     public ChannelBoard validateChannelBoard(Long channelBoardId, Long channelId) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
@@ -53,6 +53,8 @@ public class ChannelBoardService {
     @Transactional
     public List<ChannelBoardLoadDto> loadChannelBoards(String channelLink) {
 
+        channelService.getChannel(channelLink);
+
         List<ChannelBoard> channelBoards = channelBoardRepository.findAllByChannel_ChannelLinkOrderByIndex(channelLink);
 
         List<ChannelBoardLoadDto> channelBoardLoadDtoList = channelBoards.stream()

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelRuleService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelRuleService.java
@@ -23,12 +23,12 @@ public class ChannelRuleService {
 
     @Transactional
     public ChannelRuleDto updateChannelRule(String channelLink, ChannelRuleDto channelRuleDto) {
-        Channel channel = channelService.getChannel(channelLink);
         Member member = memberService.findCurrentMember();
-        Participant participant = channelService.getParticipant(channel.getId(), member.getId());
+        Participant participant = channelService.getParticipant(member.getId(), channelLink);
+        Channel channel = participant.getChannel();
         channelService.checkRoleHost(participant.getRole());
 
-        ChannelRule channelRule = channelRuleRepository.findChannelRuleByChannel_ChannelLink(channelLink);
+        ChannelRule channelRule = channelRuleRepository.findChannelRuleByChannel_Id(channel.getId());
 
         Optional.ofNullable(channelRuleDto.getTier())
                 .ifPresent(tier -> {
@@ -55,7 +55,6 @@ public class ChannelRuleService {
 
     @Transactional
     public ChannelRuleDto getChannelRule(String channelLink) {
-        channelService.getChannel(channelLink);
         ChannelRule channelRule = channelRuleRepository.findChannelRuleByChannel_ChannelLink(channelLink);
 
         return new ChannelRuleDto().builder().tier(channelRule.getTier()).tierMax(channelRule.getTierMax())

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -96,8 +96,7 @@ public class ChannelService {
     @Transactional
     public ChannelDto findChannel(String channelLink) {
 
-        Channel findChannel = channelRepository.findByChannelLink(channelLink)
-                .orElseThrow(ChannelNotFoundException::new);
+        Channel findChannel = getChannel(channelLink);
 
         ChannelDto channelDto = ChannelDto.builder().title(findChannel.getTitle())
                 .realPlayer(findChannel.getRealPlayer()).gameCategory(findChannel.getGameCategory())

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -57,7 +57,7 @@ public class ChannelService {
 
         channelRepository.save(channel);
 
-        ChannelRule channelRule = ChannelRule.createChannelRule(channel,  createChannelDto.getTier(), createChannelDto.getTierMax(),
+        ChannelRule channelRule = ChannelRule.createChannelRule(channel, createChannelDto.getTier(), createChannelDto.getTierMax(),
                 createChannelDto.getTierMin(),
                 createChannelDto.getPlayCount(),
                 createChannelDto.getPlayCountMin());
@@ -109,8 +109,8 @@ public class ChannelService {
     @Transactional
     public void updateChannel(String channelLink, UpdateChannelDto updateChannelDto) {
         Member member = memberService.findCurrentMember();
-        Channel channel = getChannel(channelLink);
-        Participant participant = getParticipant(channel.getId(), member.getId());
+        Participant participant = getParticipant(member.getId(), channelLink);
+        Channel channel = participant.getChannel();
         checkRoleHost(participant.getRole());
 
 
@@ -119,6 +119,7 @@ public class ChannelService {
         Optional.ofNullable(updateChannelDto.getChannelImageUrl()).ifPresent(channel::updateChannelImageUrl);
     }
 
+
     public Channel getChannel(String channelLink) {
         Channel channel = channelRepository.findByChannelLink(channelLink)
                 .orElseThrow(ChannelNotFoundException::new);
@@ -126,10 +127,10 @@ public class ChannelService {
     }
 
 
-    public Participant getParticipant(Long channelId, Long memberId) {
-        Participant participant = participantRepository.findParticipantByMemberIdAndChannel_Id(memberId, channelId)
+    public Participant getParticipant(Long memberId, String channelLink) {
+        return participantRepository
+                .findParticipantByMemberIdAndChannel_ChannelLink(memberId, channelLink)
                 .orElseThrow(() -> new InvalidParticipantAuthException());
-        return participant;
     }
 
     public void checkRoleHost(Role role) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -6,6 +6,7 @@ import leaguehub.leaguehubbackend.dto.participant.ResponseStatusPlayerDto;
 import leaguehub.leaguehubbackend.dto.participant.ResponseUserGameInfoDto;
 import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.entity.channel.ChannelRule;
+import leaguehub.leaguehubbackend.entity.member.BaseRole;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.entity.participant.GameTier;
 import leaguehub.leaguehubbackend.entity.participant.Participant;
@@ -81,7 +82,7 @@ public class ParticipantService {
     public Participant participateChannel(String channelLink) {
 
         Member member = memberService.findCurrentMember();
-        checkEmail(memberService.getVerifiedEmail(member));
+        checkEmail(member.getBaseRole());
 
         Channel channel = channelService.getChannel(channelLink);
 
@@ -315,11 +316,10 @@ public class ParticipantService {
     /**
      * 이메일이 인증되었는지 확인
      *
-     * @param verifiedEmail
+     * @param baseRole
      */
-    public void checkEmail(String verifiedEmail) {
-        if (!verifiedEmail.equals(USER.convertBaseRole()))
-            throw new UnauthorizedEmailException();
+    public void checkEmail(BaseRole baseRole) {
+        if (baseRole != USER) throw new UnauthorizedEmailException();
     }
 
 
@@ -372,8 +372,7 @@ public class ParticipantService {
     public Participant getParticipant(String channelLink) {
 
         Member member = memberService.findCurrentMember();
-        String verifiedEmail = memberService.getVerifiedEmail(member);
-        checkEmail(verifiedEmail);
+        checkEmail(member.getBaseRole());
 
         Participant participant = participantRepository.findParticipantByMemberIdAndChannel_ChannelLink(member.getId(), channelLink)
                 .orElseThrow(() -> new InvalidParticipantAuthException());


### PR DESCRIPTION
## 🙆‍♂️ Issue

#209 

## 📝 Description

쓸데 없는 쿼리를 최대한 줄이기 위해 fetch join을 이용해서 성능 최적화를 해봤어요. 스프링 데이터 JPA를 활용하면 항상 JPQL을 사용하기 때문에 쿼리 문이 날아가는데, 로직 자체가 Partcipant를 가져올 때 channel을 가져오는 경우가 많았기에, Participant를 가져올 때 channel을 fetch join으로 가져오도록 하고 코드를 조금 수정했어요. 앞으로 만들 매치에서도 쿼리를 최대한 줄일 방법을 생각 해봐야겠어요.

다행히 잘 짠 코드 덕에 테스트는 하나도 바꾸지 않아도 잘 돌아가네요 !

<img width="1188" alt="image" src="https://github.com/TheUpperPart/leaguehub-backend/assets/102659136/d6895f88-177d-4fbd-83fe-bf21d0a07f50">

그리고 fetch join을 이용하실 때에는 Spring data Jpa로 데이터를 못거르고 직접 쿼리문으로 where을 써서 @Param을 활용해야 하니 주의 하세요 !

## ✨ Feature

각 Repository fetch join 추가, 추가된 코드에 따른 서비스 문 코드 변경

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #209 