### PR TITLE
Feat#268: 점수 업데이트시 체크 로직 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -20,6 +20,10 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
     @Query("select mp from MatchPlayer mp join fetch mp.participant join fetch mp.match where mp.match.id = :matchId")
     List<MatchPlayer> findMatchPlayersAndMatchAndParticipantByMatchId(@Param("matchId") Long matchId);
 
+    @Query("select mp from MatchPlayer mp join fetch mp.participant join fetch mp.match where mp.match.id = :matchId " +
+            "and mp.playerStatus != leaguehub.leaguehubbackend.entity.match.PlayerStatus.DISQUALIFICATION")
+    List<MatchPlayer> findMatchPlayersWithoutDisqualification(@Param("matchId") Long matchId);
+
     Optional<MatchPlayer> findByParticipantIdAndMatchId(Long participantId, Long matchId);
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -173,11 +173,9 @@ public class MatchPlayerService {
 
         validMatchResult(findMatchPlayerList, matchRankResultDtoList);
 
-
         matchRankResultDtoList
                 .forEach(matchRankResultDto ->
                         findMatchPlayerList.stream()
-                                .filter(matchPlayer -> validUpdatePlayerScore(matchRankResultDto, matchPlayer))
                                 .forEach(matchPlayer -> matchPlayer.updateMatchPlayerScore(matchRankResultDto.getPlacement()))
                 );
 
@@ -204,17 +202,6 @@ public class MatchPlayerService {
         if (count != findMatchPlayerList.size()) {
             throw new MatchResultIdNotFoundException();
         }
-    }
-
-    /**
-     * 실격이 아니고 게임 Id가 동일한지 검사하는 로직
-     * @param matchRankResultDto
-     * @param matchPlayer
-     * @return
-     */
-    private boolean validUpdatePlayerScore(MatchRankResultDto matchRankResultDto, MatchPlayer matchPlayer) {
-        return matchRankResultDto.getGameId().equals(matchPlayer.getParticipant().getGameId())
-                && (matchPlayer.getPlayerStatus() != PlayerStatus.DISQUALIFICATION);
     }
 
     private void checkMatchEnd(MatchSet matchSet, Match match) {

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -9,5 +9,4 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.devtools.livereload.enabled=true
 spring.jpa.properties.hibernate.default_batch_fetch_size=100
-spring.profiles.include=API-KEY
 spring.jpa.properties.hibernate.auto_quote_keyword=true


### PR DESCRIPTION
## 🙆‍♂️ Issue

#268 

## 📝 Description

점수 업데이트 시 실격을 제외한 참가자들을 불러와 참가자들의 게임 Id와 조회된 라이엇의 match 안에 플레이어 리스트의 게임 Id를 체크해서 그 수가 동일한지 체크 하는 로직을 추가했어요. 그리고 uuid 값은 유니크라 이전 매치는 조회되지 않기 때문에 앞서 말한 기능만 추가했습니다.
그리고 prod에서 API-KEY를 포함해서 서버가 뜨지 않은 버그도 수정했어요 !

## ✨ Feature

실격 제외 플레이어 리스트 확인 로직 추가, prod 설정 파일 버그 해결

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.
This is closes #268 