### PR TITLE
Refactor#244: 대진표 요청 시 필요한 값 수정

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerInfo.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerInfo.java
@@ -22,6 +22,9 @@ public class MatchPlayerInfo {
     @Schema(description = "참가자 점수", example = "8(점), 5(점), ...")
     private Integer score;
 
+    @Schema(description = "참가자 프로필 이미지 주소", example = "https://league.s3.ap-northeast-2.amazonaws.com/imgSrc.png")
+    private String profileSrc;
+
 
     @Builder
     public MatchPlayerInfo(String gameId, String gameTier, PlayerStatus playerStatus, Integer score) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -257,6 +257,7 @@ public class MatchService {
                     matchPlayerInfo.setGameTier(matchPlayer.getParticipant().getGameTier());
                     matchPlayerInfo.setPlayerStatus(matchPlayer.getPlayerStatus());
                     matchPlayerInfo.setScore(matchPlayer.getPlayerScore());
+                    matchPlayerInfo.setProfileSrc(matchPlayer.getParticipant().getProfileImageUrl());
                     return matchPlayerInfo;
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 🙆‍♂️ Issue

#244 

## 📝 Description

프론트의 요청에 따라 대진표를 요청할 때 플레이어의 정보에서 필요한 값을 추가하였어요
해당 값은 S3에서 저장한 이미지 url을 사용하는 프로필 이미지 주소에요

## ✨ Feature

대진표 요청 시 반환되는 dto 값 수정
대진표의 플레이어 정보에 이미지 주소 설정하는 코드 추가

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #244 