### PR TITLE
Fix#320: 점수 업데이트 로직 수정 및 api 코드 수정

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/LeaguehubBackendApplication.java
+++ b/src/main/java/leaguehub/leaguehubbackend/LeaguehubBackendApplication.java
@@ -8,20 +8,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-@AllArgsConstructor
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = "leaguehub.leaguehubbackend.repository")
 @EnableMongoRepositories(basePackages = "leaguehub.leaguehubbackend.mongo_repository")
 public class LeaguehubBackendApplication {
-
-    private final UserUtil userUtil;
-
     public static void main(String[] args) {
         SpringApplication.run(LeaguehubBackendApplication.class, args);
-    }
-
-    @PostConstruct
-    protected void init() {
-        userUtil.addDefaultUsers();
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -102,21 +102,12 @@ public class MatchController {
     }
 
     @MessageMapping("/match/{matchId}/{matchSet}/score-update")
-    public List<MatchRankResultDto> updateMatchPlayerScore(@DestinationVariable("matchId") String matchIdStr, @DestinationVariable("matchSet") String matchSetStr) {
+    public void updateMatchPlayerScore(@DestinationVariable("matchId") String matchIdStr, @DestinationVariable("matchSet") String matchSetStr) {
         Long matchId = Long.valueOf(matchIdStr);
         Integer matchSet = Integer.valueOf(matchSetStr);
-        List<MatchRankResultDto> matchRankResultDtos = matchPlayerService.updateMatchPlayerScore(matchId, matchSet);
+        MatchInfoDto matchInfoDto = matchPlayerService.updateMatchPlayerScore(matchId, matchSet);
 
-        simpMessagingTemplate.convertAndSend("/match/" + matchId + "/" + matchSet, matchRankResultDtos);
-        return matchRankResultDtos;
-    }
-
-    @MessageMapping("/match/{matchId}")
-    public void getMatchInfo(@DestinationVariable("matchId") String matchIdStr) {
-        Long matchId = Long.valueOf(matchIdStr);
-        MatchInfoDto matchInfo = matchService.getMatchInfo(matchId);
-
-        simpMessagingTemplate.convertAndSend("/match/" + matchId, matchInfo);
+        simpMessagingTemplate.convertAndSend("/match/" + matchId + "/" + matchSet, matchInfoDto);
     }
 
 

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerInfo.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchPlayerInfo.java
@@ -17,7 +17,7 @@ public class MatchPlayerInfo {
     @Schema(description = "플레이어의 게임 티어", example = "Diamond II")
     private String gameTier;
 
-    @Schema(description = "플레이어의 경기 상태", example = "대기 | 경기 중 | 실격 | 탈락 | 승급 | 우승")
+    @Schema(description = "플레이어의 체크인 상태", example = "READY, WAITING")
     private PlayerStatus playerStatus;
 
     @Schema(description = "참가자 점수", example = "8(점), 5(점), ...")

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
@@ -48,7 +48,10 @@ public class MatchPlayer extends BaseTimeEntity {
     public void updateMatchPlayerScore(Integer placement) {
         this.playerScore += 9 - placement;
     }
-    public void changeStatusToReady() { this.playerStatus = PlayerStatus.READY; }
+
+    public void updatePlayerCheckInStatus(PlayerStatus playerStatus) {
+        this.playerStatus = playerStatus;
+    }
 
     public void updateMatchPlayerResultStatus(MatchPlayerResultStatus matchPlayerResultStatus) {
         this.matchPlayerResultStatus = matchPlayerResultStatus;

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -45,6 +46,7 @@ import static leaguehub.leaguehubbackend.entity.participant.Role.*;
 
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ParticipantService {
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#320 

## 📝 Description

오늘 회의 하는 동안 이상하거나 부족했던 것들을 모아서 고쳤어요.  기존 중복된 API를 제거하고, 퍼블리싱을 위한 데이터 반환 값, 그리고 점수 업데이트시 참가자가 아닌 유저가 섞여 있을 경우 재선정, service에 누락된 트랜잭션, 그리고 MatchPlayerInfo Dto에 있던 잘못 설명된 값을 수정했어요.

## ✨ Feature

점수 업데이트 시 준비 상태 해제, 점수 업데이트 시 matchInfo 뿌리기, 점수 업데이트 시 참가자를 제외한 플레이어 순위를 제거하고, 다시 등수 산정, participantService 트랜잭션 추가, MatchPlayerInfo 준비 상태 설명 수정

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #320 