### PR TITLE
Feat#343 : 매치 채팅 내역 조회 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchChatController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchChatController.java
@@ -1,12 +1,23 @@
 package leaguehub.leaguehubbackend.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import leaguehub.leaguehubbackend.dto.chat.MatchMessage;
+import leaguehub.leaguehubbackend.dto.member.LoginMemberResponse;
+import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.chat.MatchChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -26,12 +37,20 @@ public class MatchChatController {
         matchChatService.processMessage(message);
     }
 
-    @MessageMapping("/channel/{channelId}/match/{matchId}/chat/history")
-    public void getMatchChatHistory(@DestinationVariable("matchId") String channelIdStr, @DestinationVariable("matchId") String matchIdStr) {
+    @Operation(summary = "관리자 페이지에서 매치 채팅 내역 조회")
+    @Parameters(value = {
+            @Parameter(name = "channelId", description = "채널 id", example = "1"),
+            @Parameter(name = "matchId", description = "매치 id", example = "1")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "매치 채팅 내역 조회성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MatchMessage.class))),
+    })
+    @PostMapping("/api/channel/{channelId}/match/{matchId}/chat/history")
+    public void getMatchChatHistory(@PathVariable("matchId") Long channelId, @PathVariable("matchId") Long matchId) {
 
-        List<MatchMessage> matchMessages = matchChatService.findMatchChatHistory(channelIdStr, matchIdStr);
+        List<MatchMessage> matchMessages = matchChatService.findMatchChatHistory(channelId, matchId);
 
-        String matchChat = String.format(MATCH_CHAT_DESTINATION_FORMAT, matchIdStr);
+        String matchChat = String.format(MATCH_CHAT_DESTINATION_FORMAT, matchId);
 
         simpMessagingTemplate.convertAndSend(matchChat, matchMessages);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -8,9 +8,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import leaguehub.leaguehubbackend.dto.chat.MatchMessage;
 import leaguehub.leaguehubbackend.dto.match.*;
 import leaguehub.leaguehubbackend.entity.match.GameResult;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.service.chat.MatchChatService;
 import leaguehub.leaguehubbackend.service.match.MatchPlayerService;
 import leaguehub.leaguehubbackend.service.match.MatchService;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +37,7 @@ public class MatchController {
     private final MatchPlayerService matchPlayerService;
     private final MatchService matchService;
     private final SimpMessagingTemplate simpMessagingTemplate;
-
+    private final MatchChatService matchChatService;
     @Operation(summary = "라운드 수(몇 강) 리스트 반환")
     @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
     @ApiResponses(value = {
@@ -126,10 +128,14 @@ public class MatchController {
             @ApiResponse(responseCode = "200", description = "매치가 조회됨", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MatchScoreInfoDto.class))),
             @ApiResponse(responseCode = "404", description = "매치를 찾지 못함", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
-    @GetMapping("/match/{matchId}/player/info")
-    public ResponseEntity loadMatchScore(@PathVariable("matchId") Long matchId) {
+    @GetMapping("/channel/{channelId}/match/{matchId}/player/info")
+    public ResponseEntity loadMatchScore(@PathVariable("matchId") Long channelId, @PathVariable("matchId") Long matchId) {
 
         MatchScoreInfoDto matchScoreInfoDto = matchService.getMatchScoreInfo(matchId);
+
+        List<MatchMessage> matchMessages = matchChatService.findMatchChatHistory(channelId, matchId);
+
+        matchScoreInfoDto.setMatchMessages(matchMessages);
 
         return new ResponseEntity<>(matchScoreInfoDto, OK);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchScoreInfoDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchScoreInfoDto.java
@@ -1,5 +1,6 @@
 package leaguehub.leaguehubbackend.dto.match;
 
+import leaguehub.leaguehubbackend.dto.chat.MatchMessage;
 import lombok.Builder;
 import lombok.Data;
 
@@ -11,4 +12,8 @@ public class MatchScoreInfoDto {
     private String requestMatchPlayerId;
 
     private List<MatchPlayerInfo> matchPlayerInfos;
+
+    private List<MatchMessage> matchMessages;
+
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/chat/MatchChatService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/chat/MatchChatService.java
@@ -63,9 +63,7 @@ public class MatchChatService {
     }
 
 
-    public List<MatchMessage> findMatchChatHistory(String channelIdStr, String matchIdStr) {
-        Long matchId = Long.valueOf(matchIdStr);
-        Long channelId = Long.valueOf(channelIdStr);
+    public List<MatchMessage> findMatchChatHistory(Long matchId, Long channelId) {
 
         String targetMatch = String.format(REDIS_KEY_FORMAT, channelId, matchId);
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#343 

## 📝 Description

매치 정보를 불러올시 채팅내역도 함께 추가하여 전달합니다.
관리자 페이지에서 매치 채팅 조회를 위한 api 또한 구현했습니다.

## ✨ Feature
1. 매치 정보에 채팅 내역 추가
2. 관리자 페이지 매치 채팅 조회 api 구현 

## 👌 Review Change
This closes #343 
리뷰를 통해 수정한 부분을 나열해주세요.