### PR TITLE
Fix#240: 중괄호 누락 문제 수정 및 불 필요한 필드명 삭제

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -11,7 +11,6 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
 
     List<MatchPlayer> findAllByMatch_Id(Long matchId);
 
-    List<MatchPlayer> findAllByMatch_MatchLinkAndMatch_MatchName(String matchLink, String matchName);
 
     List<MatchPlayer> findAllByMatch_MatchNameAndMatch_MatchRound(String matchName, Integer matchRound);
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -97,7 +97,7 @@ public class MatchService {
 
         List<Match> matchList = findMatchList(channelLink, matchRound);
 
-        if(!participant.getChannel().getMaxPlayer().equals(matchRound))
+        if (!participant.getChannel().getMaxPlayer().equals(matchRound))
             checkUpdateScore(matchList);
 
         List<Participant> playerList = getParticipantList(channelLink, matchRound);
@@ -147,8 +147,8 @@ public class MatchService {
 
     private void findLiveRound(String channelLink, List<Integer> roundList, MatchRoundListDto roundListDto) {
         roundList.forEach(round -> {
-            List<Match> matchList = findMatchList(channelLink, round);
-            matchList.stream()
+                    List<Match> matchList = findMatchList(channelLink, round);
+                    matchList.stream()
                             .filter(match -> match.getMatchStatus().equals(MatchStatus.PROGRESS))
                             .findFirst()
                             .ifPresent(match -> roundListDto.setLiveRound(match.getMatchRound()));
@@ -290,6 +290,7 @@ public class MatchService {
                 ))
                 .sorted(Comparator.comparingInt(MatchPlayerInfo::getScore).reversed())
                 .collect(Collectors.toList());
+    }
 
     private Participant checkHost(String channelLink) {
         Member member = memberService.findCurrentMember();


### PR DESCRIPTION
## 🙆‍♂️ Issue

#240 

## 📝 Description

#239 에 컨플릭트 해결단계에서 matchService에 대한 중괄호가 하나 누락되었어요
해당 문제를 해결했으며 matchPlayerRepository에서 이미 삭제된 필드명 matchLink를 사용하는 메서드를 삭제하였어

## ✨ Feature

 matchService 중괄호 누락 수정
 이전에 삭제한 matchLink가 사용되는 메서드 삭제

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #240 