### PR TITLE
fix: convertMatchPlayerDto 중복 등수 추가 및 통합

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -397,7 +397,7 @@ public class MatchService {
 
 
     public List<MatchPlayerInfo> convertMatchPlayerInfoList(List<MatchPlayer> matchPlayers) {
-        List<MatchPlayerInfo> collect = matchPlayers.stream()
+        List<MatchPlayerInfo> matchPlayerInfoList = matchPlayers.stream()
                 .map(matchPlayer -> new MatchPlayerInfo(
                         matchPlayer.getId(),
                         matchPlayer.getParticipant().getId(),
@@ -409,15 +409,13 @@ public class MatchService {
                         matchPlayer.getParticipant().getProfileImageUrl(),
                         matchPlayer.getPlayerScore()
                 ))
-                .sorted(Comparator.comparingInt(MatchPlayerInfo::getScore).reversed())
+                .sorted(Comparator.comparingInt(MatchPlayerInfo::getScore).reversed()
+                        .thenComparing(MatchPlayerInfo::getGameId))
                 .collect(Collectors.toList());
 
-        int i = INITIAL_RANK;
-        for (MatchPlayerInfo matchPlayerInfo : collect) {
-            matchPlayerInfo.setMatchRank(i++);
-        }
+        assignRankToMatchPlayerInfoList(matchPlayerInfoList);
 
-        return collect;
+        return matchPlayerInfoList;
     }
 
     private Participant checkHost(String channelLink) {
@@ -473,8 +471,6 @@ public class MatchService {
 
         List<MatchPlayerInfo> matchPlayerInfoList = convertMatchPlayerInfoList(matchPlayers);
 
-        sortAndRankMatchPlayerInfoList(matchPlayerInfoList);
-
         Long requestMatchPlayerId = getRequestMatchPlayerId(channelLink, matchPlayers);
 
         return MatchScoreInfoDto.builder()
@@ -484,17 +480,6 @@ public class MatchService {
                 .matchSetCount(match.getMatchSetCount())
                 .requestMatchPlayerId(requestMatchPlayerId)
                 .build();
-    }
-
-    private void sortAndRankMatchPlayerInfoList(List<MatchPlayerInfo> matchPlayerInfoList) {
-        sortMatchPlayerInfoList(matchPlayerInfoList);
-        assignRankToMatchPlayerInfoList(matchPlayerInfoList);
-    }
-
-    private void sortMatchPlayerInfoList(List<MatchPlayerInfo> matchPlayerInfoList) {
-        matchPlayerInfoList.sort(Comparator
-                .comparing(MatchPlayerInfo::getScore).reversed()
-                .thenComparing(MatchPlayerInfo::getGameId));
     }
 
     private void assignRankToMatchPlayerInfoList(List<MatchPlayerInfo> matchPlayerInfoList) {


### PR DESCRIPTION
## 🙆‍♂️ Issue

#388 

## 📝 Description

등수를 추가하고 반환하는 로직을 통합했어요. 그 전 이슈에선 중복 등수가 안되었는데 이번엔 중복 등수까지 추가했습니다.
getMatchScoreInfo 반환과 점수 업데이트시 반환하는 로직의 반환이 비슷해서 통합시켰으니 코드 삭제, 수정 확인 부탁드릴께요.

## ✨ Feature

matchService refactoring 및 버그 fix

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #388 