### PR TITLE
Feat#202: 해당 채널의 라운드 당 경기 횟수 개별 설정 기능 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -135,4 +135,22 @@ public class MatchController {
         return new ResponseEntity<>(matchScoreInfoDto, OK);
     }
 
+    @Operation(summary = "해당 채널의 (1, 2, 3)라운드에 대한 경기 횟수 설정")
+    @Parameters(value = {
+            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
+            @Parameter(name = "roundCountList", description = "설정할려는 횟수 배열", example = "[3, 4, 2, 1]")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "경기 횟수가 배정되었습니다."),
+            @ApiResponse(responseCode = "403", description = "매치 또는 채널을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/match/{channelLink}/count")
+    public ResponseEntity setMatchRoundCount(@PathVariable("channelLink") String channelLink,
+                                             @RequestBody List<Integer> roundCountList){
+
+        matchService.setMatchRoundCount(channelLink, roundCountList);
+
+        return new ResponseEntity("경기 횟수가 배정되었습니다.", OK);
+    }
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -61,4 +61,6 @@ public class Match extends BaseTimeEntity {
     public void updateMatchStatus(MatchStatus matchStatus) {
         this.matchStatus = matchStatus;
     }
+
+    public void updateMatchRoundMaxCount(Integer roundMaxCount) { this.roundMaxCount = roundMaxCount; }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface MatchRepository extends JpaRepository<Match, Long> {
     List<Match> findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(String channelLink, Integer matchRound);
 
+    List<Match> findAllByChannel_ChannelLink(String channelLink);
+
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#202 

## 📝 Description

원하는 채널의 매치에 대한 경기 횟수를 설정하는 서비스를 만들었어요
해당 서비스는 클라이언트로부터 경기 횟수 리스트를 받아 설정하도록 만들었어요

경기 횟수를 설정한 후 matchSet을 언제 생성하는지에 대한 내용은 회의 때 얘기해봐야할 것 같아요

## ✨ Feature

해당 채널 안 매치 경기 횟수를 설정하는 기능 구현

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #202 