### PR TITLE
Feat#217: 등수 업데이트 로직 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -104,4 +104,12 @@ public class MatchController {
     }
 
 
+
+    public ResponseEntity updateMatchPlayerPlacement(@RequestBody MatchResultUpdateDto matchResultUpdateDto) {
+        matchRankService.updateMatchPlayerPlacement(matchResultUpdateDto);
+
+        return new ResponseEntity<>("등수가 성공적으로 업데이트 되었습니다.", HttpStatus.OK);
+    }
+
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchRankResultDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchRankResultDto.java
@@ -5,8 +5,8 @@ import lombok.Data;
 @Data
 public class MatchRankResultDto {
 
-    private String name;
+    private String gameId;
 
-    private String placement;
+    private Integer placement;
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchResultUpdateDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchResultUpdateDto.java
@@ -1,0 +1,20 @@
+package leaguehub.leaguehubbackend.dto.match;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MatchResultUpdateDto {
+
+    @NotBlank
+    private Long matchId;
+
+    @NotBlank
+    private Long matchPlayerId;
+
+    @NotBlank
+    private Integer placement;
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static jakarta.persistence.FetchType.LAZY;
@@ -40,6 +42,12 @@ public class Match extends BaseTimeEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "channel_id")
     private Channel channel;
+
+    @OneToMany(fetch = LAZY, mappedBy = "match")
+    List<MatchPlayer> matchPlayerList = new ArrayList<>();
+
+    @OneToMany(fetch = LAZY, mappedBy = "match")
+    List<MatchRank> matchRankList = new ArrayList<>();
 
     @Builder
     public Match(MatchStatus matchStatus, Integer matchRound, String matchName, String matchPasswd) {

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchRank.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchRank.java
@@ -17,9 +17,7 @@ public class MatchRank extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    private String participant;
-
-    private String placement;
+    private Integer placement;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "match_result_id")
@@ -33,16 +31,15 @@ public class MatchRank extends BaseTimeEntity {
     @JoinColumn(name = "match")
     private Match match;
 
-    public static MatchRank createMatchRank(String participant, String placement, MatchResult matchResult){
+    public static MatchRank createMatchRank(MatchPlayer matchPlayer, Integer placement){
         MatchRank matchRank = new MatchRank();
-        matchRank.participant = participant;
+        matchRank.matchPlayer = matchPlayer;
         matchRank.placement = placement;
-        matchRank.matchResult = matchResult;
 
         return matchRank;
     }
 
     public void updateMatchRank(Integer placement) {
-        this.placement = placement + "등";
+        this.placement = placement;
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchRank.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchRank.java
@@ -25,6 +25,14 @@ public class MatchRank extends BaseTimeEntity {
     @JoinColumn(name = "match_result_id")
     private MatchResult matchResult;
 
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "match_player_id")
+    private MatchPlayer matchPlayer;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "match")
+    private Match match;
+
     public static MatchRank createMatchRank(String participant, String placement, MatchResult matchResult){
         MatchRank matchRank = new MatchRank();
         matchRank.participant = participant;
@@ -32,5 +40,9 @@ public class MatchRank extends BaseTimeEntity {
         matchRank.matchResult = matchResult;
 
         return matchRank;
+    }
+
+    public void updateMatchRank(Integer placement) {
+        this.placement = placement + "등";
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionCode.java
@@ -14,7 +14,8 @@ public enum MatchExceptionCode implements ExceptionCode {
 
     MATCH_NOT_FOUND(NOT_FOUND, "MA-C-001", "유효하지 않은 경기입니다."),
     MATCH_RESULT_NOT_FOUNT(NOT_FOUND, "MA-C-002", "매치 결과를 찾을 수 없습니다."),
-    MATCH_NOT_ENOUGH_PLAYER(BAD_REQUEST, "MA-C-003", "매치 인원수가 충분하지 않습니다.");
+    MATCH_NOT_ENOUGH_PLAYER(BAD_REQUEST, "MA-C-003", "매치 인원수가 충분하지 않습니다."),
+    MATCH_PLAYER_NOT_FOUND(NOT_FOUND, "MA-C-004", "매치 플레이어를 찾을 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/leaguehub/leaguehubbackend/exception/match/exception/MatchPlayerNotFoundException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/match/exception/MatchPlayerNotFoundException.java
@@ -1,0 +1,18 @@
+package leaguehub.leaguehubbackend.exception.match.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.match.MatchExceptionCode.MATCH_PLAYER_NOT_FOUND;
+
+public class MatchPlayerNotFoundException extends RuntimeException {
+    private final ExceptionCode exceptionCode;
+
+    public MatchPlayerNotFoundException() {
+        super(MATCH_PLAYER_NOT_FOUND.getMessage());
+        this.exceptionCode = MATCH_PLAYER_NOT_FOUND;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -2,6 +2,8 @@ package leaguehub.leaguehubbackend.repository.match;
 
 import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,5 +13,11 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
 
     List<MatchPlayer> findAllByMatch_MatchNameAndMatch_MatchRound(String matchName, Integer matchRound);
 
-    List<MatchPlayer> findAllByMatch_Id(Long matchId);
+    /**
+     * 매치의 매치 플레이어와 그 매치와 관련된  MatchRank, Participant를 가져온다.
+     * @param matchId
+     * @return
+     */
+    @Query("select mp from MatchPlayer mp join fetch Participant p join fetch MatchRank where mp.match.id =: matchId")
+    List<MatchPlayer> findAllByMatch_Id(@Param("matchId") Long matchId);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
@@ -2,6 +2,8 @@ package leaguehub.leaguehubbackend.repository.match;
 
 import leaguehub.leaguehubbackend.entity.match.Match;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +13,7 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
     Optional<Match> findByMatchLink(String matchLink);
 
     List<Match> findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(String channelLink, Integer matchRound);
+
+    @Query("select ma from Match ma join fetch MatchPlayer join fetch MatchRank where ma.id =: matchId")
+    Optional<Match> findMatchAndMatchPlayerAndMatchRank(@Param("matchId") Long matchId);
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#217 

## 📝 Description

등수 업데이트 로직을 구현했어요. API가 날아오면 등수를 체크하고, 만약 1등이 날아온다면 라이엇 API의 호출로 경기 정보를 불러내, 등수를 재업데이트 해요. 아직 시간 체크 같은건 없어서 나중에 넣고, 엔티티 및 테스트 오류는 따로 이슈 파서 올릴께요. 웹소켓 매핑은 나중에 한번에 추가할께요 !

## ✨ Feature

등수 업데이트 API, 매치 랭크 엔티티 리팩터 및 기능 추가

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #217 