### PR TITLE
Feat#222

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -69,7 +69,7 @@ public class MatchController {
         return new ResponseEntity<>(roundList, HttpStatus.OK);
     }
 
-    @Operation(summary = "해당 채널의 경기 첫 배정")
+    @Operation(summary = "해당 채널의 라운드 경기 배정")
     @Parameters(value = {
             @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
             @Parameter(name = "matchRound", description = "배정 싶은 매치의 라운드(1, 2 라운드)", example = "1, 2, 3, 4")
@@ -81,6 +81,7 @@ public class MatchController {
     @PostMapping("/match/{channelLink}/{matchRound}")
     public ResponseEntity assignmentMatches(@PathVariable("channelLink") String channelLink, @PathVariable("matchRound") Integer matchRound){
 
+        matchService.updateMatchPlayerStatus(channelLink, matchRound);
         matchService.matchAssignment(channelLink, matchRound);
 
         return new ResponseEntity<>("참가자들이 첫 매치에 배정되었습니다.", HttpStatus.OK);

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
@@ -119,6 +119,12 @@ public class Participant extends BaseTimeEntity {
         return this;
     }
 
+    public Participant dropoutParticipantStatus(){
+        this.participantStatus = ParticipantStatus.DROPOUT;
+
+        return this;
+    }
+
     public void newCustomChannelIndex(Optional<Integer> index) {
         this.index = index.map(i -> i + 1).orElseGet(() -> 0);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -2,6 +2,8 @@ package leaguehub.leaguehubbackend.repository.match;
 
 import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,5 +13,6 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
 
     List<MatchPlayer> findAllByMatch_MatchNameAndMatch_MatchRound(String matchName, Integer matchRound);
 
-    List<MatchPlayer> findAllByMatch_Id(Long matchId);
+    @Query("select mp from MatchPlayer mp join fetch mp.participant where mp.match.id = :matchId")
+    List<MatchPlayer> findAllByMatch_IdOrderByPlayerScoreDesc(@Param("matchId") Long matchId);
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#222 

## 📝 Description

라운드가 완전히 끝난 후 다음 매치를 배정하기 전 상위 4명을 제외한 플레이어를 탈락시키는 서비스를 만들었어요
해당 플레이어 리스트를 찾을 때 패치조인을 사용하여 participant 상태를 업데이트 시켜 주었어요
업데이트 시켜주는 로직을 람다 스트림으로 사용할려고 하니 지역 변수가 존재하여 문제가 생겨 사용하지 못했어요

따라서 코드가 이해가 안되시는게 있으시면 질문 부탁드려요!

## ✨ Feature

매치 내 상위 플레이어 4명을 제외한 플레이어 탈락시키는 서비스
참가자(participant)의 상태를 업데이트 해주는 메서드

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #224 