### PR TITLE
Feat#215 : 매치 준비 화면 조회

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import leaguehub.leaguehubbackend.dto.match.MatchInfoDto;
 import leaguehub.leaguehubbackend.dto.match.MatchRoundInfoDto;
 import leaguehub.leaguehubbackend.dto.match.MatchRoundListDto;
+import leaguehub.leaguehubbackend.dto.match.MatchScoreInfoDto;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.match.MatchPlayerService;
 import leaguehub.leaguehubbackend.service.match.MatchService;
@@ -93,4 +94,13 @@ public class MatchController {
 
         return new ResponseEntity(matchInfo, OK);
     }
+
+    @GetMapping("/match/{matchId}/player/info")
+    public ResponseEntity loadMatchScore(@PathVariable("matchId") Long matchId) {
+
+        MatchScoreInfoDto matchScoreInfoDto = matchService.getMatchScoreInfo(matchId);
+
+        return new ResponseEntity<>(matchScoreInfoDto, OK);
+    }
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerScoreInfo.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerScoreInfo.java
@@ -1,0 +1,23 @@
+package leaguehub.leaguehubbackend.dto.match;
+
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MatchPlayerScoreInfo {
+
+    private Long matchPlayerId;
+
+    private Long participantId;
+
+    private Integer matchRank;
+
+    private String participantImageUrl;
+
+    private String participantGameId;
+
+    private Integer playerScore;
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchScoreInfoDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchScoreInfoDto.java
@@ -1,0 +1,14 @@
+package leaguehub.leaguehubbackend.dto.match;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class MatchScoreInfoDto {
+    private String requestMatchPlayerId;
+
+    private List<MatchPlayerScoreInfo> matchPlayerScoreInfos;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -17,7 +17,7 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
     @Query("select mp from MatchPlayer mp join fetch mp.participant where mp.match.id = :matchId")
     List<MatchPlayer> findAllByMatch_IdOrderByPlayerScoreDesc(@Param("matchId") Long matchId);
 
-    @Query("select mp from MatchPlayer mp join fetch mp.participant join fetch mp.match where mp.match.id =: matchId")
+    @Query("select mp from MatchPlayer mp join fetch mp.participant join fetch mp.match where mp.match.id = :matchId")
     List<MatchPlayer> findMatchPlayersAndMatchAndParticipantByMatchId(@Param("matchId") Long matchId);
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -1,9 +1,6 @@
 package leaguehub.leaguehubbackend.service.match;
 
-import leaguehub.leaguehubbackend.dto.match.MatchInfoDto;
-import leaguehub.leaguehubbackend.dto.match.MatchPlayerInfo;
-import leaguehub.leaguehubbackend.dto.match.MatchRoundInfoDto;
-import leaguehub.leaguehubbackend.dto.match.MatchRoundListDto;
+import leaguehub.leaguehubbackend.dto.match.*;
 import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.entity.match.Match;
 import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
@@ -13,6 +10,7 @@ import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.entity.participant.Role;
 import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchNotEnoughPlayerException;
+import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
 import leaguehub.leaguehubbackend.exception.participant.exception.InvalidParticipantAuthException;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
 import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
@@ -23,10 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -323,4 +318,73 @@ public class MatchService {
         }
 
     }
+
+    public MatchScoreInfoDto getMatchScoreInfo(Long matchId) {
+        Member member = memberService.findCurrentMember();
+
+        List<MatchPlayer> matchPlayers = matchPlayerRepository.findMatchPlayersAndMatchAndParticipantByMatchId(matchId);
+
+        List<MatchPlayerScoreInfo> matchPlayerScoreInfoList = convertToMatchPlayerScoreInfoList(matchPlayers);
+
+        sortAndRankMatchPlayerScoreInfoList(matchPlayerScoreInfoList);
+
+        String requestMatchPlayerId = findRequestMatchPlayerId(member, matchPlayers);
+
+        MatchScoreInfoDto matchScoreInfoDto = MatchScoreInfoDto.builder()
+                .matchPlayerScoreInfos(matchPlayerScoreInfoList)
+                .requestMatchPlayerId(requestMatchPlayerId)
+                .build();
+
+        return matchScoreInfoDto;
+    }
+
+    private List<MatchPlayerScoreInfo> convertToMatchPlayerScoreInfoList(List<MatchPlayer> matchPlayers) {
+        List<MatchPlayerScoreInfo> matchPlayerScoreInfoList = new ArrayList<>();
+
+        for (MatchPlayer mp : matchPlayers) {
+            MatchPlayerScoreInfo info = MatchPlayerScoreInfo.builder()
+                    .matchPlayerId(mp.getId())
+                    .participantId(mp.getParticipant().getId())
+                    .participantImageUrl(mp.getParticipant().getProfileImageUrl())
+                    .participantGameId(mp.getParticipant().getGameId())
+                    .playerScore(mp.getPlayerScore())
+                    .build();
+
+            matchPlayerScoreInfoList.add(info);
+        }
+
+        return matchPlayerScoreInfoList;
+    }
+
+    private void sortAndRankMatchPlayerScoreInfoList(List<MatchPlayerScoreInfo> matchPlayerScoreInfoList) {
+        sortMatchPlayerScoreInfoList(matchPlayerScoreInfoList);
+        assignRankToMatchPlayerScoreInfoList(matchPlayerScoreInfoList);
+    }
+
+    private void sortMatchPlayerScoreInfoList(List<MatchPlayerScoreInfo> matchPlayerScoreInfoList) {
+        matchPlayerScoreInfoList.sort(Comparator
+                .comparing(MatchPlayerScoreInfo::getPlayerScore).reversed()
+                .thenComparing(MatchPlayerScoreInfo::getParticipantGameId));
+    }
+
+    private void assignRankToMatchPlayerScoreInfoList(List<MatchPlayerScoreInfo> matchPlayerScoreInfoList) {
+        int rank = 1;
+        for (int i = 0; i < matchPlayerScoreInfoList.size(); i++) {
+            MatchPlayerScoreInfo info = matchPlayerScoreInfoList.get(i);
+            if (i > 0 && !info.getPlayerScore().equals(matchPlayerScoreInfoList.get(i - 1).getPlayerScore())) {
+                rank = i + 1;
+            }
+            info.setMatchRank(rank);
+        }
+    }
+
+    private String findRequestMatchPlayerId(Member member, List<MatchPlayer> matchPlayers) {
+        for (MatchPlayer mp : matchPlayers) {
+            if (mp.getParticipant().getMember().getId().equals(member.getId())) {
+                return mp.getId().toString();
+            }
+        }
+        throw new MemberNotFoundException();
+    }
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -339,21 +339,15 @@ public class MatchService {
     }
 
     private List<MatchPlayerScoreInfo> convertToMatchPlayerScoreInfoList(List<MatchPlayer> matchPlayers) {
-        List<MatchPlayerScoreInfo> matchPlayerScoreInfoList = new ArrayList<>();
-
-        for (MatchPlayer mp : matchPlayers) {
-            MatchPlayerScoreInfo info = MatchPlayerScoreInfo.builder()
-                    .matchPlayerId(mp.getId())
-                    .participantId(mp.getParticipant().getId())
-                    .participantImageUrl(mp.getParticipant().getProfileImageUrl())
-                    .participantGameId(mp.getParticipant().getGameId())
-                    .playerScore(mp.getPlayerScore())
-                    .build();
-
-            matchPlayerScoreInfoList.add(info);
-        }
-
-        return matchPlayerScoreInfoList;
+        return matchPlayers.stream()
+                .map(mp -> MatchPlayerScoreInfo.builder()
+                        .matchPlayerId(mp.getId())
+                        .participantId(mp.getParticipant().getId())
+                        .participantImageUrl(mp.getParticipant().getProfileImageUrl())
+                        .participantGameId(mp.getParticipant().getGameId())
+                        .playerScore(mp.getPlayerScore())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     private void sortAndRankMatchPlayerScoreInfoList(List<MatchPlayerScoreInfo> matchPlayerScoreInfoList) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -42,6 +42,7 @@ public class MatchService {
     private final ChannelRepository channelRepository;
     private final ParticipantRepository participantRepository;
     private final MemberService memberService;
+    private static final int INITIAL_RANK = 1;
 
 
     /**
@@ -360,9 +361,8 @@ public class MatchService {
                 .comparing(MatchPlayerScoreInfo::getPlayerScore).reversed()
                 .thenComparing(MatchPlayerScoreInfo::getParticipantGameId));
     }
-
     private void assignRankToMatchPlayerScoreInfoList(List<MatchPlayerScoreInfo> matchPlayerScoreInfoList) {
-        int rank = 1;
+        int rank = INITIAL_RANK;
         for (int i = 0; i < matchPlayerScoreInfoList.size(); i++) {
             MatchPlayerScoreInfo info = matchPlayerScoreInfoList.get(i);
             if (i > 0 && !info.getPlayerScore().equals(matchPlayerScoreInfoList.get(i - 1).getPlayerScore())) {


### PR DESCRIPTION
## 🙆‍♂️ Issue

#215 

## 📝 Description

현재 진행중인 게임에 대해 정보 요청시 점수 기준으로 정렬하여 클라이언트에게 전달을 합니다.

테스트코드, 스웨거는 따로 이슈를 생성하여 올리겠습니다.

![화면 캡처 2023-09-03 174911](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/9973491a-796c-49c5-a0be-70e0e02457aa)

## ✨ Feature

1. 현재 진행중인 매치에 대해 점수 기준으로 정렬 후 전달
2. 동일 점수 시 gameId기준으로 정렬

## 👌 Review Change
This closes #215 
리뷰를 통해 수정한 부분을 나열해주세요.