### PR TITLE
Feat#185: 경기가 끝난 후 다음 매치 재배정

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
@@ -88,6 +88,7 @@ public class Participant extends BaseTimeEntity {
     public Participant approveParticipantMatch() {
         this.requestStatus = RequestStatus.DONE;
         this.role = Role.PLAYER;
+        this.participantStatus = ParticipantStatus.PROGRESS;
 
         return this;
     }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/ParticipantStatus.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/ParticipantStatus.java
@@ -1,5 +1,5 @@
 package leaguehub.leaguehubbackend.entity.participant;
 
 public enum ParticipantStatus {
-    PROGRESS, DROPOUT
+    PROGRESS, DROPOUT, DISQUALIFICATION
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
@@ -1,6 +1,7 @@
 package leaguehub.leaguehubbackend.repository.particiapnt;
 
 import leaguehub.leaguehubbackend.entity.participant.Participant;
+import leaguehub.leaguehubbackend.entity.participant.ParticipantStatus;
 import leaguehub.leaguehubbackend.entity.participant.RequestStatus;
 import leaguehub.leaguehubbackend.entity.participant.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -34,5 +35,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     Optional<Integer> findMaxIndexByParticipant(@Param("memberId") Long memberId);
 
     List<Participant> findAllByMemberIdAndAndIndexGreaterThan(Long memberId, int deleteIndex);
+
+    List<Participant> findAllByChannel_ChannelLinkAndRoleAndParticipantStatus(String channelLink, Role role,ParticipantStatus participantStatus);
 
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#185 

## 📝 Description

기존의 채널 첫 경기 배정 코드를 재사용하여 그 다음 경기를 재배정할 때 사용하는 코드를 만들었어요
해당 방식은 기존의 Participant 엔티티에 있는 ParticipanrStatus가 Progress인 사람만 가져와 경기를 배정하는 방식으로 만들었어요

아직 경기가 끝난 후 상위 4명만 진출하도록하는 서비스가 만들어져있지 않아
이후 이슈를 파서 상위 4명을 제외한 나머지를 탈락하는 서비스를 만들 예정이에요


## ✨ Feature

경기가 끝난 후 다음 매치 재배정

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #185 