### PR TITLE
Fix#275: 테스트 관련 코드 수정

### DIFF
--- a/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
@@ -76,7 +76,7 @@ class ParticipantControllerTest {
         Member member = memberRepository.save(UserFixture.createMember());
         Member ironMember = memberRepository.save(UserFixture.createCustomeMember("썹맹구"));
         Member unrankedMember = memberRepository.save(UserFixture.createCustomeMember("서초임"));
-        Member platinumMember = memberRepository.save(UserFixture.createCustomeMember("손성한"));
+        Member platinumMember = memberRepository.save(UserFixture.createCustomeMember("연습용아이디가됨"));
         Member masterMember = memberRepository.save(UserFixture.createCustomeMember("채수채수밭"));
         Member alreadyMember = memberRepository.save(UserFixture.createCustomeMember("요청한사람"));
         Member rejectedMember = memberRepository.save(UserFixture.createCustomeMember("거절된사람"));
@@ -166,10 +166,10 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (판수 제한 o) - 성공")
     void participateLimitedPlayCountMatchSuccessTest() throws Exception {
 
-        Channel channel = createCustomChannel(false, true, 800, null, 100);
-        UserFixture.setUpCustomAuth("손성한");
+        Channel channel = createCustomChannel(false, true, 2400, null, 1);
+        UserFixture.setUpCustomAuth("연습용아이디가됨");
 
-        ParticipantDto participantResponseDto = ParticipantFixture.createParticipantResponseDto("손성한");
+        ParticipantDto participantResponseDto = ParticipantFixture.createParticipantResponseDto("연습용아이디가됨");
         String dtoToJson = mapper.writeValueAsString(participantResponseDto);
 
         mockMvc.perform(post("/api/"+ channel.getChannelLink()+"/participant")
@@ -183,10 +183,10 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (마스터 10000점 이하, 판수 제한 o) - 성공")
     void participateLimitedMasterMatchSuccessTest() throws Exception {
 
-        Channel channel = createCustomChannel(true, true, 3200, null, 20);
-        UserFixture.setUpCustomAuth("채수채수밭");
+        Channel channel = createCustomChannel(true, true, 2400, null, 1);
+        UserFixture.setUpCustomAuth("연습용아이디가됨");
 
-        ParticipantDto participantResponseDto = ParticipantFixture.createParticipantResponseDto("채수채수밭");
+        ParticipantDto participantResponseDto = ParticipantFixture.createParticipantResponseDto("연습용아이디가됨");
         String dtoToJson = mapper.writeValueAsString(participantResponseDto);
 
         mockMvc.perform(post("/api/"+ channel.getChannelLink()+"/participant")
@@ -270,10 +270,10 @@ class ParticipantControllerTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어 제한) - 실패")
     void participateLimitedTierMatchFailTest() throws Exception {
 
-        Channel channel = createCustomChannel(true, false, 800, null, 20);
-        UserFixture.setUpCustomAuth("손성한");
+        Channel channel = createCustomChannel(true, false, 400, null, 1);
+        UserFixture.setUpCustomAuth("연습용아이디가됨");
 
-        ParticipantDto participantResponseDto = ParticipantFixture.createParticipantResponseDto("손성한");
+        ParticipantDto participantResponseDto = ParticipantFixture.createParticipantResponseDto("연습용아이디가됨");
         String dtoToJson = mapper.writeValueAsString(participantResponseDto);
 
         mockMvc.perform(post("/api/"+ channel.getChannelLink()+"/participant")
@@ -574,11 +574,11 @@ class ParticipantControllerTest {
     void participateUnAuthMatchFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
         Member guestMember = memberRepository.save(UserFixture.createGuestMember());
-        UserFixture.setUpCustomGuest("idGuest");
+        UserFixture.setUpCustomGuest("Guest");
 
         Channel channel = createCustomChannel(false, false, 800, null, 100);
 
-        ParticipantDto participantResponseDto = ParticipantFixture.createParticipantResponseDto("손성한");
+        ParticipantDto participantResponseDto = ParticipantFixture.createParticipantResponseDto("연습용아이디가됨");
         String dtoToJson = mapper.writeValueAsString(participantResponseDto);
 
         mockMvc.perform(post("/api/" + channel.getChannelLink() + "/participant/observer")

--- a/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
+++ b/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
@@ -27,7 +27,7 @@ public class UserFixture {
 
     public static Member createGuestMember() {
         Member member = Member.builder()
-                .personalId("idGuest").profileImageUrl("urlGuest")
+                .personalId("Guest").profileImageUrl("urlGuest")
                 .nickname("nickNameGuest").refreshToken("refreshTokenGuest")
                 .emailAuth(new EmailAuth("idGuest@example.com", "authToken"))
                 .loginProvider(LoginProvider.KAKAO).baseRole(BaseRole.GUEST)

--- a/src/test/java/leaguehub/leaguehubbackend/service/match/MatchServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/match/MatchServiceTest.java
@@ -124,8 +124,8 @@ class MatchServiceTest {
 
         matchService.createSubMatches(channel, channel.getMaxPlayer());
 
-        List<Match> findMatchRound16 = matchRepository.findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(channel.getChannelLink(), 16);
-        List<Match> findMatchRound8 = matchRepository.findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(channel.getChannelLink(), 8);
+        List<Match> findMatchRound16 = matchRepository.findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(channel.getChannelLink(), 1);
+        List<Match> findMatchRound8 = matchRepository.findAllByChannel_ChannelLinkAndMatchRoundOrderByMatchName(channel.getChannelLink(), 2);
 
         assertThat(findMatchRound16.size()).isEqualTo(2);
         assertThat(findMatchRound8.size()).isEqualTo(1);

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -84,7 +84,7 @@ class ParticipantServiceTest {
         Member member = memberRepository.save(UserFixture.createMember());
         Member ironMember = memberRepository.save(UserFixture.createCustomeMember("썹맹구"));
         Member unrankedMember = memberRepository.save(UserFixture.createCustomeMember("서초임"));
-        Member platinumMember = memberRepository.save(UserFixture.createCustomeMember("손성한"));
+        Member platinumMember = memberRepository.save(UserFixture.createCustomeMember("연습용아이디가됨"));
         Member masterMember = memberRepository.save(UserFixture.createCustomeMember("채수채수밭"));
         Member alreadyMember = memberRepository.save(UserFixture.createCustomeMember("요청한사람"));
         Member rejectedMember = memberRepository.save(UserFixture.createCustomeMember("거절된사람"));
@@ -189,11 +189,11 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의  경기 참가 테스트 (티어, 판수 제한 o) - 성공")
     void participatelimitedMatchSuccessTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, true, 2100, null, 100);
-        UserFixture.setUpCustomAuth("손성한");
+        Channel channel = createCustomChannel(true, true, 2100, null, 1);
+        UserFixture.setUpCustomAuth("연습용아이디가됨");
         ParticipantDto responseDto = new ParticipantDto();
 
-        responseDto.setGameId("손성한");
+        responseDto.setGameId("연습용아이디가됨");
 
         participantService.participateMatch(responseDto, channel.getChannelLink());
 
@@ -213,11 +213,11 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어 마스터 20000점 이하, 판수 제한 o) - 성공")
     void participatelimitedMatchMasterSuccessTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, true, 3200, null, 20);
-        UserFixture.setUpCustomAuth("채수채수밭");
+        Channel channel = createCustomChannel(true, true, 2400, null, 1);
+        UserFixture.setUpCustomAuth("연습용아이디가됨");
         ParticipantDto responseDto = new ParticipantDto();
 
-        responseDto.setGameId("채수채수밭");
+        responseDto.setGameId("연습용아이디가됨");
 
         participantService.participateMatch(responseDto, channel.getChannelLink());
 
@@ -297,11 +297,11 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어 제한 o) - 실패")
     void participatelimitedTierMatchFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, false, 800, null, 100);
-        UserFixture.setUpCustomAuth("손성한");
+        Channel channel = createCustomChannel(true, false, 400, null, 100);
+        UserFixture.setUpCustomAuth("연습용아이디가됨");
         ParticipantDto responseDto = new ParticipantDto();
 
-        responseDto.setGameId("손성한");
+        responseDto.setGameId("연습용아이디가됨");
 
         assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantInvalidRankException.class);
@@ -313,10 +313,10 @@ class ParticipantServiceTest {
     void participatelimitedTierMatchFailTest_tierMin() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
         Channel channel = createCustomChannel(true, false, null, 2400, 100);
-        UserFixture.setUpCustomAuth("손성한");
+        UserFixture.setUpCustomAuth("연습용아이디가됨");
         ParticipantDto responseDto = new ParticipantDto();
 
-        responseDto.setGameId("손성한");
+        responseDto.setGameId("연습용아이디가됨");
 
         assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantInvalidRankException.class);
@@ -343,11 +343,11 @@ class ParticipantServiceTest {
     @DisplayName("해당 채널의 경기 참가 테스트 (티어 마스터 100점 이하, 판수 제한 o) - 실패")
     void participatelimitedMatchMasterFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
-        Channel channel = createCustomChannel(true, true, 2400, null, 20);
-        UserFixture.setUpCustomAuth("채수채수밭");
+        Channel channel = createCustomChannel(true, true, 400, null, 20);
+        UserFixture.setUpCustomAuth("연습용아이디가됨");
         ParticipantDto responseDto = new ParticipantDto();
 
-        responseDto.setGameId("채수채수밭");
+        responseDto.setGameId("연습용아이디가됨");
 
         //when
         assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
@@ -686,7 +686,7 @@ class ParticipantServiceTest {
         //then
 
         assertThat(participantChannelDto.getChannelLink()).isEqualTo(channel.getChannelLink());
-        assertThat(participantChannelDto.getGameCategory()).isEqualTo(GameCategory.TFT);
+        assertThat(participantChannelDto.getGameCategory()).isEqualTo(GameCategory.TFT.getNum());
         assertThat(participantChannelDto.getTitle()).isEqualTo(channel.getTitle());
     }
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#275 

## 📝 Description

TFT가 9.5로 업데이트함에 따라 기존의 데이터가 변경되어 테스트 코드를 수정하였어요

그리고 이메일 인증이 안된 Guest 계정을 사용하여 실패 테스트를 확인해야 하는데  테스트가 성공으로 넘어가
UserFixture에 Guest를 만드는 메서드를 수정해야할 것 같아요

<img width="632" alt="image" src="https://github.com/TheUpperPart/leaguehub-backend/assets/87762815/96a917d3-1204-4251-80db-d56c3916a0dd">


## ✨ Feature

Service 테스트 코드 수정
Controller 테스트 코드 수정

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.
This closes #275 