### PR TITLE
Feat#272: 몽고 DB 추가 및 경기 결과 관련 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/leaguehub/leaguehubbackend/config/MongoDataConfig.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/MongoDataConfig.java
@@ -1,0 +1,30 @@
+package leaguehub.leaguehubbackend.config;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@Configuration
+public class MongoDataConfig {
+
+    private String mongoUri = "mongodb://localhost:27017/leaguehub";
+
+    @Bean
+    public MongoClient mongoClient() {
+        return MongoClients.create(mongoUri);
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate() {
+        return new MongoTemplate(mongoClient(), getDatabaseName());
+    }
+
+    private String getDatabaseName() {
+        ConnectionString connectionString = new ConnectionString(mongoUri);
+        return connectionString.getDatabase();
+    }
+}
+

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -101,9 +101,11 @@ public class MatchController {
     }
 
     @MessageMapping("/match/{matchId}/{matchSet}/score-update")
-    public void updateMatchPlayerScore(@PathVariable("matchId") Long matchId, @PathVariable("matchSet") Integer matchSet) {
+    public List<MatchRankResultDto> updateMatchPlayerScore(@PathVariable("matchId") Long matchId, @PathVariable("matchSet") Integer matchSet) {
 
-        matchPlayerService.updateMatchPlayerScore(matchId, matchSet);
+        List<MatchRankResultDto> matchRankResultDtos = matchPlayerService.updateMatchPlayerScore(matchId, matchSet);
+
+        return matchRankResultDtos;
     }
 
     @MessageMapping("/match/{matchId}")

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -160,4 +160,20 @@ public class MatchController {
         return new ResponseEntity("경기 횟수가 배정되었습니다.", OK);
     }
 
+
+    @Operation(summary = "해당 채널 세트의 결과 - 이전 경기 결과를 가져옴(Mongo 형식)")
+    @Parameters(value = {
+            @Parameter(name = "matchSetId", description = "불러오고 싶은 매치 세트의 PK", example = "3"),
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "경기 횟수가 배정되었습니다."),
+            @ApiResponse(responseCode = "404", description = "매치 세트를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/match/{matchSetId}/result")
+    public ResponseEntity getGameResult(@PathVariable Long matchSetId) {
+        List<MatchRankResultDto> gameResult = matchPlayerService.getGameResult(matchSetId);
+
+        return new ResponseEntity(gameResult, OK);
+    }
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -105,6 +105,7 @@ public class MatchController {
 
         List<MatchRankResultDto> matchRankResultDtos = matchPlayerService.updateMatchPlayerScore(matchId, matchSet);
 
+        simpMessagingTemplate.convertAndSend("/match/" + matchId + "/" + matchSet, matchRankResultDtos);
         return matchRankResultDtos;
     }
 
@@ -154,7 +155,7 @@ public class MatchController {
     public ResponseEntity setMatchRoundCount(@PathVariable("channelLink") String channelLink,
                                              @RequestBody List<Integer> roundCountList){
 
-        matchService.setMatchRoundCount(channelLink, roundCountList);
+        matchService.setMatchSetCount(channelLink, roundCountList);
 
         return new ResponseEntity("경기 횟수가 배정되었습니다.", OK);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchInfoDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchInfoDto.java
@@ -25,22 +25,22 @@ public class MatchInfoDto {
     private Integer matchRound;
 
     @Schema(description = "해당 매치 경기 현재 횟수", example = "1(회)")
-    private Integer matchRoundCount;
+    private Integer matchCurrentSet;
 
     @Schema(description = "해당 매치 최대 경기 횟수", example = "3(회)")
-    private Integer matchRoundMaxCount;
+    private Integer matchSetCount;
 
     @Schema(description = "매치에 속해있는 플레이어의 정보", example = "배열로 반환")
     private List<MatchPlayerInfo> matchPlayerInfoList;
 
     @Builder
-    public MatchInfoDto(String matchName, Long matchId, MatchStatus matchStatus, Integer matchRound, Integer matchRoundCount, Integer matchRoundMaxCount, List<MatchPlayerInfo> matchPlayerInfoList) {
+    public MatchInfoDto(String matchName, Long matchId, MatchStatus matchStatus, Integer matchRound, Integer matchCurrentSet, Integer matchSetCount, List<MatchPlayerInfo> matchPlayerInfoList) {
         this.matchName = matchName;
         this.matchId = matchId;
         this.matchStatus = matchStatus;
         this.matchRound = matchRound;
-        this.matchRoundCount = matchRoundCount;
-        this.matchRoundMaxCount = matchRoundMaxCount;
+        this.matchCurrentSet = matchCurrentSet;
+        this.matchSetCount = matchSetCount;
         this.matchPlayerInfoList = matchPlayerInfoList;
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/GameResult.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/GameResult.java
@@ -1,0 +1,29 @@
+package leaguehub.leaguehubbackend.entity.match;
+
+import jakarta.persistence.Id;
+import leaguehub.leaguehubbackend.dto.match.MatchRankResultDto;
+import leaguehub.leaguehubbackend.entity.BaseTimeEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document(collection = "game_result")
+@Getter
+@NoArgsConstructor
+public class GameResult extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    private List<MatchRankResultDto> matchRankResult;
+
+    public static GameResult createGameResult(Long id, List<MatchRankResultDto> matchRankResult) {
+        GameResult gameResult = new GameResult();
+        gameResult.id = id;
+        gameResult.matchRankResult = matchRankResult;
+
+        return gameResult;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -33,6 +33,10 @@ public class Match extends BaseTimeEntity {
 
     private Integer roundRealCount;
 
+    private Integer matchSetCount;
+
+    private Integer matchCurrentSet;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "channel_id")
     private Channel channel;
@@ -53,6 +57,8 @@ public class Match extends BaseTimeEntity {
         match.matchPasswd = GlobalConstant.NO_DATA.getData();
         match.roundMaxCount = 1;
         match.roundRealCount = 0;
+        match.matchCurrentSet = 0;
+        match.matchSetCount = 3;
         match.channel = channel;
 
         return match;
@@ -63,4 +69,8 @@ public class Match extends BaseTimeEntity {
     }
 
     public void updateMatchRoundMaxCount(Integer roundMaxCount) { this.roundMaxCount = roundMaxCount; }
+
+    public void updateCurrentMatchSet(Integer matchCurrentSet) {
+        this.matchCurrentSet = matchCurrentSet + 1;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -29,10 +29,6 @@ public class Match extends BaseTimeEntity {
 
     private String matchPasswd;
 
-    private Integer roundMaxCount;
-
-    private Integer roundRealCount;
-
     private Integer matchSetCount;
 
     private Integer matchCurrentSet;
@@ -55,8 +51,6 @@ public class Match extends BaseTimeEntity {
         match.matchRound = matchRound;
         match.matchName = matchName;
         match.matchPasswd = GlobalConstant.NO_DATA.getData();
-        match.roundMaxCount = 1;
-        match.roundRealCount = 0;
         match.matchCurrentSet = 0;
         match.matchSetCount = 3;
         match.channel = channel;
@@ -68,7 +62,7 @@ public class Match extends BaseTimeEntity {
         this.matchStatus = matchStatus;
     }
 
-    public void updateMatchRoundMaxCount(Integer roundMaxCount) { this.roundMaxCount = roundMaxCount; }
+    public void updateMatchSetCount(Integer matchSetCount) { this.matchSetCount = matchSetCount; }
 
     public void updateCurrentMatchSet(Integer matchCurrentSet) {
         this.matchCurrentSet = matchCurrentSet;

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -71,6 +71,6 @@ public class Match extends BaseTimeEntity {
     public void updateMatchRoundMaxCount(Integer roundMaxCount) { this.roundMaxCount = roundMaxCount; }
 
     public void updateCurrentMatchSet(Integer matchCurrentSet) {
-        this.matchCurrentSet = matchCurrentSet + 1;
+        this.matchCurrentSet = matchCurrentSet;
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/GameResultRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/GameResultRepository.java
@@ -1,0 +1,8 @@
+package leaguehub.leaguehubbackend.repository.match;
+
+import leaguehub.leaguehubbackend.entity.match.GameResult;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface GameResultRepository extends MongoRepository<GameResult, Long> {
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -160,7 +160,7 @@ public class MatchPlayerService {
         return new RiotAPIDto(riotMatchUuid, matchRankResultDtoList);
     }
 
-    public void updateMatchPlayerScore(Long matchId, Integer setCount) {
+    public List<MatchRankResultDto> updateMatchPlayerScore(Long matchId, Integer setCount) {
         List<MatchPlayer> findMatchPlayerList = matchPlayerRepository.findMatchPlayersWithoutDisqualification(matchId);
 
         RiotAPIDto matchDetailFromRiot = getMatchDetailFromRiot(findMatchPlayerList.get(0).getParticipant().getGameId());
@@ -184,6 +184,8 @@ public class MatchPlayerService {
 
         Match match = findMatchPlayerList.get(0).getMatch();
         checkMatchEnd(matchSet, match);
+
+        return matchRankResultDtoList;
     }
 
     /**
@@ -206,7 +208,7 @@ public class MatchPlayerService {
         if(match.getMatchSetCount() == matchSet.getSetCount()) {
             match.updateMatchStatus(MatchStatus.END);
         } else {
-            match.updateCurrentMatchSet(matchSet.getSetCount());
+            match.updateCurrentMatchSet(matchSet.getSetCount() + 1);
         }
     }
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -203,8 +203,10 @@ public class MatchPlayerService {
     }
 
     private void checkMatchEnd(MatchSet matchSet, Match match) {
-        if(match.getRoundMaxCount() == matchSet.getSetCount()) {
+        if(match.getMatchSetCount() == matchSet.getSetCount()) {
             match.updateMatchStatus(MatchStatus.END);
+        } else {
+            match.updateCurrentMatchSet(matchSet.getSetCount());
         }
     }
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -8,6 +8,7 @@ import leaguehub.leaguehubbackend.exception.match.exception.MatchNotFoundExcepti
 import leaguehub.leaguehubbackend.exception.match.exception.MatchPlayerNotFoundException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchResultIdNotFoundException;
 import leaguehub.leaguehubbackend.exception.participant.exception.ParticipantGameIdNotFoundException;
+import leaguehub.leaguehubbackend.repository.match.GameResultRepository;
 import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
 import leaguehub.leaguehubbackend.repository.match.MatchSetRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import reactor.core.publisher.Mono;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -41,6 +43,7 @@ public class MatchPlayerService {
     private final MatchPlayerRepository matchPlayerRepository;
     private final MatchSetRepository matchSetRepository;
     private final MatchService matchService;
+    private final GameResultRepository gameResultRepository;
 
     /**
      * 소환사의 라이엇 puuid를 얻는 메서드
@@ -182,10 +185,18 @@ public class MatchPlayerService {
 
         matchSet.updateScore(true);
 
+        gameResultRepository.save(GameResult.createGameResult(matchSet.getId(), matchRankResultDtoList));
+
         Match match = findMatchPlayerList.get(0).getMatch();
         checkMatchEnd(matchSet, match);
 
         return matchRankResultDtoList;
+    }
+
+    public List<MatchRankResultDto> getGameResult(Long matchSetId) {
+        GameResult gameResult = gameResultRepository.findById(matchSetId).orElseThrow(() -> new MatchResultIdNotFoundException());
+
+        return gameResult.getMatchRankResult();
     }
 
     /**

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -144,7 +144,7 @@ public class MatchService {
 
     }
 
-    public void setMatchRoundCount(String channelLink, List<Integer> roundCount){
+    public void setMatchSetCount(String channelLink, List<Integer> roundCount){
 
         List<Match> findMatchList = matchRepository.findAllByChannel_ChannelLink(channelLink);
 
@@ -153,7 +153,7 @@ public class MatchService {
 
         AtomicInteger roundCountIndex = new AtomicInteger(0);
 
-        updateMatchRoundCount(roundCount, findMatchList, roundCountIndex);
+        updateMatchSetCount(roundCount, findMatchList, roundCountIndex);
     }
 
 
@@ -255,8 +255,8 @@ public class MatchService {
         matchInfoDto.setMatchId(match.getId());
         matchInfoDto.setMatchStatus(match.getMatchStatus());
         matchInfoDto.setMatchRound(match.getMatchRound());
-        matchInfoDto.setMatchRoundCount(match.getRoundRealCount());
-        matchInfoDto.setMatchRoundMaxCount(match.getRoundMaxCount());
+        matchInfoDto.setMatchCurrentSet(match.getMatchCurrentSet());
+        matchInfoDto.setMatchSetCount(match.getMatchSetCount());
 
         List<MatchPlayer> playerList = matchPlayerRepository.findAllByMatch_IdOrderByPlayerScoreDesc(match.getId());
         List<MatchPlayerInfo> matchPlayerInfoList = createMatchPlayerInfoList(playerList);
@@ -307,7 +307,8 @@ public class MatchService {
                 .matchName(match.getMatchName())
                 .matchStatus(match.getMatchStatus())
                 .matchRound(match.getMatchRound())
-                .matchRoundCount(match.getRoundRealCount())
+                .matchSetCount(match.getMatchSetCount())
+                .matchCurrentSet(match.getMatchCurrentSet())
                 .matchPlayerInfoList(convertMatchPlayerInfoList(matchPlayers))
                 .build();
     }
@@ -419,12 +420,12 @@ public class MatchService {
         return "Observer";
     }
 
-    private static void updateMatchRoundCount(List<Integer> roundCount, List<Match> findMatchList, AtomicInteger roundCountIndex) {
+    private static void updateMatchSetCount(List<Integer> roundCount, List<Match> findMatchList, AtomicInteger roundCountIndex) {
         IntStream.rangeClosed(1, roundCount.size() + 1)
                 .forEach(roundIndex -> findMatchList.stream()
                         .filter(match -> match.getMatchRound() == roundIndex)
                         .forEach(match -> {
-                            match.updateMatchRoundMaxCount(roundCount.get(roundCountIndex.get()));
+                            match.updateMatchSetCount(roundCount.get(roundCountIndex.get()));
                             roundCountIndex.incrementAndGet();
                         }));
     }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,11 +1,15 @@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/connectdb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.data.mongodb.url=mongodb://localhost:27017/leaguehub
 spring.datasource.username=root
 spring.datasource.password=root
+spring.data.mongodb.username=root
+spring.data.mongodb.database=leaguehub
+spring.data.mongodb.password=root
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.type.descriptor.sql=trace
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.devtools.livereload.enabled=true
 spring.jpa.properties.hibernate.default_batch_fetch_size=100


### PR DESCRIPTION
## 🙆‍♂️ Issue

#272 

## 📝 Description

몽고 DB 도입에 따른 DAO와 각종 설정, 그리고 코드를 작성했어요. GameResult 엔티티로 저장하는데 라이엇 API에서 가져온 등수 및 게임아이디를 그대로 넣기 위해 DTO 그대로 저장했어요. 그리고 Id는 matchSet PK 값을 GameResult의 PK로 지정해 게임 결과를 matchSet Id  값으로 불러 올 수 있도록 했어요. 
게임 점수 업데이트 시에 성공적으로 저장했으면, 게임 결과를 Save 하도록 했어요.
해당 부분들을 유심히 보시길 바랄께요.

## ✨ Feature

Mongo 관련 Config, Mongo Dao, Mongo Entity, 게임 결과 저장 및 조회 기능

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #272 