### PR TITLE
Feat#232: 대회 플레이어의 탈락, 실격 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/ParticipantController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/ParticipantController.java
@@ -132,6 +132,24 @@ public class ParticipantController {
         return new ResponseEntity<>("reject participant", OK);
     }
 
+    @Operation(summary = "플레이어 실격처리", description = "관리자가 해당 게임 플레이어를 실격처리")
+    @Parameters(value = {
+            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
+            @Parameter(name = "participantId", description = "해당 채널 참가자의 고유 Id", example = "1")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "실격 처리 되었습니다."),
+            @ApiResponse(responseCode = "404", description = "채널 참가자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/{channelLink}/{participantId}/disqualification")
+    public ResponseEntity disqualifiedParticipant(@PathVariable("channelLink") String channelLink,
+                                              @PathVariable("participantId") Long participantId) {
+
+        participantService.disqualifiedParticipant(channelLink, participantId);
+
+        return new ResponseEntity<>("disqualified participant", OK);
+    }
+
     @Operation(summary = "관리자 권한 부여", description = "관리자가 관전자에게 권한을 부여")
     @Parameters(value = {
             @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
@@ -101,6 +101,12 @@ public class Participant extends BaseTimeEntity {
         return this;
     }
 
+    public Participant disqualificationParticipant(){
+        this.participantStatus = ParticipantStatus.DISQUALIFICATION;
+
+        return this;
+    }
+
 
     public Participant updateParticipantStatus(String gameId, String gameTier, String nickname) {
         this.gameId = gameId;

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -179,18 +179,16 @@ public class ParticipantService {
      * @param participantId
      */
     public void approveParticipantRequest(String channelLink, Long participantId) {
-
         Participant participant = getParticipant(channelLink);
         checkRoleHost(participant.getRole());
-        Channel channel = participant.getChannel();
 
-        checkRealPlayerCount(channel);
+        checkRealPlayerCount(participant.getChannel());
 
         Participant findParticipant = getFindParticipant(channelLink, participantId);
 
         findParticipant.approveParticipantMatch();
 
-        updateRealPlayerCount(channelLink, channel);
+        updateRealPlayerCount(channelLink, participant.getChannel());
     }
 
 
@@ -212,6 +210,12 @@ public class ParticipantService {
         updateRealPlayerCount(channelLink, participant.getChannel());
     }
 
+    public void disqualifiedParticipant(String channelLink, Long participantId){
+        Participant findParticipant = checkHostAndGetParticipant(channelLink, participantId);
+
+        findParticipant.disqualificationParticipant();
+    }
+
     /**
      * 사용자를 관리자로 권한을 변경한다.
      *
@@ -219,10 +223,7 @@ public class ParticipantService {
      * @param participantId
      */
     public void updateHostRole(String channelLink, Long participantId) {
-        Participant participant = getParticipant(channelLink);
-        checkRoleHost(participant.getRole());
-
-        Participant findParticipant = getFindParticipant(channelLink, participantId);
+        Participant findParticipant = checkHostAndGetParticipant(channelLink, participantId);
 
         findParticipant.updateHostRole();
     }
@@ -240,7 +241,6 @@ public class ParticipantService {
         if (category.equals(0)) {
             userGameInfoDto = getTierAndPlayCount(gameId);
         }
-
 
         return userGameInfoDto;
     }
@@ -368,6 +368,14 @@ public class ParticipantService {
 
         channel.updateRealPlayer(playerLists.size());
     }
+
+    private Participant checkHostAndGetParticipant(String channelLink, Long participantId) {
+        Participant participant = getParticipant(channelLink);
+        checkRoleHost(participant.getRole());
+
+        return getFindParticipant(channelLink, participantId);
+    }
+
 
 
     /**

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -190,12 +190,9 @@ public class ParticipantService {
 
         findParticipant.approveParticipantMatch();
 
-        List<Participant> playerLists = participantRepository
-                .findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, PLAYER, DONE);
-
-
-        channel.updateRealPlayer(playerLists.size());
+        updateRealPlayerCount(channelLink, channel);
     }
+
 
     /**
      * 해당 채널의 요청한 참가자를 거절함
@@ -207,9 +204,12 @@ public class ParticipantService {
         Participant participant = getParticipant(channelLink);
         checkRoleHost(participant.getRole());
 
+
         Participant findParticipant = getFindParticipant(channelLink, participantId);
 
         findParticipant.rejectParticipantRequest();
+
+        updateRealPlayerCount(channelLink, participant.getChannel());
     }
 
     /**
@@ -360,6 +360,13 @@ public class ParticipantService {
         Participant findParticipant = participantRepository.findParticipantByIdAndChannel_ChannelLink(participantId, channelLink)
                 .orElseThrow(ParticipantNotFoundException::new);
         return findParticipant;
+    }
+
+    private void updateRealPlayerCount(String channelLink, Channel channel) {
+        List<Participant> playerLists = participantRepository
+                .findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, PLAYER, DONE);
+
+        channel.updateRealPlayer(playerLists.size());
     }
 
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#232 

## 📝 Description

채널에서 대회 플레이어에 대한 탈락, 실격 서비스를 구현하였어요
대회시작 전 관리자는 플레이어를 탈락시킬 수 있으며 탈락을 하였을 때 현재 참가된 플레이어 수를 업데이트 시켜요
대회시작 후 관리자는 플레이어를 실격시킬 수 있으며 현재 역할을 유지하며 참가 상태만 바뀌게 만들 수 있어요



## ✨ Feature

참가자 탈락 기능에 플레이어 수 업데이트 하는 메서드 추가
참가자 실격 기능

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #232 