### PR TITLE
Feat#307 : 리그(채널) 종료시 채팅 삭제

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -18,6 +18,7 @@ import leaguehub.leaguehubbackend.repository.channel.ChannelBoardRepository;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRuleRepository;
 import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
+import leaguehub.leaguehubbackend.service.chat.MatchChatService;
 import leaguehub.leaguehubbackend.service.match.MatchService;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import leaguehub.leaguehubbackend.util.SecurityUtils;
@@ -43,6 +44,7 @@ public class ChannelService {
     private final ParticipantRepository participantRepository;
     private final MatchService matchService;
     private final ChannelRuleRepository channelRuleRepository;
+    private final MatchChatService matchChatService;
 
     @Transactional
     public ParticipantChannelDto createChannel(CreateChannelDto createChannelDto) {
@@ -162,7 +164,14 @@ public class ChannelService {
 
         participant.getChannel().updateChannelStatus(ChannelStatus.convertStatus(status));
 
-        if(status == 1)
+        if (status == 2) {
+            Optional<Channel> channel = channelRepository.findByChannelLink(channelLink);
+            channel.orElseThrow(ChannelNotFoundException::new);
+            matchChatService.deleteChannelMatchChat(channel.get());
+        }
+
+        if (status == 1) {
             matchService.processMatchSet(channelLink);
+        }
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -162,12 +162,11 @@ public class ChannelService {
         Participant participant = getParticipant(member.getId(), channelLink);
         checkRoleHost(participant.getRole());
 
-        participant.getChannel().updateChannelStatus(ChannelStatus.convertStatus(status));
+        Channel channel = participant.getChannel();
+        channel.updateChannelStatus(ChannelStatus.convertStatus(status));
 
         if (status == 2) {
-            Optional<Channel> channel = channelRepository.findByChannelLink(channelLink);
-            channel.orElseThrow(ChannelNotFoundException::new);
-            matchChatService.deleteChannelMatchChat(channel.get());
+            matchChatService.deleteChannelMatchChat(channel);
         }
 
         if (status == 1) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/chat/MatchChatService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/chat/MatchChatService.java
@@ -4,6 +4,7 @@ package leaguehub.leaguehubbackend.service.chat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import leaguehub.leaguehubbackend.dto.chat.MatchMessage;
+import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.exception.chat.exception.MatchChatMessageConversionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +12,8 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Set;
 
 @Service
 @Slf4j
@@ -22,6 +25,7 @@ public class MatchChatService {
     private final ObjectMapper objectMapper;
     private static final String REDIS_KEY_FORMAT = "channelId:%d:matchId:%d:messages";
     private static final String PUBLISH_KEY_FORMAT = "matchId:%d:messages";
+    private static final String DELETE_CHANNEL_CHAT_FORMAT = "channelId:%d:matchId:*:messages";
 
     public void processMessage(MatchMessage message) {
 
@@ -53,5 +57,17 @@ public class MatchChatService {
 
     private void publishMessage(String key, String messageJson) {
         stringRedisTemplate.convertAndSend(key, messageJson);
+    }
+
+    public void deleteChannelMatchChat(Channel channel) {
+
+        String targetChannel = String.format(DELETE_CHANNEL_CHAT_FORMAT, channel.getId());
+        Set<String> keys = stringRedisTemplate.keys(targetChannel);
+
+        if (keys != null) {
+            for (String key : keys) {
+                stringRedisTemplate.delete(key);
+            }
+        }
     }
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#307 

## 📝 Description

채널 종료시 해당 채널의 매치에서 발생한 채팅을 삭제합니다.

## ✨ Feature

1. 채널종료시 매치채팅 삭제 

## 👌 Review Change
This closes #307 
리뷰를 통해 수정한 부분을 나열해주세요.