### PR TITLE
Feat#319 : 익명 유저 요청 SecurityContext에 등록

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -389,8 +389,6 @@ public class MatchService {
 
 
     public MatchScoreInfoDto getMatchScoreInfo(Long matchId) {
-        Member member = memberService.findCurrentMember();
-
         List<MatchPlayer> matchPlayers = Optional.ofNullable(
                         matchPlayerRepository.findMatchPlayersAndMatchAndParticipantByMatchId(matchId))
                 .filter(list -> !list.isEmpty())
@@ -399,13 +397,19 @@ public class MatchService {
         List<MatchPlayerScoreInfo> matchPlayerScoreInfoList = convertToMatchPlayerScoreInfoList(matchPlayers);
 
         sortAndRankMatchPlayerScoreInfoList(matchPlayerScoreInfoList);
-
-        String requestMatchPlayerId = findRequestMatchPlayerId(member, matchPlayers);
+        String requestMatchPlayerId = getRequestMatchPlayerId(matchPlayers);
 
         return MatchScoreInfoDto.builder()
                 .matchPlayerScoreInfos(matchPlayerScoreInfoList)
                 .requestMatchPlayerId(requestMatchPlayerId)
                 .build();
+    }
+
+    private String getRequestMatchPlayerId(List<MatchPlayer> matchPlayers) {
+        if (memberService.checkIfMemberIsAnonymous()) {
+            return "anonymous";
+        }
+        return findRequestMatchPlayerId(memberService.findCurrentMember(), matchPlayers);
     }
 
     private List<MatchPlayerScoreInfo> convertToMatchPlayerScoreInfoList(List<MatchPlayer> matchPlayers) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -20,11 +20,13 @@ import leaguehub.leaguehubbackend.service.jwt.JwtService;
 import leaguehub.leaguehubbackend.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -139,6 +141,16 @@ public class MemberService {
         return loginMemberResponse;
     }
 
+    public Boolean checkIfMemberIsAnonymous() {
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+        Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
 
+        for (GrantedAuthority authority : authorities) {
+            if ("ROLE_ANONYMOUS".equals(authority.getAuthority())) {
+                return true;
+            }
+        }
+        return false;
+    }
 }
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#319 

## 📝 Description

익명 유저(비로그인 유저)가 점수 정보를 요청시 participantId를 anonymous로 반환 합니다.

## ✨ Feature

1. 비로그인 유저 점수 정보 요청시 participantId를 anonymous로 반환

## 👌 Review Change
This closes #319 
리뷰를 통해 수정한 부분을 나열해주세요.