### PR TITLE
Test#312: 테스트 실패 케이스 수정

### DIFF
--- a/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
@@ -581,7 +581,7 @@ class ParticipantControllerTest {
         ParticipantDto participantResponseDto = ParticipantFixture.createParticipantResponseDto("연습용아이디가됨");
         String dtoToJson = mapper.writeValueAsString(participantResponseDto);
 
-        mockMvc.perform(post("/api/" + channel.getChannelLink() + "/participant/observer")
+        mockMvc.perform(post("/api/" + channel.getChannelLink() + "/participant")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(dtoToJson))
                 .andExpect(status().isUnauthorized());

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -734,7 +734,7 @@ class ParticipantServiceTest {
     void participateUnAuthMatchFailTest() throws Exception {
         //given, 역할이 OBSERVER인 참가자, 해당 채널, 해당 채널 룰, 유저 디테일
         Member guestMember = memberRepository.save(UserFixture.createGuestMember());
-        UserFixture.setUpCustomGuest("idGuest");
+        UserFixture.setUpCustomGuest("Guest");
 
         Channel channel = createCustomChannel(false, false, 800, null, 100);
         ParticipantDto responseDto = new ParticipantDto();


### PR DESCRIPTION
## 🙆‍♂️ Issue

#312 

## 📝 Description

테스트 실패 케이스를 수정했어요. api 주소가 잘못 매칭 되있었고, service 에서는 setUpCustomGuest에 잘못 입력된 id 값을 바꾸었어요.

<img width="1184" alt="image" src="https://github.com/TheUpperPart/leaguehub-backend/assets/102659136/54182ea1-55f2-40b6-bd78-372125849f42">

지금 코드 커버리지는 66%에, 조건문 분기 커버리지는 45%이예요. 테스트 코드 쪽을 손을 봐야할 때가 온 것 같네요 !

## ✨ Feature

ParticipantService, ParticipantController 실패 코드 수정

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is close #312 