### PR TITLE
fix: 관리자 부여 시 이메일 인증 검증 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static leaguehub.leaguehubbackend.entity.member.BaseRole.GUEST;
 import static leaguehub.leaguehubbackend.entity.member.BaseRole.USER;
 import static leaguehub.leaguehubbackend.entity.participant.RequestStatus.*;
 import static leaguehub.leaguehubbackend.entity.participant.Role.*;
@@ -143,6 +144,7 @@ public class ParticipantService {
         List<Participant> findParticipants = participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, OBSERVER, NO_REQUEST);
 
         return findParticipants.stream()
+                .filter(participant -> participant.getMember().getBaseRole() == USER)
                 .map(participant -> mapToResponseStatusPlayerDto(participant))
                 .collect(Collectors.toList());
     }
@@ -240,6 +242,8 @@ public class ParticipantService {
      */
     public void updateHostRole(String channelLink, Long participantId) {
         Participant findParticipant = checkHostAndGetParticipant(channelLink, participantId);
+        if(findParticipant.getMember().getBaseRole() == GUEST)
+            throw new InvalidParticipantAuthException();
 
         findParticipant.updateHostRole();
     }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#398 

## 📝 Description

관전자 조회 시, 관리자 부여 시 이메일 인증 검증을 추가 하였어요
이메일 인증이 되지않는 유저들은 관리자 권한을 부여받지 못하도록 하였어요

## ✨ Feature

* 관리자 부여 시 이메일 검증 추가
* 관전자 조회 시 이메일 검증 추가

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #398 