### PR TITLE
Feat#271: 매치 세트 관련 기능 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -101,9 +101,11 @@ public class MatchController {
     }
 
     @MessageMapping("/match/{matchId}/{matchSet}/score-update")
-    public void updateMatchPlayerScore(@PathVariable("matchId") Long matchId, @PathVariable("matchSet") Integer matchSet) {
+    public List<MatchRankResultDto> updateMatchPlayerScore(@PathVariable("matchId") Long matchId, @PathVariable("matchSet") Integer matchSet) {
 
-        matchPlayerService.updateMatchPlayerScore(matchId, matchSet);
+        List<MatchRankResultDto> matchRankResultDtos = matchPlayerService.updateMatchPlayerScore(matchId, matchSet);
+
+        return matchRankResultDtos;
     }
 
     @MessageMapping("/match/{matchId}")

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -105,6 +105,7 @@ public class MatchController {
 
         List<MatchRankResultDto> matchRankResultDtos = matchPlayerService.updateMatchPlayerScore(matchId, matchSet);
 
+        simpMessagingTemplate.convertAndSend("/match/" + matchId + "/" + matchSet, matchRankResultDtos);
         return matchRankResultDtos;
     }
 
@@ -154,7 +155,7 @@ public class MatchController {
     public ResponseEntity setMatchRoundCount(@PathVariable("channelLink") String channelLink,
                                              @RequestBody List<Integer> roundCountList){
 
-        matchService.setMatchRoundCount(channelLink, roundCountList);
+        matchService.setMatchSetCount(channelLink, roundCountList);
 
         return new ResponseEntity("경기 횟수가 배정되었습니다.", OK);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchInfoDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchInfoDto.java
@@ -25,22 +25,22 @@ public class MatchInfoDto {
     private Integer matchRound;
 
     @Schema(description = "해당 매치 경기 현재 횟수", example = "1(회)")
-    private Integer matchRoundCount;
+    private Integer matchCurrentSet;
 
     @Schema(description = "해당 매치 최대 경기 횟수", example = "3(회)")
-    private Integer matchRoundMaxCount;
+    private Integer matchSetCount;
 
     @Schema(description = "매치에 속해있는 플레이어의 정보", example = "배열로 반환")
     private List<MatchPlayerInfo> matchPlayerInfoList;
 
     @Builder
-    public MatchInfoDto(String matchName, Long matchId, MatchStatus matchStatus, Integer matchRound, Integer matchRoundCount, Integer matchRoundMaxCount, List<MatchPlayerInfo> matchPlayerInfoList) {
+    public MatchInfoDto(String matchName, Long matchId, MatchStatus matchStatus, Integer matchRound, Integer matchCurrentSet, Integer matchSetCount, List<MatchPlayerInfo> matchPlayerInfoList) {
         this.matchName = matchName;
         this.matchId = matchId;
         this.matchStatus = matchStatus;
         this.matchRound = matchRound;
-        this.matchRoundCount = matchRoundCount;
-        this.matchRoundMaxCount = matchRoundMaxCount;
+        this.matchCurrentSet = matchCurrentSet;
+        this.matchSetCount = matchSetCount;
         this.matchPlayerInfoList = matchPlayerInfoList;
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -33,6 +33,10 @@ public class Match extends BaseTimeEntity {
 
     private Integer roundRealCount;
 
+    private Integer matchSetCount;
+
+    private Integer matchCurrentSet;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "channel_id")
     private Channel channel;
@@ -53,6 +57,8 @@ public class Match extends BaseTimeEntity {
         match.matchPasswd = GlobalConstant.NO_DATA.getData();
         match.roundMaxCount = 1;
         match.roundRealCount = 0;
+        match.matchCurrentSet = 0;
+        match.matchSetCount = 3;
         match.channel = channel;
 
         return match;
@@ -63,4 +69,8 @@ public class Match extends BaseTimeEntity {
     }
 
     public void updateMatchRoundMaxCount(Integer roundMaxCount) { this.roundMaxCount = roundMaxCount; }
+
+    public void updateCurrentMatchSet(Integer matchCurrentSet) {
+        this.matchCurrentSet = matchCurrentSet + 1;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -29,10 +29,6 @@ public class Match extends BaseTimeEntity {
 
     private String matchPasswd;
 
-    private Integer roundMaxCount;
-
-    private Integer roundRealCount;
-
     private Integer matchSetCount;
 
     private Integer matchCurrentSet;
@@ -55,8 +51,6 @@ public class Match extends BaseTimeEntity {
         match.matchRound = matchRound;
         match.matchName = matchName;
         match.matchPasswd = GlobalConstant.NO_DATA.getData();
-        match.roundMaxCount = 1;
-        match.roundRealCount = 0;
         match.matchCurrentSet = 0;
         match.matchSetCount = 3;
         match.channel = channel;
@@ -68,7 +62,7 @@ public class Match extends BaseTimeEntity {
         this.matchStatus = matchStatus;
     }
 
-    public void updateMatchRoundMaxCount(Integer roundMaxCount) { this.roundMaxCount = roundMaxCount; }
+    public void updateMatchSetCount(Integer matchSetCount) { this.matchSetCount = matchSetCount; }
 
     public void updateCurrentMatchSet(Integer matchCurrentSet) {
         this.matchCurrentSet = matchCurrentSet;

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -71,6 +71,6 @@ public class Match extends BaseTimeEntity {
     public void updateMatchRoundMaxCount(Integer roundMaxCount) { this.roundMaxCount = roundMaxCount; }
 
     public void updateCurrentMatchSet(Integer matchCurrentSet) {
-        this.matchCurrentSet = matchCurrentSet + 1;
+        this.matchCurrentSet = matchCurrentSet;
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -160,7 +160,7 @@ public class MatchPlayerService {
         return new RiotAPIDto(riotMatchUuid, matchRankResultDtoList);
     }
 
-    public void updateMatchPlayerScore(Long matchId, Integer setCount) {
+    public List<MatchRankResultDto> updateMatchPlayerScore(Long matchId, Integer setCount) {
         List<MatchPlayer> findMatchPlayerList = matchPlayerRepository.findMatchPlayersWithoutDisqualification(matchId);
 
         RiotAPIDto matchDetailFromRiot = getMatchDetailFromRiot(findMatchPlayerList.get(0).getParticipant().getGameId());
@@ -184,6 +184,8 @@ public class MatchPlayerService {
 
         Match match = findMatchPlayerList.get(0).getMatch();
         checkMatchEnd(matchSet, match);
+
+        return matchRankResultDtoList;
     }
 
     /**
@@ -206,7 +208,7 @@ public class MatchPlayerService {
         if(match.getMatchSetCount() == matchSet.getSetCount()) {
             match.updateMatchStatus(MatchStatus.END);
         } else {
-            match.updateCurrentMatchSet(matchSet.getSetCount());
+            match.updateCurrentMatchSet(matchSet.getSetCount() + 1);
         }
     }
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -203,8 +203,10 @@ public class MatchPlayerService {
     }
 
     private void checkMatchEnd(MatchSet matchSet, Match match) {
-        if(match.getRoundMaxCount() == matchSet.getSetCount()) {
+        if(match.getMatchSetCount() == matchSet.getSetCount()) {
             match.updateMatchStatus(MatchStatus.END);
+        } else {
+            match.updateCurrentMatchSet(matchSet.getSetCount());
         }
     }
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -144,7 +144,7 @@ public class MatchService {
 
     }
 
-    public void setMatchRoundCount(String channelLink, List<Integer> roundCount){
+    public void setMatchSetCount(String channelLink, List<Integer> roundCount){
 
         List<Match> findMatchList = matchRepository.findAllByChannel_ChannelLink(channelLink);
 
@@ -153,7 +153,7 @@ public class MatchService {
 
         AtomicInteger roundCountIndex = new AtomicInteger(0);
 
-        updateMatchRoundCount(roundCount, findMatchList, roundCountIndex);
+        updateMatchSetCount(roundCount, findMatchList, roundCountIndex);
     }
 
 
@@ -255,8 +255,8 @@ public class MatchService {
         matchInfoDto.setMatchId(match.getId());
         matchInfoDto.setMatchStatus(match.getMatchStatus());
         matchInfoDto.setMatchRound(match.getMatchRound());
-        matchInfoDto.setMatchRoundCount(match.getRoundRealCount());
-        matchInfoDto.setMatchRoundMaxCount(match.getRoundMaxCount());
+        matchInfoDto.setMatchCurrentSet(match.getMatchCurrentSet());
+        matchInfoDto.setMatchSetCount(match.getMatchSetCount());
 
         List<MatchPlayer> playerList = matchPlayerRepository.findAllByMatch_IdOrderByPlayerScoreDesc(match.getId());
         List<MatchPlayerInfo> matchPlayerInfoList = createMatchPlayerInfoList(playerList);
@@ -307,7 +307,8 @@ public class MatchService {
                 .matchName(match.getMatchName())
                 .matchStatus(match.getMatchStatus())
                 .matchRound(match.getMatchRound())
-                .matchRoundCount(match.getRoundRealCount())
+                .matchSetCount(match.getMatchSetCount())
+                .matchCurrentSet(match.getMatchCurrentSet())
                 .matchPlayerInfoList(convertMatchPlayerInfoList(matchPlayers))
                 .build();
     }
@@ -419,12 +420,12 @@ public class MatchService {
         return "Observer";
     }
 
-    private static void updateMatchRoundCount(List<Integer> roundCount, List<Match> findMatchList, AtomicInteger roundCountIndex) {
+    private static void updateMatchSetCount(List<Integer> roundCount, List<Match> findMatchList, AtomicInteger roundCountIndex) {
         IntStream.rangeClosed(1, roundCount.size() + 1)
                 .forEach(roundIndex -> findMatchList.stream()
                         .filter(match -> match.getMatchRound() == roundIndex)
                         .forEach(match -> {
-                            match.updateMatchRoundMaxCount(roundCount.get(roundCountIndex.get()));
+                            match.updateMatchSetCount(roundCount.get(roundCountIndex.get()));
                             roundCountIndex.incrementAndGet();
                         }));
     }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#271 

## 📝 Description

매치 세트를 화면에 표시하기 위해서 매치 엔티티에 현재 매치, 총 매치 세트를 나타내는 컬럼을 추가했어요. 그리고 매치 세트를 업데이트 하는 기능을 checkEnd 메서드에 추가했어요. 반환값을 없앴는데 그 반환값을 유저가 라이엇 API에서 오는 경기 결과를 확인 할 수 있도록 반환해주기로 했어요 !

## ✨ Feature

매치 엔티티에 매치 세트, 현재 매치 세트 컬럼 추가,  매치 종료 체크시 종료 되지 않았다면 매치 엔티티 안 현재 매치 세트를 다음 세트(matchCurrentSet + 1)로 넘기는 기능 추가, Riot API를 통한 통신 성공시 해당 경기 결과를 Dto로 바꿔 전송하는 기능 추가(플레이어들의 경기 결과 확인)

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #271 