### PR TITLE
Feat#264 : 이메일 인증토큰 폼 변경

### DIFF
--- a/src/main/resources/static/emailTemplate.html
+++ b/src/main/resources/static/emailTemplate.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>Email Confirmation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+        body,
+        table,
+        td,
+        a {
+            -ms-text-size-adjust: 100%;
+            -webkit-text-size-adjust: 100%;
+        }
+        table,
+        td {
+            mso-table-rspace: 0pt;
+            mso-table-lspace: 0pt;
+        }
+        img {
+            -ms-interpolation-mode: bicubic;
+        }
+        a[x-apple-data-detectors] {
+            font-family: inherit !important;
+            font-size: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+        div[style*="margin: 16px 0;"] {
+            margin: 0 !important;
+        }
+        body {
+            width: 100% !important;
+            height: 100% !important;
+            padding: 0 !important;
+            margin: 0 !important;
+        }
+        table {
+            border-collapse: collapse !important;
+        }
+        a {
+            color: #1a82e2;
+        }
+        img {
+            height: auto;
+            line-height: 100%;
+            text-decoration: none;
+            border: 0;
+            outline: none;
+        }
+    </style>
+
+</head>
+<body style="background-color: #e9ecef;">
+
+<div class="preheader" style="display: none; max-width: 0; max-height: 0; overflow: hidden; font-size: 1px; line-height: 1px; color: #fff; opacity: 0;">
+    리그허브 이메일 인증
+</div>
+
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+
+    <tr>
+        <td align="center" bgcolor="#e9ecef">
+            <!--[if (gte mso 9)|(IE)]>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+                <tr>
+                    <td align="center" valign="top" width="600">
+            <![endif]-->
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+                <tr>
+                    <td align="center" valign="top" style="padding: 36px 24px;">
+                        <a href="https://www.leagueHub.com" target="_blank" style="display: inline-block;">
+                            <img src="https://avatars.githubusercontent.com/u/133736202?s=200&v=4" alt="Logo" border="0" width="48" style="display: block; width: 48px; max-width: 48px; min-width: 48px;">
+                        </a>
+                    </td>
+                </tr>
+            </table>
+            <!--[if (gte mso 9)|(IE)]>
+            </td>
+            </tr>
+            </table>
+            <![endif]-->
+        </td>
+    </tr>
+    <tr>
+        <td align="center" bgcolor="#e9ecef">
+            <!--[if (gte mso 9)|(IE)]>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+                <tr>
+                    <td align="center" valign="top" width="600">
+            <![endif]-->
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+                <tr>
+                    <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
+                        <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">이메일 인증하기</h1>
+                    </td>
+                </tr>
+            </table>
+
+        </td>
+    </tr>
+    <tr>
+        <td align="center" bgcolor="#e9ecef">
+            <!--[if (gte mso 9)|(IE)]>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+                <tr>
+                    <td align="center" valign="top" width="600">
+            <![endif]-->
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+                <tr>
+                    <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+                        <p style="margin: 0;">아래의 버튼을 클릭하여 인증을 완료하세요!</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td align="left" bgcolor="#ffffff">
+                        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                            <tr>
+                                <td align="center" bgcolor="#ffffff" style="padding: 12px;">
+                                    <table border="0" cellpadding="0" cellspacing="0">
+                                        <tr>
+                                            <td align="center" bgcolor="#1a82e2" style="border-radius: 6px;">
+                                                <!-- HTML 파일의 일부 -->
+                                                <a href="{{LINK}}" target="_blank" style="display: inline-block; padding: 16px 36px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; color: #ffffff; text-decoration: none; border-radius: 6px;">인증 완료하기</a>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <!--                <tr>-->
+                <!--                    <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">-->
+                <!--                        <p style="margin: 0;">만약 이메일 인증이 실패한다면 아래 링크를 클릭해주세요</p>-->
+                <!--                        <p style="margin: 0;"><a href="https://blogdesire.com" target="_blank">https://leagueHub.com</a></p>-->
+                <!--                    </td>-->
+                <!--                </tr>-->
+
+                <tr>
+                    <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px; border-bottom: 3px solid #d4dadf">
+                        <p style="margin: 0;"><br> LeagueHub</p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+
+</table>
+</body>
+</html>

--- a/src/test/java/leaguehub/leaguehubbackend/service/email/EmailServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/email/EmailServiceTest.java
@@ -1,5 +1,7 @@
 package leaguehub.leaguehubbackend.service.email;
 
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
 import leaguehub.leaguehubbackend.entity.email.EmailAuth;
 import leaguehub.leaguehubbackend.entity.member.BaseRole;
@@ -24,6 +26,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.Assert.assertThrows;
@@ -68,6 +71,7 @@ public class EmailServiceTest {
         when(userDetails.getUsername()).thenReturn(personalId);
         when(memberRepository.findMemberByPersonalId(personalId)).thenReturn(Optional.of(member));
         when(memberService.findCurrentMember()).thenReturn(member);
+        when(mailSender.createMimeMessage()).thenReturn(new MimeMessage(Session.getDefaultInstance(new Properties())));
 
         emailService.sendEmailWithConfirmation(email);
 
@@ -123,6 +127,7 @@ public class EmailServiceTest {
         when(userDetails.getUsername()).thenReturn(personalId);
         when(memberRepository.findMemberByPersonalId(personalId)).thenReturn(Optional.of(member));
         when(memberService.findCurrentMember()).thenReturn(member);
+        when(mailSender.createMimeMessage()).thenReturn(new MimeMessage(Session.getDefaultInstance(new Properties())));
 
         emailService.sendEmailWithConfirmation(email);
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

해결한 이슈를 태그해주세요.

## 📝 Description

이메일 인증토큰을 보내는 폼 변경하였습니다.
기존 url을 버튼으로 대체하였습니다


## ✨ Feature
Before
![화면 캡처 2023-09-11 145726](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/468a91ab-af2f-4e29-af77-aba5dcc8369e)

After
![화면 캡처 2023-09-11 212327](https://github.com/TheUpperPart/leaguehub-backend/assets/48763809/8a4c587e-52a6-49a8-bee2-da02c37ba59c)


## 👌 Review Change
This closes #264 
리뷰를 통해 수정한 부분을 나열해주세요.