### PR TITLE
Feat#226 유저 준비 상태 완료

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/config/StompHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/StompHandler.java
@@ -32,7 +32,7 @@ public class StompHandler implements ChannelInterceptor {
             Optional<String> accessToken = jwtService.extractAccessToken(accessor);
 
             if (accessToken.isEmpty()) {
-                log.info("Stomp : 토큰 기간 만료됨");
+                log.info("Stomp : 토큰이 헤더에 없음");
                 throw new AuthTokenNotFoundException();
             }
             if (jwtService.isTokenExpired(accessToken.get())) {

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -8,17 +8,20 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import leaguehub.leaguehubbackend.dto.match.MatchInfoDto;
-import leaguehub.leaguehubbackend.dto.match.MatchRoundInfoDto;
-import leaguehub.leaguehubbackend.dto.match.MatchRoundListDto;
+import leaguehub.leaguehubbackend.dto.match.*;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.match.MatchPlayerService;
 import leaguehub.leaguehubbackend.service.match.MatchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static org.springframework.http.HttpStatus.OK;
 
@@ -30,6 +33,7 @@ public class MatchController {
 
     private final MatchPlayerService matchPlayerService;
     private final MatchService matchService;
+    private final SimpMessagingTemplate simpMessagingTemplate;
 
     @Operation(summary = "라운드 수(몇 강) 리스트 반환")
     @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
@@ -93,4 +97,15 @@ public class MatchController {
 
         return new ResponseEntity(matchInfo, OK);
     }
+
+    @MessageMapping("/match/{matchId}")
+    public void receiveNote(@DestinationVariable Long matchId, @Payload MatchSetReadyMessage message) {
+
+        matchPlayerService.markPlayerAsReady(message, matchId);
+
+        List<MatchSetStatusMessage> allPlayerStatus = matchPlayerService.getAllPlayerStatusForMatch(matchId);
+
+        simpMessagingTemplate.convertAndSend("/match/" + matchId, allPlayerStatus);
+    }
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -99,13 +99,14 @@ public class MatchController {
     }
 
     @MessageMapping("/match/{matchId}")
-    public void receiveNote(@DestinationVariable Long matchId, @Payload MatchSetReadyMessage message) {
+    @SendTo("/match/{matchId}")
+    public List<MatchSetStatusMessage> receiveNote(@DestinationVariable Long matchId, @Payload MatchSetReadyMessage message) {
 
         matchPlayerService.markPlayerAsReady(message, matchId);
 
         List<MatchSetStatusMessage> allPlayerStatus = matchPlayerService.getAllPlayerStatusForMatch(matchId);
 
-        simpMessagingTemplate.convertAndSend("/match/" + matchId, allPlayerStatus);
+        return allPlayerStatus;
     }
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchSetReadyMessage.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchSetReadyMessage.java
@@ -1,0 +1,12 @@
+package leaguehub.leaguehubbackend.dto.match;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Data
+@ToString
+public class MatchSetReadyMessage {
+    private Long matchPlayerId;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchSetStatusMessage.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchSetStatusMessage.java
@@ -1,0 +1,12 @@
+package leaguehub.leaguehubbackend.dto.match;
+
+import leaguehub.leaguehubbackend.entity.match.PlayerStatus;
+import lombok.*;
+
+@AllArgsConstructor
+@Data
+@ToString
+public class MatchSetStatusMessage {
+    private Long playerId;
+    private PlayerStatus status;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
@@ -44,4 +44,5 @@ public class MatchPlayer extends BaseTimeEntity {
     public void updateMatchPlayerScore(Integer placement) {
         this.playerScore += 9 - placement;
     }
+    public void changeStatusToReady() { this.playerStatus = PlayerStatus.READY; }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/match/MatchExceptionCode.java
@@ -15,7 +15,9 @@ public enum MatchExceptionCode implements ExceptionCode {
     MATCH_NOT_FOUND(NOT_FOUND, "MA-C-001", "유효하지 않은 경기입니다."),
     MATCH_RESULT_NOT_FOUNT(NOT_FOUND, "MA-C-002", "매치 결과를 찾을 수 없습니다."),
     MATCH_NOT_ENOUGH_PLAYER(BAD_REQUEST, "MA-C-003", "매치 인원수가 충분하지 않습니다."),
-    MATCH_ALREADY_UPDATE(BAD_REQUEST, "MA-C-004", "이미 매치의 점수가 업데이트 되었습니다.");
+    MATCH_ALREADY_UPDATE(BAD_REQUEST, "MA-C-004", "이미 매치의 점수가 업데이트 되었습니다."),
+    MATCH_PLAYER_NOT_FOUND(NOT_FOUND, "MA-C-005", "해당 매치 플레이어가 없습니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/leaguehub/leaguehubbackend/exception/match/exception/MatchPlayerNotFoundException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/match/exception/MatchPlayerNotFoundException.java
@@ -1,0 +1,20 @@
+package leaguehub.leaguehubbackend.exception.match.exception;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.match.MatchExceptionCode.MATCH_PLAYER_NOT_FOUND;
+
+
+public class MatchPlayerNotFoundException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public MatchPlayerNotFoundException(){
+        super(MATCH_PLAYER_NOT_FOUND.getMessage());
+        this.exceptionCode = MATCH_PLAYER_NOT_FOUND;
+    }
+
+    public ExceptionCode getExceptionCode(){
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -6,11 +6,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> {
 
     List<MatchPlayer> findAllByMatch_Id(Long matchId);
-
 
     List<MatchPlayer> findAllByMatch_MatchNameAndMatch_MatchRound(String matchName, Integer matchRound);
 
@@ -19,5 +19,8 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
 
     @Query("select mp from MatchPlayer mp join fetch mp.participant join fetch mp.match where mp.match.id =: matchId")
     List<MatchPlayer> findMatchPlayersAndMatchAndParticipantByMatchId(@Param("matchId") Long matchId);
+
+    @Query("select mp from MatchPlayer mp where mp.participant.id = :participantId and mp.match.id = :matchId")
+    Optional<MatchPlayer> findMatchPlayerByParticipantIdAndMatchId(@Param("participantId") Long participantId, @Param("matchId") Long matchId);
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -20,7 +20,6 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
     @Query("select mp from MatchPlayer mp join fetch mp.participant join fetch mp.match where mp.match.id =: matchId")
     List<MatchPlayer> findMatchPlayersAndMatchAndParticipantByMatchId(@Param("matchId") Long matchId);
 
-    @Query("select mp from MatchPlayer mp where mp.participant.id = :participantId and mp.match.id = :matchId")
-    Optional<MatchPlayer> findMatchPlayerByParticipantIdAndMatchId(@Param("participantId") Long participantId, @Param("matchId") Long matchId);
+    Optional<MatchPlayer> findByParticipantIdAndMatchId(Long participantId, Long matchId);
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
     List<Match> findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(String channelLink, Integer matchRound);
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -217,17 +217,20 @@ public class MatchPlayerService {
         return matchSet;
     }
 
+    private MatchPlayer findMatchPlayer(Long matchPlayerId, Long matchId) {
+        return matchPlayerRepository.findByParticipantIdAndMatchId(matchPlayerId, matchId)
+                .orElseThrow(MatchPlayerNotFoundException::new);
+    }
+
     @Transactional
     public void markPlayerAsReady(MatchSetReadyMessage message, Long matchId) {
 
         Long matchPlayerId = message.getMatchPlayerId();
 
-        MatchPlayer matchPlayer = matchPlayerRepository.findMatchPlayerByParticipantIdAndMatchId(matchPlayerId, matchId)
-                .orElseThrow(MatchPlayerNotFoundException::new);
+        MatchPlayer matchPlayer = findMatchPlayer(matchPlayerId, matchId);
 
         matchPlayer.changeStatusToReady();
         matchPlayerRepository.save(matchPlayer);
-
     }
 
     public List<MatchSetStatusMessage> getAllPlayerStatusForMatch(Long matchId) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -1,8 +1,6 @@
 package leaguehub.leaguehubbackend.service.match;
 
-import leaguehub.leaguehubbackend.dto.match.MatchInfoDto;
-import leaguehub.leaguehubbackend.dto.match.MatchRankResultDto;
-import leaguehub.leaguehubbackend.dto.match.RiotAPIDto;
+import leaguehub.leaguehubbackend.dto.match.*;
 import leaguehub.leaguehubbackend.entity.match.Match;
 import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
 import leaguehub.leaguehubbackend.entity.match.MatchSet;
@@ -10,6 +8,7 @@ import leaguehub.leaguehubbackend.entity.match.MatchStatus;
 import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchAlreadyUpdateException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchNotFoundException;
+import leaguehub.leaguehubbackend.exception.match.exception.MatchPlayerNotFoundException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchResultIdNotFoundException;
 import leaguehub.leaguehubbackend.exception.participant.exception.ParticipantGameIdNotFoundException;
 import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
@@ -29,6 +28,7 @@ import reactor.core.publisher.Mono;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -215,5 +215,30 @@ public class MatchPlayerService {
         }
 
         return matchSet;
+    }
+
+    @Transactional
+    public void markPlayerAsReady(MatchSetReadyMessage message, Long matchId) {
+
+        Long matchPlayerId = message.getMatchPlayerId();
+
+        MatchPlayer matchPlayer = matchPlayerRepository.findMatchPlayerByParticipantIdAndMatchId(matchPlayerId, matchId)
+                .orElseThrow(MatchPlayerNotFoundException::new);
+
+        matchPlayer.changeStatusToReady();
+        matchPlayerRepository.save(matchPlayer);
+
+    }
+
+    public List<MatchSetStatusMessage> getAllPlayerStatusForMatch(Long matchId) {
+        List<MatchPlayer> matchPlayers = matchPlayerRepository.findAllByMatch_Id(matchId);
+
+        if (matchPlayers.isEmpty()) {
+            throw new MatchNotFoundException();
+        }
+
+        return matchPlayers.stream()
+                .map(mp -> new MatchSetStatusMessage (mp.getId(), mp.getPlayerStatus()))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#226 

## 📝 Description

특정 매치에 대해 유저가 준비 상태를 하면 해당 매치플레이어를 준비상태로 변경합니다.

그 후 해당 유저가 참여하고 있는 match의 모든 match_player의 정보를 소켓을 사용하여 반환합니다.

## ✨ Feature

1. 특정 매치에 유저가 준비완료 신청시 그유저를 준비 상태로 변경
2. 해당 유저가 참여하고 있는 경기의 모든 플레이어의 준비 상태 반환

## 👌 Review Change
This closes #226 
리뷰를 통해 수정한 부분을 나열해주세요.