### PR TITLE
Feat#350 : Match 정보 조회 정보 변경

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchScoreInfoDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/match/MatchScoreInfoDto.java
@@ -9,7 +9,11 @@ import java.util.List;
 @Data
 @Builder
 public class MatchScoreInfoDto {
-    private String requestMatchPlayerId;
+    private Long requestMatchPlayerId;
+
+    private Integer currentMatchRound;
+
+    private Integer totalMatchRound;
 
     private List<MatchPlayerInfo> matchPlayerInfos;
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -434,14 +434,19 @@ public class MatchService {
                 .filter(list -> !list.isEmpty())
                 .orElseThrow(MatchNotFoundException::new);
 
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(MatchNotFoundException::new);
+
         List<MatchPlayerInfo> matchPlayerInfoList = convertMatchPlayerInfoList(matchPlayers);
 
         sortAndRankMatchPlayerInfoList(matchPlayerInfoList);
 
-        String requestMatchPlayerId = getRequestMatchPlayerId(matchPlayers);
+        Long requestMatchPlayerId = getRequestMatchPlayerId(matchPlayers);
 
         return MatchScoreInfoDto.builder()
                 .matchPlayerInfos(matchPlayerInfoList)
+                .currentMatchRound(match.getMatchCurrentSet())
+                .totalMatchRound(match.getMatchSetCount())
                 .requestMatchPlayerId(requestMatchPlayerId)
                 .build();
     }
@@ -468,20 +473,20 @@ public class MatchService {
         }
     }
 
-    private String getRequestMatchPlayerId(List<MatchPlayer> matchPlayers) {
+    private Long getRequestMatchPlayerId(List<MatchPlayer> matchPlayers) {
         if (memberService.checkIfMemberIsAnonymous()) {
-            return "anonymous";
+            return 0L;
         }
         return findRequestMatchPlayerId(memberService.findCurrentMember(), matchPlayers);
     }
 
-    private String findRequestMatchPlayerId(Member member, List<MatchPlayer> matchPlayers) {
+    private Long findRequestMatchPlayerId(Member member, List<MatchPlayer> matchPlayers) {
         for (MatchPlayer mp : matchPlayers) {
             if (mp.getParticipant().getMember().getId().equals(member.getId())) {
-                return mp.getId().toString();
+                return mp.getId();
             }
         }
-        return "Observer";
+        return 0L;
     }
 
     private static void updateMatchSetCount(List<Integer> roundCount, List<Match> findMatchList) {


### PR DESCRIPTION
## 🙆‍♂️ Issue

#350 

## 📝 Description

Match 정보를 조회시 이제 총 round와 현재 round 정보를 반환합니다.
또한 비로그인 혹은 옵저바가 Match 정보를 조회시 MatchPlayerId를 0으로 반환합니다.
일반 참여자는 고유 MatchPlayerId가 반환됩니다.

## ✨ Feature

1. MatchScoreInfoDto 조회시 round 상황 반환
2. 비로그인 + 옵저버가 조회시 matchPlayerId 0 반환

## 👌 Review Change
This closes #350 
리뷰를 통해 수정한 부분을 나열해주세요.