### PR TITLE
Fix#238: 쿼리문 수정 및 메서드 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -18,4 +18,7 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
     @Query("select mp from MatchPlayer mp join fetch mp.participant where mp.match.id = :matchId")
     List<MatchPlayer> findAllByMatch_IdOrderByPlayerScoreDesc(@Param("matchId") Long matchId);
 
+    @Query("select mp from MatchPlayer mp join fetch mp.participant join fetch mp.match where mp.match.id =: matchId")
+    List<MatchPlayer> findMatchPlayersAndMatchAndParticipantByMatchId(@Param("matchId") Long matchId);
+
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#238 

## 📝 Description

fetch join에서 엔티티를 전부 들고 오게 쿼리를 썼는데 mp.match 이렇게 관련된 엔티티만 들고 올 수 있도록 바꿨어요. 그리고 이전 #228 에서 컨플릭트를 해결하다가 메서드가 누락되서 추가했어요.

## ✨ Feature

메서드 누락 추가, 쿼리문 수정

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #238 