### PR TITLE
feat#105: 채널의 상태 업데이트 API 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelController.java
@@ -2,6 +2,7 @@ package leaguehub.leaguehubbackend.controller.channel;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -91,5 +92,22 @@ public class ChannelController {
         channelService.updateChannel(channelLink, updateChannelDto);
 
         return new ResponseEntity("Channel successfully updated", OK);
+    }
+
+    @Operation(summary = "채널 상태 업데이트  - 준비중(PREPARING, 0), 진행중(PROCEEDING, 1), 끝남(FINISH, 2)")
+    @Parameters(value = {
+            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
+            @Parameter(name = "status", description = "채널 진행 상태 변경 쿼리 파라미터", example = "준비중(0), 진행중(1), 끝남(2)")
+    }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", description = "채널 링크가 올바르지 않음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PutMapping("/channel/{channelLink}")
+    public ResponseEntity updateChannelStatus(@PathVariable("channelLink") String channelLink,
+                                              @RequestParam("status") Integer status) {
+        channelService.updateChannelStatus(channelLink, status);
+        return new ResponseEntity("Channel Status Successfully updated", OK);
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
@@ -94,4 +94,7 @@ public class Channel extends BaseTimeEntity {
         this.channelImageUrl = channelImageUrl;
     }
 
+    public void updateChannelStatus(ChannelStatus channelStatus) {
+        this.channelStatus = channelStatus;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelStatus.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelStatus.java
@@ -1,5 +1,23 @@
 package leaguehub.leaguehubbackend.entity.channel;
 
+
+import leaguehub.leaguehubbackend.exception.channel.exception.ChannelRequestException;
+
+import java.util.Arrays;
+
 public enum ChannelStatus {
-    PREPARING, PROCEEDING, FINISH
+    PREPARING(0), PROCEEDING(1), FINISH(2);
+
+    private final Integer status;
+
+    ChannelStatus(Integer status) {
+        this.status = status;
+    }
+
+    public static ChannelStatus convertStatus(Integer status) {
+        return Arrays.stream(ChannelStatus.values())
+                .filter(channelStatus -> (channelStatus.status == status))
+                .findFirst()
+                .orElseThrow(ChannelRequestException::new);
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -7,6 +7,7 @@ import leaguehub.leaguehubbackend.dto.channel.UpdateChannelDto;
 import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.entity.channel.ChannelBoard;
 import leaguehub.leaguehubbackend.entity.channel.ChannelRule;
+import leaguehub.leaguehubbackend.entity.channel.ChannelStatus;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.entity.participant.Role;
@@ -154,4 +155,11 @@ public class ChannelService {
         );
     }
 
+    public void updateChannelStatus(String channelLink, Integer status) {
+        Member member = memberService.findCurrentMember();
+        Participant participant = getParticipant(member.getId(), channelLink);
+        checkRoleHost(participant.getRole());
+
+        participant.getChannel().updateChannelStatus(ChannelStatus.convertStatus(status));
+    }
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#105 

## 📝 Description

대회 진행 상태를 업데이트 하는 API를 구현했어요. 아직은 대회가 끝나는 (FINISH) 시점에 무슨 일이 일어날지 몰라서 준비 중, 진행 중, 끝남을 한 API로 받아 채널의 상태만 변경하도록 구현했어요.

## ✨ Feature

대회 진행 상태 업데이트 API 구현

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.