### PR TITLE
Refactor#306 : MatchMessage Enum 추가, 타입 변경

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/dto/chat/MatchMessage.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/chat/MatchMessage.java
@@ -1,5 +1,6 @@
 package leaguehub.leaguehubbackend.dto.chat;
 
+import leaguehub.leaguehubbackend.entity.chat.MessageType;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -15,10 +16,10 @@ public class MatchMessage {
 
     private Long matchId;
 
-    private String participantId;
+    private Long participantId;
 
     private LocalDateTime timestamp;
 
-    private String type;
+    private MessageType type;
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/chat/MessageType.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/chat/MessageType.java
@@ -1,0 +1,6 @@
+package leaguehub.leaguehubbackend.entity.chat;
+
+public enum MessageType {
+    TEXT,
+
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue

#306 

## 📝 Description

MatchMessage의 ParticipantId 타입 변경과 MessageType Enum을 추가했습니다.
## ✨ Feature

1. ParticipantId 타입 변경
2. MessageType Enum 추가 

## 👌 Review Change
Thsi closes #306
리뷰를 통해 수정한 부분을 나열해주세요.