### PR TITLE
Feat#290 : 채팅 기능 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/config/RedisConfig.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/RedisConfig.java
@@ -1,11 +1,16 @@
 package leaguehub.leaguehubbackend.config;
 
+import leaguehub.leaguehubbackend.dto.chat.MatchMessage;
+import leaguehub.leaguehubbackend.service.chat.MatchChatSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 
 @Configuration
 public class RedisConfig {
@@ -22,10 +27,23 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisMessage(RedisConnectionFactory factory) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
+    public RedisTemplate<String, MatchMessage> redisMessage(RedisConnectionFactory factory) {
+        RedisTemplate<String, MatchMessage> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
         return template;
     }
+    @Bean
+    public MessageListenerAdapter messageListener(MatchChatSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber);
+    }
 
+    @Bean
+    public RedisMessageListenerContainer redisContainer(RedisConnectionFactory connectionFactory,
+                                                        MessageListenerAdapter listenerAdapter) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(listenerAdapter, new PatternTopic("matchId:*:messages"));
+        return container;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchChatController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchChatController.java
@@ -1,0 +1,21 @@
+package leaguehub.leaguehubbackend.controller;
+
+import leaguehub.leaguehubbackend.dto.chat.MatchMessage;
+import leaguehub.leaguehubbackend.service.chat.MatchChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MatchChatController {
+
+    private final MatchChatService matchChatService;
+
+    @MessageMapping("/match/chat")
+    public void sendMessage(@Payload MatchMessage message) {
+        matchChatService.processMessage(message);
+    }
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/chat/MatchMessage.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/chat/MatchMessage.java
@@ -1,0 +1,24 @@
+package leaguehub.leaguehubbackend.dto.chat;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class MatchMessage {
+
+    private Long channelId;
+
+    private String content;
+
+    private Long matchId;
+
+    private String participantId;
+
+    private LocalDateTime timestamp;
+
+    private String type;
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/chat/ChatExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/chat/ChatExceptionCode.java
@@ -1,0 +1,19 @@
+package leaguehub.leaguehubbackend.exception.chat;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatExceptionCode implements ExceptionCode {
+
+    MATCH_CHAT_CONVERSION_EXCEPTION(INTERNAL_SERVER_ERROR, "CH-C-001", "메시지 변환 중 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/chat/ChatExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/chat/ChatExceptionHandler.java
@@ -1,0 +1,30 @@
+package leaguehub.leaguehubbackend.exception.chat;
+
+import leaguehub.leaguehubbackend.exception.chat.exception.MatchChatMessageConversionException;
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class ChatExceptionHandler {
+
+    @ExceptionHandler(MatchChatMessageConversionException.class)
+    public ResponseEntity<ExceptionResponse> invalidEmailAddress(
+            MatchChatMessageConversionException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/chat/exception/MatchChatMessageConversionException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/chat/exception/MatchChatMessageConversionException.java
@@ -1,0 +1,21 @@
+package leaguehub.leaguehubbackend.exception.chat.exception;
+
+import leaguehub.leaguehubbackend.exception.chat.ChatExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+
+import static leaguehub.leaguehubbackend.exception.chat.ChatExceptionCode.MATCH_CHAT_CONVERSION_EXCEPTION;
+
+public class MatchChatMessageConversionException  extends RuntimeException{
+
+    private final ChatExceptionCode exceptionCode;
+
+    public MatchChatMessageConversionException() {
+        super(MATCH_CHAT_CONVERSION_EXCEPTION.getMessage());
+        this.exceptionCode = MATCH_CHAT_CONVERSION_EXCEPTION;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}
+

--- a/src/main/java/leaguehub/leaguehubbackend/service/chat/MatchChatService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/chat/MatchChatService.java
@@ -1,0 +1,57 @@
+package leaguehub.leaguehubbackend.service.chat;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import leaguehub.leaguehubbackend.dto.chat.MatchMessage;
+import leaguehub.leaguehubbackend.exception.chat.exception.MatchChatMessageConversionException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MatchChatService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private final ObjectMapper objectMapper;
+    private static final String REDIS_KEY_FORMAT = "channelId:%d:matchId:%d:messages";
+    private static final String PUBLISH_KEY_FORMAT = "matchId:%d:messages";
+
+    public void processMessage(MatchMessage message) {
+
+        Long matchId = message.getMatchId();
+        Long channelId = message.getChannelId();
+
+        message.setTimestamp(LocalDateTime.now());
+
+        String messageJson = convertMessageToJson(message);
+        String redisKey = String.format(REDIS_KEY_FORMAT, channelId, matchId);
+        String publishKey = String.format(PUBLISH_KEY_FORMAT, matchId);
+
+        saveMessageToRedis(redisKey, messageJson);
+        publishMessage(publishKey, messageJson);
+    }
+
+    private String convertMessageToJson(MatchMessage message) {
+        try {
+            return objectMapper.writeValueAsString(message);
+        } catch (JsonProcessingException e) {
+            log.error("message로 변경 실패: {}", e.getMessage());
+            throw new MatchChatMessageConversionException();
+        }
+    }
+
+    private void saveMessageToRedis(String key, String messageJson) {
+        stringRedisTemplate.opsForList().leftPush(key, messageJson);
+    }
+
+    private void publishMessage(String key, String messageJson) {
+        stringRedisTemplate.convertAndSend(key, messageJson);
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/chat/MatchChatSubscriber.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/chat/MatchChatSubscriber.java
@@ -1,0 +1,51 @@
+package leaguehub.leaguehubbackend.service.chat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import leaguehub.leaguehubbackend.dto.chat.MatchMessage;
+import leaguehub.leaguehubbackend.exception.chat.exception.MatchChatMessageConversionException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchChatSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private static final String MATCH_CHAT_DESTINATION_FORMAT = "/match/%d/chat";
+
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        MatchMessage receivedMessageObj = convertToMatchMessage(message);
+        broadcastMessage(receivedMessageObj);
+    }
+
+    private MatchMessage convertToMatchMessage(Message message) {
+        try {
+            return objectMapper.readValue(message.getBody(), MatchMessage.class);
+        } catch (IOException e) {
+            log.error("message로 변경 실패: {}", e.getMessage());
+            throw new MatchChatMessageConversionException();
+        }
+    }
+
+    private String getDestination(Long matchId) {
+        return String.format(MATCH_CHAT_DESTINATION_FORMAT, matchId);
+    }
+
+    private void broadcastMessage(MatchMessage message) {
+        Long matchId = message.getMatchId();
+        String destination = getDestination(matchId);
+        messagingTemplate.convertAndSend(destination, message);
+    }
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue

#290 

## 📝 Description

소켓을 통해 채팅 정보를 받은 후 Redis에 저장을합니다. 그 후 RedisListener를 사용하여
변경사항이 있으면 Stomp 소켓을 사용하여 변경된 내용을 구독(sub)에게 메세지를 전달합니다.

리그(채널)이 종료된 후 해당 리그에서 발생한 메시지를 삭제하는 로직과 이전 채팅 기록 또한 따로 이슈로 올리겠습니다.

## ✨ Feature

1. Stomp 소켓을 사용하여 메시지를 받는다.
2. Redis에 저장을 한다.
3. Redis에 변경사항이 있으면 Stomp Subscriber에게 메세지를 전달한다.

## 👌 Review Change
This closes #290 
리뷰를 통해 수정한 부분을 나열해주세요.