### PR TITLE
Feat#212: 대진표 관련 기능 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import leaguehub.leaguehubbackend.dto.match.MatchInfoDto;
-import leaguehub.leaguehubbackend.dto.match.MatchRankResultDto;
-import leaguehub.leaguehubbackend.dto.match.MatchResponseDto;
-import leaguehub.leaguehubbackend.dto.match.MatchRoundListDto;
+import leaguehub.leaguehubbackend.dto.match.*;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.match.MatchRankService;
 import leaguehub.leaguehubbackend.service.match.MatchService;
@@ -101,7 +98,7 @@ public class MatchController {
     @GetMapping("/match/{channelLink}/{matchRound}")
     public ResponseEntity loadMatchInfo(@PathVariable("channelLink") String channelLink, @PathVariable("matchRound") Integer matchRound){
 
-        List<MatchInfoDto> matchInfoDtoList = matchService.loadMatchPlayerList(channelLink, matchRound);
+        MatchRoundInfoDto matchInfoDtoList = matchService.loadMatchPlayerList(channelLink, matchRound);
 
         return new ResponseEntity<>(matchInfoDtoList, HttpStatus.OK);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerInfo.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerInfo.java
@@ -7,8 +7,8 @@ import lombok.Data;
 @Data
 public class MatchPlayerInfo {
 
-    @Schema(description = "플레이어의 채널 닉네임", example = "채널안의 닉네임")
-    private String nickName;
+    @Schema(description = "플레이어의 게임 닉네임", example = "돈절래")
+    private String gameId;
 
     @Schema(description = "플레이어의 게임 티어", example = "Diamond II")
     private String gameTier;

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchRoundInfoDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchRoundInfoDto.java
@@ -1,0 +1,13 @@
+package leaguehub.leaguehubbackend.dto.match;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MatchRoundInfoDto {
+
+    private String myGameId;
+
+    private List<MatchInfoDto> matchInfoDtoList;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchRoundListDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchRoundListDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 @Data
 public class MatchRoundListDto {
 
+    private Integer liveRound;
 
-    List<Integer> roundList;
+    private List<Integer> roundList;
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -7,6 +7,7 @@ import leaguehub.leaguehubbackend.dto.match.MatchRoundListDto;
 import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.entity.match.Match;
 import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
+import leaguehub.leaguehubbackend.entity.match.MatchStatus;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.entity.participant.Role;
@@ -69,7 +70,10 @@ public class MatchService {
         List<Integer> roundList = calculateRoundList(maxPlayers);
 
         MatchRoundListDto roundListDto = new MatchRoundListDto();
+        roundListDto.setLiveRound(0);
         roundListDto.setRoundList(roundList);
+
+        findLiveRound(channelLink, roundList, roundListDto);
 
         return roundListDto;
     }
@@ -127,6 +131,17 @@ public class MatchService {
         }
 
         return roundList;
+    }
+
+    private void findLiveRound(String channelLink, List<Integer> roundList, MatchRoundListDto roundListDto) {
+        roundList.forEach(round -> {
+                    List<Match> matchList = matchRepository.findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(channelLink, round);
+                    matchList.stream()
+                            .filter(match -> match.getMatchStatus().equals(MatchStatus.PROGRESS))
+                            .findFirst()
+                            .ifPresent(match -> roundListDto.setLiveRound(match.getMatchRound()));
+                }
+        );
     }
 
     private int createSubMatchesForRound(Channel channel, int maxPlayers) {


### PR DESCRIPTION
## 🙆‍♂️ Issue

#212 

## 📝 Description

대진표를 보여줄 때 사용자가 참가되어 있으면 자신을 표시하도록 기능을 추가하였어요
또한 해당 채널의 라운드를 표시할 때 경기 중인 라운드를 표시하도록 기능을 추가하였어요

추가적으로 대진표에 보여주는 닉네임을 채널의 고유 닉네임이 아닌 게임에 사용되는 닉네임으로 변경하였어요


## ✨ Feature

대회 참가자 표시할 때 닉네임 -> 게임Id로 변경
대진표를 보여줄 때 자신이 참가하고 있으면 표시해주는 기능 추가
라운드를 나열해줄 때 현재 경기가 진행중인 라운드가 있으면 표시해주는 기능 추가

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #212 