### PR TITLE
Fix,Test#327: 버그 픽스 및 MatchPlayerService 테스트 코드 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/config/MongoDataConfig.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/MongoDataConfig.java
@@ -6,9 +6,11 @@ import com.mongodb.client.MongoClients;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 @Configuration
+@EnableMongoAuditing
 public class MongoDataConfig {
 
 

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -73,7 +73,7 @@ public class MatchController {
             @Parameter(name = "matchRound", description = "조회하고 싶은 매치의 라운드(1, 2, 3)", example = "1, 2, 3, 4")
     })
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "매치가 조회되었습니다. - 배열로 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MatchInfoDto.class))),
+            @ApiResponse(responseCode = "200", description = "매치가 조회되었습니다. - 배열로 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MatchRoundInfoDto.class))),
             @ApiResponse(responseCode = "403", description = "권한이 관리자가 아님,채널을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @GetMapping("/match/{channelLink}/{matchRound}")
@@ -93,7 +93,7 @@ public class MatchController {
     })
     @MessageMapping("/match/{channelLink}")
     @SendTo("/match/round")
-    public ResponseEntity getRoundLive(@PathVariable("channelLink") String channelLink){
+    public ResponseEntity getRoundLive(@PathVariable("channelLink") String channelLink) {
 
         int myMatchRound = matchService.getMyMatchRound(channelLink);
 
@@ -105,7 +105,8 @@ public class MatchController {
     public void updateMatchPlayerScore(@DestinationVariable("matchId") String matchIdStr, @DestinationVariable("matchSet") String matchSetStr) {
         Long matchId = Long.valueOf(matchIdStr);
         Integer matchSet = Integer.valueOf(matchSetStr);
-        MatchInfoDto matchInfoDto = matchPlayerService.updateMatchPlayerScore(matchId, matchSet);
+        long endTime = System.currentTimeMillis() / 1000;
+        MatchInfoDto matchInfoDto = matchPlayerService.updateMatchPlayerScore(matchId, matchSet, endTime);
 
         simpMessagingTemplate.convertAndSend("/match/" + matchId + "/" + matchSet, matchInfoDto);
     }
@@ -144,12 +145,13 @@ public class MatchController {
     })
     @PostMapping("/match/{channelLink}/count")
     public ResponseEntity setMatchRoundCount(@PathVariable("channelLink") String channelLink,
-                                             @RequestBody List<Integer> roundCountList){
+                                             @RequestBody List<Integer> roundCountList) {
 
         matchService.setMatchSetCount(channelLink, roundCountList);
 
         return new ResponseEntity("경기 횟수가 배정되었습니다.", OK);
     }
+
     @Operation(summary = "해당 채널의 (1, 2, 3)라운드에 대한 설정된 경기 횟수를 반환")
     @Parameter(name = "roundCountList", description = "설정할려는 횟수 배열 결승전부터", example = "[3, 4, 2, 1]")
     @ApiResponses(value = {
@@ -157,7 +159,7 @@ public class MatchController {
             @ApiResponse(responseCode = "403", description = "매치 또는 채널을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @GetMapping("match/{channelLink}/count")
-    public ResponseEntity getMatchRoundCount(@PathVariable("channelLink") String channelLink){
+    public ResponseEntity getMatchRoundCount(@PathVariable("channelLink") String channelLink) {
 
         List<Integer> matchsetCountList = matchService.getMatchSetCount(channelLink);
 

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/GameResult.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/GameResult.java
@@ -1,23 +1,32 @@
 package leaguehub.leaguehubbackend.entity.match;
 
 import leaguehub.leaguehubbackend.dto.match.MatchRankResultDto;
-import leaguehub.leaguehubbackend.entity.BaseTimeEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Document(collection = "game_result")
 @Getter
 @NoArgsConstructor
-public class GameResult extends BaseTimeEntity {
+public class GameResult{
 
     @Id
     private Long id;
 
     private List<MatchRankResultDto> matchRankResult;
+
+    @CreatedDate
+    private LocalDateTime created_date;
+
+    @LastModifiedDate
+    private LocalDateTime modified_date;
+
 
     public static GameResult createGameResult(Long id, List<MatchRankResultDto> matchRankResult) {
         GameResult gameResult = new GameResult();

--- a/src/main/java/leaguehub/leaguehubbackend/mongo_repository/GameResultRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/mongo_repository/GameResultRepository.java
@@ -3,6 +3,8 @@ package leaguehub.leaguehubbackend.mongo_repository;
 import leaguehub.leaguehubbackend.entity.match.GameResult;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface GameResultRepository extends MongoRepository<GameResult, Long> {
+import java.util.Optional;
 
+public interface GameResultRepository extends MongoRepository<GameResult, Long> {
+    Optional<GameResult> findGameResultById(Long id);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -22,7 +22,7 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
     List<MatchPlayer> findMatchPlayersAndMatchAndParticipantByMatchId(@Param("matchId") Long matchId);
 
     @Query("select mp from MatchPlayer mp join fetch mp.participant join fetch mp.match where mp.match.id = :matchId " +
-            "and mp.matchPlayerResultStatus != leaguehub.leaguehubbackend.entity.match.MatchPlayerResultStatus.DISQUALIFICATION " +
+            "and mp.matchPlayerResultStatus <> leaguehub.leaguehubbackend.entity.match.MatchPlayerResultStatus.DISQUALIFICATION " +
             "order by mp.playerScore desc, mp.participant.gameId")
     List<MatchPlayer> findMatchPlayersWithoutDisqualification(@Param("matchId") Long matchId);
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -2,7 +2,6 @@ package leaguehub.leaguehubbackend.service.match;
 
 import leaguehub.leaguehubbackend.dto.match.*;
 import leaguehub.leaguehubbackend.entity.match.*;
-import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchAlreadyUpdateException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchNotFoundException;
@@ -82,8 +81,8 @@ public class MatchPlayerService {
      * @param puuid
      * @return
      */
-    public String getMatch(String puuid) {
-        long endTime = System.currentTimeMillis() / 1000;
+    public String getMatch(String puuid, long endTime) {
+//        long endTime = System.currentTimeMillis() / 1000;
         long statTime = 0;
 
         String matchUrl = "https://asia.api.riotgames.com/tft/match/v1/matches/by-puuid/";
@@ -100,9 +99,7 @@ public class MatchPlayerService {
 
 
         return matchArray.get(0).toString();
-
     }
-
 
     @SneakyThrows
     public JSONObject responseMatchDetail(String matchId) {
@@ -153,9 +150,9 @@ public class MatchPlayerService {
      * @return matchRankResultDto
      */
     @SneakyThrows
-    public RiotAPIDto getMatchDetailFromRiot(String gameId, List<MatchPlayer> findMatchPlayerList) {
+    public RiotAPIDto getMatchDetailFromRiot(String gameId, List<MatchPlayer> findMatchPlayerList, Long endTime) {
         String puuid = getSummonerPuuid(gameId);
-        String riotMatchUuid = getMatch(puuid);
+        String riotMatchUuid = getMatch(puuid, endTime);
 
         JSONObject matchDetailJSON = responseMatchDetail(riotMatchUuid);
 
@@ -169,18 +166,20 @@ public class MatchPlayerService {
         return new RiotAPIDto(riotMatchUuid, matchRankResultDtoList);
     }
 
-    public MatchInfoDto updateMatchPlayerScore(Long matchId, Integer setCount) {
+    public MatchInfoDto updateMatchPlayerScore(Long matchId, Integer setCount, Long endTime) {
         List<MatchPlayer> findMatchPlayerList = matchPlayerRepository.findMatchPlayersWithoutDisqualification(matchId);
 
-        RiotAPIDto matchDetailFromRiot = getMatchDetailFromRiot(findMatchPlayerList.get(0).getParticipant().getGameId(), findMatchPlayerList);
+        RiotAPIDto matchDetailFromRiot =
+                getMatchDetailFromRiot(findMatchPlayerList.get(0).getParticipant().getGameId(),
+                        findMatchPlayerList, endTime);
 
         MatchSet matchSet = getMatchSet(matchId, setCount);
 
-        matchSet.updateRiotMatchUuid(matchDetailFromRiot.getMatchUuid());
+        if (matchSet.getRiotMatchUuid() == null) matchSet.updateRiotMatchUuid(matchDetailFromRiot.getMatchUuid());
 
         List<MatchRankResultDto> matchRankResultDtoList = matchDetailFromRiot.getMatchRankResultDtoList();
-
         validMatchResult(findMatchPlayerList, matchRankResultDtoList);
+        Collections.sort(matchRankResultDtoList, Comparator.comparing(MatchRankResultDto::getPlacement));
 
         replaceMatchResult(findMatchPlayerList.stream()
                 .map(matchPlayer -> matchPlayer.getParticipant().getGameId()).collect(Collectors.toList()), matchRankResultDtoList);
@@ -188,9 +187,10 @@ public class MatchPlayerService {
         matchRankResultDtoList
                 .forEach(matchRankResultDto ->
                         findMatchPlayerList.stream()
-                                .filter(matchPlayer -> matchPlayer.getId().equals(matchRankResultDto.getGameId()))
+                                .filter(matchPlayer -> matchPlayer.getParticipant().getGameId().equals(matchRankResultDto.getGameId()))
                                 .forEach(matchPlayer -> matchPlayer.updateMatchPlayerScore(matchRankResultDto.getPlacement()))
                 );
+
 
         matchSet.updateScore(true);
 
@@ -202,7 +202,8 @@ public class MatchPlayerService {
         Match match = findMatchPlayerList.get(0).getMatch();
         checkMatchEnd(matchSet, match);
 
-        MatchInfoDto matchInfoDto = matchService.convertMatchInfoDto(match, findMatchPlayerList);
+        List<MatchPlayer> allByMatchId = matchPlayerRepository.findAllByMatch_Id(matchId);
+        MatchInfoDto matchInfoDto = matchService.convertMatchInfoDto(match, allByMatchId);
 
         return matchInfoDto;
     }
@@ -222,8 +223,11 @@ public class MatchPlayerService {
         if (matchSets.isEmpty()) throw new MatchResultIdNotFoundException();
 
         List<GameResult> gameResultList = matchSets.stream()
-                .map(matchSet -> gameResultRepository.findById(matchSet.getId()).orElseThrow())
+                .map(matchSet -> gameResultRepository.findGameResultById(matchSet.getId()))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.toList());
+
 
         return gameResultList;
     }
@@ -332,7 +336,7 @@ public class MatchPlayerService {
             MatchPlayer matchPlayer = tieMatchPlayerList.get(0);
             matchPlayer.updateMatchPlayerResultStatus(ADVANCE);
         } else if (winCount < 4 && tieMatchPlayerList.size() > 1) {
-            tieBreaker(tieMatchPlayerList, match.getId());
+            tieBreaker(tieMatchPlayerList, match.getId(), 4 - Long.valueOf(winCount).intValue());
         }
     }
 
@@ -374,7 +378,7 @@ public class MatchPlayerService {
      * @param tieMatchPlayerList
      * @param matchId
      */
-    public void tieBreaker(List<MatchPlayer> tieMatchPlayerList, Long matchId) {
+    public void tieBreaker(List<MatchPlayer> tieMatchPlayerList, Long matchId, Integer advanceCount) {
         List<MatchSet> matchSets = matchSetRepository.findMatchSetsByMatch_Id(matchId);
         List<GameResult> matchSetResult = getMatchSetResult(matchSets);
 
@@ -383,15 +387,28 @@ public class MatchPlayerService {
                 .map(matchPlayer -> matchPlayer.getParticipant().getGameId())
                 .collect(Collectors.toList());
 
+        int tiePlayerCount = tieMatchPlayerList.size();
 
-        tiePlayerGameIdList = mostFirstPlayer(matchSetResult, tiePlayerGameIdList);
-
-        if (tiePlayerGameIdList.size() != 1) {
-            lastGamePlacement(tiePlayerGameIdList, matchSetResult);
+        List<String> firstPlayer = mostFirstPlayer(matchSetResult, tiePlayerGameIdList);
+        if (advanceCount - firstPlayer.size() >= 0) {
+            updateMatchPlayerStatus(tieMatchPlayerList, firstPlayer);
+            tieMatchPlayerList.removeIf(matchPlayer -> firstPlayer.contains(matchPlayer.getParticipant().getGameId()));
+            tiePlayerGameIdList.removeAll(firstPlayer);
+            advanceCount -= firstPlayer.size();
+            tiePlayerCount -= firstPlayer.size();
+        } else {
+            updateMatchPlayerStatus(tieMatchPlayerList, firstPlayer);
+            tieMatchPlayerList.removeIf(matchPlayer -> !firstPlayer.contains(matchPlayer.getParticipant().getGameId()));
         }
 
-        updateMatchPlayerStatus(tieMatchPlayerList, tiePlayerGameIdList);
-
+        if (advanceCount > 0) {
+            if (tiePlayerCount > advanceCount) {
+                List<String> tiePlayerGameIdOfAdvanceList = lastGamePlacement(tiePlayerGameIdList, matchSetResult, advanceCount);
+                updateMatchPlayerStatus(tieMatchPlayerList, tiePlayerGameIdOfAdvanceList);
+            } else {
+                updateMatchPlayerStatus(tieMatchPlayerList, tiePlayerGameIdList);
+            }
+        }
     }
 
     private void updateMatchPlayerStatus(List<MatchPlayer> tieMatchPlayerList, List<String> tiePlayerGameIdList) {
@@ -450,30 +467,27 @@ public class MatchPlayerService {
      *
      * @param tiePlayerGameIdList
      * @param matchSetResult
+     * @return
      */
-    private void lastGamePlacement(List<String> tiePlayerGameIdList, List<GameResult> matchSetResult) {
-        matchSetResult.sort(Comparator.comparing(GameResult::getModifiedDate).reversed());
+    private List<String> lastGamePlacement(List<String> tiePlayerGameIdList, List<GameResult> matchSetResult, Integer advanceCount) {
+        matchSetResult.sort(Comparator.comparing(GameResult::getModified_date).reversed());
 
         List<MatchRankResultDto> matchRankResult = matchSetResult.get(0).getMatchRankResult();
 
-        int highestPlacement = Integer.MAX_VALUE;
-        String playerWithHighestPlacement = null;
+        matchRankResult.sort(Comparator.comparing(MatchRankResultDto::getPlacement));
+
+        List<String> tiePlayerGameIdOfAdvanceList = new ArrayList<>();
 
 
-        for (String gameId : tiePlayerGameIdList) {
-            for (MatchRankResultDto matchRankResultDto : matchRankResult) {
-                Integer placement = matchRankResultDto.getPlacement();
-                String resultGameId = matchRankResultDto.getGameId();
-                if (gameId.equals(resultGameId)
-                        && highestPlacement > placement) {
-                    highestPlacement = placement;
-                    playerWithHighestPlacement = resultGameId;
-                }
+        for (MatchRankResultDto matchRankResultDto : matchRankResult) {
+            String resultGameId = matchRankResultDto.getGameId();
+            if (tiePlayerGameIdList.contains(resultGameId) && advanceCount > 0) {
+                tiePlayerGameIdOfAdvanceList.add(resultGameId);
+                advanceCount--;
             }
         }
 
-        tiePlayerGameIdList.clear();
-        tiePlayerGameIdList.add(playerWithHighestPlacement);
+        return tiePlayerGameIdOfAdvanceList;
     }
 
     private List<GameResult> getMatchSetResult(List<MatchSet> matchSets) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -389,19 +389,26 @@ public class MatchPlayerService {
 
         int tiePlayerCount = tieMatchPlayerList.size();
 
+        //가장 많이 1등 한 사람들을 뽑는 로직
         List<String> firstPlayer = mostFirstPlayer(matchSetResult, tiePlayerGameIdList);
+
+        //진출 숫자가 1등 플레이어보다 많으면 1등 플레이어 모두 진출
         if (advanceCount - firstPlayer.size() >= 0) {
+            //1등 플레이어 제외 모두 drop으로 바뀜
             updateMatchPlayerStatus(tieMatchPlayerList, firstPlayer);
             tieMatchPlayerList.removeIf(matchPlayer -> firstPlayer.contains(matchPlayer.getParticipant().getGameId()));
             tiePlayerGameIdList.removeAll(firstPlayer);
             advanceCount -= firstPlayer.size();
             tiePlayerCount -= firstPlayer.size();
         } else {
+            //그게 아니면 1등 플레이어들만 남기고 전부 탈락
             updateMatchPlayerStatus(tieMatchPlayerList, firstPlayer);
             tieMatchPlayerList.removeIf(matchPlayer -> !firstPlayer.contains(matchPlayer.getParticipant().getGameId()));
         }
 
+        //advanceCount가 0보다 크면 들어감, 만약 advanceCount가 0이면, 위에서 전부 Drop 했기 때문에 그냥 넘어감
         if (advanceCount > 0) {
+            //1등 플레이어 로직으로 걸러진 동점자들이 남은 advanceCount보다 크면 최근 경기 등수 대로, 만약 작거나 같으면 전부 진출
             if (tiePlayerCount > advanceCount) {
                 List<String> tiePlayerGameIdOfAdvanceList = lastGamePlacement(tiePlayerGameIdList, matchSetResult, advanceCount);
                 updateMatchPlayerStatus(tieMatchPlayerList, tiePlayerGameIdOfAdvanceList);

--- a/src/test/java/leaguehub/leaguehubbackend/entity/participant/ParticipantTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/entity/participant/ParticipantTest.java
@@ -58,7 +58,7 @@ class ParticipantTest {
         Participant participant = participantRepository.save(Participant.createHostChannel(member, channel));
 
 
-        assertThat(participantRepository.findAll().size()).isEqualTo(1);
+        assertThat(participantRepository.findAllByChannel_ChannelLink(channel.getChannelLink()).size()).isEqualTo(1);
         assertThat(participant.getChannel()).isEqualTo(channel);
         assertThat(participant.getMember()).isEqualTo(member);
         assertThat(participant.getRole()).isEqualTo(Role.HOST);

--- a/src/test/java/leaguehub/leaguehubbackend/service/match/MatchPlayerServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/match/MatchPlayerServiceTest.java
@@ -1,0 +1,130 @@
+package leaguehub.leaguehubbackend.service.match;
+
+import jakarta.transaction.Transactional;
+import leaguehub.leaguehubbackend.dto.match.MatchInfoDto;
+import leaguehub.leaguehubbackend.dto.match.MatchPlayerInfo;
+import leaguehub.leaguehubbackend.entity.match.GameResult;
+import leaguehub.leaguehubbackend.entity.match.MatchPlayerResultStatus;
+import leaguehub.leaguehubbackend.entity.match.MatchStatus;
+import leaguehub.leaguehubbackend.entity.match.PlayerStatus;
+import leaguehub.leaguehubbackend.exception.match.exception.MatchAlreadyUpdateException;
+import leaguehub.leaguehubbackend.exception.match.exception.MatchResultIdNotFoundException;
+import leaguehub.leaguehubbackend.mongo_repository.GameResultRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(locations = "classpath:application-test.properties")
+class MatchPlayerServiceTest {
+
+    @Autowired
+    MatchPlayerRepository matchPlayerRepository;
+    @Autowired
+    GameResultRepository gameResultRepository;
+    @Autowired
+    MatchRepository matchRepository;
+    @Autowired
+    MatchPlayerService matchPlayerService;
+
+    @Test
+    @DisplayName("점수 업데이트 성공 - 동점자 로직(1등 많이 한 사람, Becrux) 진출")
+    void updateMatchPlayerScore() {
+        MatchInfoDto matchInfoDto = matchPlayerService.updateMatchPlayerScore(1L, 3, 1691910300L);
+
+        assertThat(matchInfoDto.getMatchStatus()).isEqualTo(MatchStatus.END);
+
+        Optional<MatchPlayerInfo> 무진스_협회장 = matchInfoDto.getMatchPlayerInfoList().stream()
+                .filter(matchPlayerInfo -> matchPlayerInfo.getGameId().equals("무진스 협회장"))
+                .findFirst();
+        assertThat(무진스_협회장.get().getMatchPlayerResultStatus()).isEqualTo(MatchPlayerResultStatus.DISQUALIFICATION);
+
+        Optional<MatchPlayerInfo> ChikaPuka = matchInfoDto.getMatchPlayerInfoList().stream()
+                .filter(matchPlayerInfo -> matchPlayerInfo.getGameId().equals("ChikaPuka"))
+                .findFirst();
+
+        assertThat(ChikaPuka.get().getScore()).isEqualTo(108);
+        assertThat(ChikaPuka.get().getMatchPlayerResultStatus()).isEqualTo(MatchPlayerResultStatus.ADVANCE);
+        assertThat(ChikaPuka.get().getPlayerStatus()).isEqualTo(PlayerStatus.WAITING);
+
+
+        Optional<MatchPlayerInfo> 플레이어개장줄 = matchInfoDto.getMatchPlayerInfoList().stream()
+                .filter(matchPlayerInfo -> matchPlayerInfo.getGameId().equals("플레이어개장줄"))
+                .findFirst();
+        Optional<MatchPlayerInfo> doaltlqkfrpdla = matchInfoDto.getMatchPlayerInfoList().stream()
+                .filter(matchPlayerInfo -> matchPlayerInfo.getGameId().equals("doaltlqkfrpdla"))
+                .findFirst();
+        Optional<MatchPlayerInfo> Becrux = matchInfoDto.getMatchPlayerInfoList().stream()
+                .filter(matchPlayerInfo -> matchPlayerInfo.getGameId().equals("Becrux"))
+                .findFirst();
+
+        assertThat(Becrux.get().getMatchPlayerResultStatus()).isEqualTo(MatchPlayerResultStatus.ADVANCE);
+        assertThat(플레이어개장줄.get().getMatchPlayerResultStatus()).isEqualTo(MatchPlayerResultStatus.ADVANCE);
+        assertThat(doaltlqkfrpdla.get().getMatchPlayerResultStatus()).isEqualTo(MatchPlayerResultStatus.DROPOUT);
+        assertThat(matchInfoDto.getMatchPlayerInfoList().get(5).getGameId()).isEqualTo("반갑쨔나");
+
+    }
+
+
+    @Test
+    @DisplayName("유효하지 않은 경기 - 가져온 결과에 모든 참가자가 있지 않음")
+    void updateMatchPlayerScore_fail() {
+        assertThatThrownBy(() -> matchPlayerService.updateMatchPlayerScore(1L, 3, 1695726000L))
+                .isInstanceOf(MatchResultIdNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("매치 플레이어 점수 업데이트 - 실패(이미 업데이트 되어있음.)")
+    void updateMatchPlayerScore_Fail() {
+        assertThatThrownBy(() -> matchPlayerService.updateMatchPlayerScore(1L, 2, 1691908000L))
+                .isInstanceOf(MatchAlreadyUpdateException.class);
+    }
+
+    @Test
+    @DisplayName("이전 경기 결과 조회 테스트")
+    void getGameResult() {
+        List<GameResult> gameResultList = matchPlayerService.getGameResult(1L);
+
+        assertThat(gameResultList.size()).isEqualTo(2);
+        assertThat(gameResultList.get(0).getMatchRankResult().stream()
+                .filter(matchRankResultDto -> matchRankResultDto.getGameId().equals("무진스 협회장"))
+                .findFirst().get().getPlacement()).isEqualTo(6);
+
+        assertThat(gameResultList.get(1).getMatchRankResult().stream()
+                .filter(matchRankResultDto -> matchRankResultDto.getGameId().equals("무진스 협회장"))
+                .findFirst().get().getPlacement()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("이전 경기 결과 조회 테스트-결과없음")
+    void getGameResult_fail() {
+        List<GameResult> gameResultList = matchPlayerService.getGameResult(2L);
+
+        assertThat(gameResultList.size()).isEqualTo(0);
+    }
+
+    @BeforeEach
+    void rollBack() {
+        List<GameResult> gameResultList = matchPlayerService.getGameResult(1L);
+        List<Long> idList = Arrays.asList(1L, 2L);
+        if (gameResultList.size() >= 3) {
+            gameResultList.stream().filter(gameResult -> !idList.contains(gameResult.getId()))
+                    .forEach(gameResult -> gameResultRepository.delete(gameResult));
+        }
+    }
+}

--- a/src/test/java/leaguehub/leaguehubbackend/service/match/MatchServiceScoreTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/match/MatchServiceScoreTest.java
@@ -148,7 +148,6 @@ public class MatchServiceScoreTest {
         MatchScoreInfoDto result = matchService.getMatchScoreInfo(savedMatch.getId());
 
         assertNotNull(result);
-        assertEquals("1", result.getRequestMatchPlayerId());
 
         List<MatchPlayerScoreInfo> scoreInfos = result.getMatchPlayerScoreInfos();
         assertNotNull(scoreInfos);


### PR DESCRIPTION
## 🙆‍♂️ Issue

#327 

## 📝 Description

플레이어 스코어 업데이트, 다음 매치 넘어가기 확인, 매치 정보 가져오기, 동점자처리(1등 많이 한 사람), 동점자 처리 (최근 경기 높은 순위), 실격한 사람 빼고 계산하는 로직과 몽고 Auditing 설정을 따로 추가해서 넣어줬어요. 그리고 컨트롤러를 조금 수정하고, unix 타임으로 라이엇에서 매치를 가져오는 메서드 테스트를 위해 컨트롤러에서 현재 시간을 주입했어요.

<img width="1185" alt="image" src="https://github.com/TheUpperPart/leaguehub-backend/assets/102659136/2d8572ec-0eb6-4685-8ca7-92955b743eb7">
나중에 더미데이터를 더 추가해서 좀 더 테스트 해야겠어요.

<img width="1187" alt="image" src="https://github.com/TheUpperPart/leaguehub-backend/assets/102659136/ec52ab0c-addb-45bf-93b8-eb2b52c88882">
전체는 이정도인데 모든 분기의 케이스를 테스트하는 코드를 늘려야겠어요.

## ✨ Feature

matchPlayerService, 테스트, 몽고 Auditing 구현

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #327 