### PR TITLE
Fix#396: 채널 보드 인덱스가 업데이트 되지 않은 문제 해결

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/dto/channel/ChannelBoardIndexListDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/channel/ChannelBoardIndexListDto.java
@@ -1,12 +1,12 @@
 package leaguehub.leaguehubbackend.dto.channel;
 
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @NoArgsConstructor
-@Getter
+@Data
 public class ChannelBoardIndexListDto {
 
     private List<ChannelBoardLoadDto> channelBoardLoadDtoList;

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
@@ -127,7 +127,7 @@ public class ChannelBoardService {
 
         channelBoardLoadDtoList.forEach(channelBoardLoadDto -> {
             channelBoards.stream()
-                    .filter(channelBoard -> channelBoard.getId() == channelBoardLoadDto.getBoardId())
+                    .filter(channelBoard -> channelBoard.getId().equals(channelBoardLoadDto.getBoardId()))
                     .findFirst()
                     .ifPresent(channelBoard -> channelBoard.updateIndex(channelBoardLoadDto.getBoardIndex()));
         });

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -264,7 +264,7 @@ public class MatchPlayerService {
      * @param match
      */
     private void checkMatchEnd(MatchSet matchSet, Match match) {
-        if (match.getMatchSetCount() == matchSet.getSetCount()) {
+        if (match.getMatchSetCount().equals(matchSet.getSetCount())) {
             match.updateMatchStatus(MatchStatus.END);
             updateEndMatchResult(match);
         } else {
@@ -474,7 +474,7 @@ public class MatchPlayerService {
             }
         }
 
-        if (mostFirstPlayerInTieList.size() != 0) {
+        if (!mostFirstPlayerInTieList.isEmpty()) {
             return mostFirstPlayerInTieList;
         }
 

--- a/src/test/java/leaguehub/leaguehubbackend/controller/channel/ChannelBoardControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/channel/ChannelBoardControllerTest.java
@@ -1,10 +1,7 @@
 package leaguehub.leaguehubbackend.controller.channel;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import leaguehub.leaguehubbackend.dto.channel.ChannelBoardDto;
-import leaguehub.leaguehubbackend.dto.channel.ChannelBoardLoadDto;
-import leaguehub.leaguehubbackend.dto.channel.CreateChannelDto;
-import leaguehub.leaguehubbackend.dto.channel.ParticipantChannelDto;
+import leaguehub.leaguehubbackend.dto.channel.*;
 import leaguehub.leaguehubbackend.entity.channel.Channel;
 import leaguehub.leaguehubbackend.entity.channel.ChannelBoard;
 import leaguehub.leaguehubbackend.entity.channel.ChannelRule;
@@ -301,8 +298,10 @@ class ChannelBoardControllerTest {
         List<ChannelBoardLoadDto> channelBoardLoadDtoList = channelBoardService.loadChannelBoards(channel.get().getChannelLink()).getChannelBoardLoadDtoList();
         channelBoardLoadDtoList.get(0).setBoardIndex(3);
         channelBoardLoadDtoList.get(2).setBoardIndex(1);
+        ChannelBoardIndexListDto channelBoardIndexListDto = new ChannelBoardIndexListDto();
+        channelBoardIndexListDto.setChannelBoardLoadDtoList(channelBoardLoadDtoList);
 
-        String json = objectMapper.writeValueAsString(channelBoardLoadDtoList);
+        String json = objectMapper.writeValueAsString(channelBoardIndexListDto);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/channel/"
                                 + channel.get().getChannelLink() + "/order")
@@ -322,7 +321,10 @@ class ChannelBoardControllerTest {
         channelBoardLoadDtoList.get(0).setBoardIndex(3);
         channelBoardLoadDtoList.get(2).setBoardIndex(1);
 
-        String json = objectMapper.writeValueAsString(channelBoardLoadDtoList);
+        ChannelBoardIndexListDto channelBoardIndexListDto = new ChannelBoardIndexListDto();
+        channelBoardIndexListDto.setChannelBoardLoadDtoList(channelBoardLoadDtoList);
+
+        String json = objectMapper.writeValueAsString(channelBoardIndexListDto);
 
         Member test = UserFixture.createCustomeMember("test231");
         memberRepository.save(test);


### PR DESCRIPTION
## 🙆‍♂️ Issue

#396 

## 📝 Description

채널 보드 인덱스가 업데이트 되지 않은 문제를 해결했어요. 해당 문제가 트랜잭션에 문제가 있다고 생각했는데, 
알고보니 Wrapper 클래스 비교에서 문제가 있었어요. 원시 값 처럼 숫자 Wrapper 클래스를 ==으로 비교했는데, 
-128 ~ 127 까지의 Integer 클래스끼리의 비교만 도와주고, 나머지는 숫자 Wrapper는 객체의 주소를 반환해서, 
Long 값 1100 이상의 값을 받으니 == 비교가 되지 않았고, 그래서 업데이트가 되지 않았어요. 전체 프로젝트를 확인 해서 고쳤어요.
자세한 내용은
https://romcanrom.tistory.com/177
를 확인해주시고, 앞으로 조심해서 사용해요~

## ✨ Feature

Wrapper equals 비교

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #396 