### PR TITLE
Feat#373: 체크인, 점수 업데이트시 유효성 매치 종료 검사 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/match/MatchPlayerRepository.java
@@ -23,6 +23,7 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
 
     @Query("select mp from MatchPlayer mp join fetch mp.participant join fetch mp.match where mp.match.id = :matchId " +
             "and mp.matchPlayerResultStatus <> leaguehub.leaguehubbackend.entity.match.MatchPlayerResultStatus.DISQUALIFICATION " +
+            "and mp.match.matchStatus <> leaguehub.leaguehubbackend.entity.match.MatchStatus.END " +
             "order by mp.playerScore desc, mp.participant.gameId")
     List<MatchPlayer> findMatchPlayersWithoutDisqualification(@Param("matchId") Long matchId);
 
@@ -31,7 +32,7 @@ public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> 
 
     List<MatchPlayer> findMatchPlayersByParticipantId(Long participantId);
 
-    Optional<MatchPlayer> findMatchPlayerByIdAndMatch_Id(Long matchPlayerId, Long matchId);
+    Optional<MatchPlayer> findMatchPlayerByIdAndMatch_Id(@Param("matchPlayerId") Long matchPlayerId, @Param("matchId") Long matchId);
 
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -27,7 +27,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -170,6 +169,8 @@ public class MatchPlayerService {
     public MatchInfoDto updateMatchPlayerScore(Long matchId, Integer setCount, Long endTime) {
         List<MatchPlayer> findMatchPlayerList = matchPlayerRepository.findMatchPlayersWithoutDisqualification(matchId);
 
+        if(findMatchPlayerList.size() == 0) throw new MatchNotFoundException();
+
         RiotAPIDto matchDetailFromRiot =
                 getMatchDetailFromRiot(findMatchPlayerList.get(0).getParticipant().getGameId(),
                         findMatchPlayerList, endTime);
@@ -303,6 +304,10 @@ public class MatchPlayerService {
         Long matchPlayerId = message.getMatchPlayerId();
 
         MatchPlayer matchPlayer = findMatchPlayer(matchPlayerId, matchId);
+
+        if(matchPlayer.getMatchPlayerResultStatus() != MatchPlayerResultStatus.PROGRESS) {
+            throw new MatchAlreadyUpdateException();
+        }
 
         matchPlayer.updatePlayerCheckInStatus(READY);
         matchPlayerRepository.save(matchPlayer);


### PR DESCRIPTION
## 🙆‍♂️ Issue

#373 

## 📝 Description

매치 종료시에 체크인 및 점수 업데이트를 하지 못하도록 했어요.

## ✨ Feature

체크인 시 플레이어 결과를 보고 매치 종료 유효성 검사, 점수 업데이트 시도 시 매치 종료 유효성 검사 추가

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #373 