### PR TITLE
Fix#248: 관리자 여러 명일 때 반환되는 값 수정

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/particiapnt/ParticipantRepository.java
@@ -27,7 +27,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     List<Participant> findAllByChannel_ChannelLink(String channelLink);
 
-    Participant findParticipantByRoleAndChannel_ChannelLinkOrderById(Role role, String channelLink);
+    List<Participant> findParticipantByRoleAndChannel_ChannelLinkOrderById(Role role, String channelLink);
 
     Optional<Participant> findParticipantByMemberIdAndChannel_Id(Long memberId, Long channelId);
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -69,7 +69,7 @@ public class ParticipantService {
     }
 
     public String findChannelHost(String channelLink) {
-        return participantRepository.findParticipantByRoleAndChannel_ChannelLinkOrderById(HOST, channelLink).getNickname();
+        return participantRepository.findParticipantByRoleAndChannel_ChannelLinkOrderById(HOST, channelLink).get(0).getNickname();
     }
 
     /**
@@ -81,7 +81,6 @@ public class ParticipantService {
     public Participant participateChannel(String channelLink) {
 
         Member member = memberService.findCurrentMember();
-        checkEmail(member.getBaseRole());
 
         Channel channel = channelService.getChannel(channelLink);
 
@@ -427,12 +426,14 @@ public class ParticipantService {
     }
 
     public void duplicateParticipant(Member member, String channelLink) {
-        participantRepository.findParticipantByMemberIdAndChannel_ChannelLink(member.getId(), channelLink)
-                .ifPresent(participant -> duplicatePlayerIdCheck(participant));
+        Optional<Participant> existingParticipant = participantRepository.findParticipantByMemberIdAndChannel_ChannelLink(member.getId(), channelLink);
+
+        if (existingParticipant.isPresent()) {
+            duplicatePlayerIdCheck();
+        }
     }
 
-
-    private void duplicatePlayerIdCheck(Participant participant) {
+    private void duplicatePlayerIdCheck() {
         throw new ParticipantDuplicatedGameIdException();
     }
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#248 

## 📝 Description

관리자가 한 명이 아닌 여러 명을 받기로 함에 따라 채널을 불러올 때 관리자는 한 명이 아닌 여려 명이 될 수 있어요
해당 오류는 한 명이 아닌 여러 명일 때 발생하는 오류로 
Reposiotry에서 관리자를 여려 명으로 불러오며 해당 리스트의 첫 번째 index를 반환하는 걸로 수정하였어요

## ✨ Feature

관리자 여러 명일 때 반환되는 값 수정

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #248 