### PR TITLE
feat#229: MatchSet 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchSet.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchSet.java
@@ -1,0 +1,28 @@
+package leaguehub.leaguehubbackend.entity.match;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class MatchSet {
+
+    @Id
+    @Column(name = "match_set_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "match_id")
+    private Match match;
+
+    @Column(unique = true, name = "riot_match_uuid")
+    private String riotMatchUuid;
+
+    private Boolean updateScore;
+
+    private Integer matchSet;
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchSetRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchSetRepository.java
@@ -1,0 +1,7 @@
+package leaguehub.leaguehubbackend.repository.match;
+
+import leaguehub.leaguehubbackend.entity.match.MatchSet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchSetRepository extends JpaRepository<MatchSet, Long> {
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue

#229 

## 📝 Description

DB 테이블 추가에 따른 matchSet엔티티를 추가했어요. Repository도 만들어놨어요. matchSet은 매치의 세트를 가리키는 엔티티인데, 안에는 라이엇 고유 매치Id와 해당 매치 세트가 몇 세트인지 저장하고, 해당 매치 세트로 점수를 업데이트 했는지 유무를 판단하는 컬럼을 넣어서 같은 경기로 두 번 업데이트를 하지 못하게 막아놨어요.

## ✨ Feature

MatchSet 엔티티, 레포지토리 구현

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #229 