### PR TITLE
Feat#282: 매치 세트 설정시 현재 설정한 세트를 불러오는 기능 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -165,7 +165,7 @@ public class MatchController {
             @ApiResponse(responseCode = "200", description = "경기 횟수 반환"),
             @ApiResponse(responseCode = "403", description = "매치 또는 채널을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
-    @GetMapping("match/{channelLink/count}")
+    @GetMapping("match/{channelLink}/count")
     public ResponseEntity getMatchRoundCount(@PathVariable("channelLink") String channelLink){
 
         List<Integer> matchsetCountList = matchService.getMatchSetCount(channelLink);

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -159,7 +159,19 @@ public class MatchController {
 
         return new ResponseEntity("경기 횟수가 배정되었습니다.", OK);
     }
+    @Operation(summary = "해당 채널의 (1, 2, 3)라운드에 대한 설정된 경기 횟수를 반환")
+    @Parameter(name = "roundCountList", description = "설정할려는 횟수 배열 결승전부터", example = "[3, 4, 2, 1]")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "경기 횟수 반환"),
+            @ApiResponse(responseCode = "403", description = "매치 또는 채널을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("match/{channelLink/count}")
+    public ResponseEntity getMatchRoundCount(@PathVariable("channelLink") String channelLink){
 
+        List<Integer> matchsetCountList = matchService.getMatchSetCount(channelLink);
+
+        return new ResponseEntity(matchsetCountList, OK);
+    }
 
     @Operation(summary = "해당 채널 세트의 결과 - 이전 경기 결과를 가져옴(Mongo 형식)")
     @Parameters(value = {

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchRepository.java
@@ -10,4 +10,6 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 
     List<Match> findAllByChannel_ChannelLink(String channelLink);
 
+    List<Match> findAllByChannel_ChannelLinkOrderByMatchRoundDesc(String channelLink);
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -19,6 +19,7 @@ import leaguehub.leaguehubbackend.repository.match.MatchRepository;
 import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -155,6 +156,16 @@ public class MatchService {
 
         updateMatchSetCount(roundCount, findMatchList, roundCountIndex);
     }
+
+    public List<Integer> getMatchSetCount(String channelLink){
+
+        List<Match> matchList = matchRepository.findAllByChannel_ChannelLinkOrderByMatchRoundDesc(channelLink);
+        List<Integer> matchSetCountList = getMatchSetCountList(matchList);
+
+        return matchSetCountList;
+    }
+
+
 
 
     private Channel getChannel(String channelLink) {
@@ -428,6 +439,20 @@ public class MatchService {
                             match.updateMatchSetCount(roundCount.get(roundCountIndex.get()));
                             roundCountIndex.incrementAndGet();
                         }));
+    }
+
+    private static List<Integer> getMatchSetCountList(List<Match> matchList) {
+        List<Integer> matchSetCountList = new ArrayList<>();
+        int matchRound = 0;
+        for(Match match : matchList){
+            if(matchRound == match.getMatchRound())
+                continue;
+            else {
+                matchSetCountList.add(match.getMatchSetCount());
+                matchRound = match.getMatchRound();
+            }
+        }
+        return matchSetCountList;
     }
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -152,9 +152,7 @@ public class MatchService {
         if(findMatchList.isEmpty())
             throw new MatchNotFoundException();
 
-        AtomicInteger roundCountIndex = new AtomicInteger(0);
-
-        updateMatchSetCount(roundCount, findMatchList, roundCountIndex);
+        updateMatchSetCount(roundCount, findMatchList);
     }
 
     public List<Integer> getMatchSetCount(String channelLink){
@@ -431,14 +429,16 @@ public class MatchService {
         return "Observer";
     }
 
-    private static void updateMatchSetCount(List<Integer> roundCount, List<Match> findMatchList, AtomicInteger roundCountIndex) {
-        IntStream.rangeClosed(1, roundCount.size() + 1)
-                .forEach(roundIndex -> findMatchList.stream()
-                        .filter(match -> match.getMatchRound() == roundIndex)
-                        .forEach(match -> {
-                            match.updateMatchSetCount(roundCount.get(roundCountIndex.get()));
-                            roundCountIndex.incrementAndGet();
-                        }));
+    private static void updateMatchSetCount(List<Integer> roundCount, List<Match> findMatchList) {
+        int responseIndex = 0;
+        for(int i = roundCount.size(); i >= 1; i--){
+            for(Match match : findMatchList){
+                if(match.getMatchRound().equals(i))
+                    match.updateMatchSetCount(roundCount.get(responseIndex));
+            }
+            responseIndex++;
+        }
+
     }
 
     private static List<Integer> getMatchSetCountList(List<Match> matchList) {


### PR DESCRIPTION
## 🙆‍♂️ Issue

#282 

## 📝 Description

매치 세트를 설정하기 전 이전에 설정하였던 세트 횟수를 불러오는 기능을 추가하였어요
해당 기능은 채널의 매치 리스트를 불러와 설정된 경기 횟수를 배열로 반환하는 기능이에요

또한 매치 세트 설정 부분에 대해 오류가 있어 수정하였습니다.

## ✨ Feature

이전에 설정된 매치 세트 횟수를 불러오는 기능
매치 세트 횟수를 설정하는 기능 수정

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #282 