### PR TITLE
Feat#400: 기권처리 실격처리 웹소켓 전환 

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leaguehub.leaguehubbackend.dto.chat.MatchMessage;
 import leaguehub.leaguehubbackend.dto.match.*;
+import leaguehub.leaguehubbackend.dto.participant.ParticipantIdResponseDto;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.chat.MatchChatService;
 import leaguehub.leaguehubbackend.service.match.MatchPlayerService;
@@ -101,9 +102,9 @@ public class MatchController {
     @MessageMapping("/match/{matchId}/checkIn")
     public void checkIn(@DestinationVariable("matchId") String matchIdStr, @Payload MatchSetReadyMessage message) {
 
-        matchPlayerService.markPlayerAsReady(message, matchIdStr);
+        ParticipantIdResponseDto participantIdResponseDto = matchPlayerService.markPlayerAsReady(message, matchIdStr);
 
-        simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, message);
+        simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, participantIdResponseDto);
     }
 
     @Operation(summary = "현재 진행중인 매치의 정보 조회.")

--- a/src/main/java/leaguehub/leaguehubbackend/controller/ParticipantController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/ParticipantController.java
@@ -140,7 +140,7 @@ public class ParticipantController {
     public void disqualifiedParticipant(@DestinationVariable("channelLink") String channelLink,
                                         @DestinationVariable("matchIdStr") String matchIdStr,
                                         @Payload ParticipantIdDto message) {
-        participantService.disqualifiedParticipant(channelLink, message.getParticipantId());
+        participantService.disqualifiedParticipant(channelLink, message.getParticipantId(), message.getAccessToken());
 
         simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, message.getMatchPlayerId());
     }
@@ -149,7 +149,7 @@ public class ParticipantController {
     public void disqualificationSelf(@DestinationVariable("channelLink") String channelLink,
                                      @DestinationVariable("matchIdStr") String matchIdStr,
                                      @Payload ParticipantIdDto message){
-        participantService.selfDisqualified(channelLink, message.getParticipantId());
+        participantService.selfDisqualified(channelLink, message.getAccessToken());
 
         simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, message.getMatchPlayerId());
     }

--- a/src/main/java/leaguehub/leaguehubbackend/controller/ParticipantController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/ParticipantController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import leaguehub.leaguehubbackend.dto.channel.ParticipantChannelDto;
 import leaguehub.leaguehubbackend.dto.match.MatchSetReadyMessage;
-import leaguehub.leaguehubbackend.dto.participant.ParticipantDto;
-import leaguehub.leaguehubbackend.dto.participant.ParticipantIdDto;
-import leaguehub.leaguehubbackend.dto.participant.ResponseStatusPlayerDto;
-import leaguehub.leaguehubbackend.dto.participant.ResponseUserGameInfoDto;
+import leaguehub.leaguehubbackend.dto.participant.*;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
 import leaguehub.leaguehubbackend.service.participant.ParticipantService;
 import lombok.RequiredArgsConstructor;
@@ -136,23 +133,16 @@ public class ParticipantController {
         return new ResponseEntity<>("reject participant", OK);
     }
 
+    //실격, 기권에 대한 웹소켓
     @MessageMapping("/{channelLink}/{matchIdStr}/disqualification")
     public void disqualifiedParticipant(@DestinationVariable("channelLink") String channelLink,
                                         @DestinationVariable("matchIdStr") String matchIdStr,
                                         @Payload ParticipantIdDto message) {
-        participantService.disqualifiedParticipant(channelLink, message.getParticipantId(), message.getAccessToken());
+        ParticipantIdResponseDto participantIdResponseDto = participantService.disqualifiedParticipant(channelLink, message);
 
-        simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, message.getMatchPlayerId());
+        simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, participantIdResponseDto);
     }
 
-    @MessageMapping("/{channelLink}/{matchIdStr}/disqualification-self")
-    public void disqualificationSelf(@DestinationVariable("channelLink") String channelLink,
-                                     @DestinationVariable("matchIdStr") String matchIdStr,
-                                     @Payload ParticipantIdDto message){
-        participantService.selfDisqualified(channelLink, message.getAccessToken());
-
-        simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, message.getMatchPlayerId());
-    }
 
     @Operation(summary = "관리자 권한 부여", description = "관리자가 관전자에게 권한을 부여")
     @Parameters(value = {

--- a/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantIdDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantIdDto.java
@@ -1,0 +1,12 @@
+package leaguehub.leaguehubbackend.dto.participant;
+
+
+import lombok.Data;
+
+@Data
+public class ParticipantIdDto {
+
+    private Long participantId;
+
+    private Long matchPlayerId;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantIdDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantIdDto.java
@@ -11,4 +11,7 @@ public class ParticipantIdDto {
     private Long participantId;
 
     private Long matchPlayerId;
+
+    //관리자: 0, 플레이어: 1, 관전자: 2
+    private int role;
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantIdDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantIdDto.java
@@ -6,6 +6,8 @@ import lombok.Data;
 @Data
 public class ParticipantIdDto {
 
+    private String accessToken;
+
     private Long participantId;
 
     private Long matchPlayerId;

--- a/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantIdResponseDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantIdResponseDto.java
@@ -1,0 +1,20 @@
+package leaguehub.leaguehubbackend.dto.participant;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class ParticipantIdResponseDto {
+
+    private Long matchPlayerId;
+
+    //체크인: 1, 실격: 2
+    private int matchPlayerStatus;
+
+    @Builder
+    public ParticipantIdResponseDto(Long matchPlayerId, int matchPlayerStatus){
+        this.matchPlayerId = matchPlayerId;
+        this.matchPlayerStatus = matchPlayerStatus;
+
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/PlayerStatus.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/PlayerStatus.java
@@ -1,5 +1,11 @@
 package leaguehub.leaguehubbackend.entity.match;
 
 public enum PlayerStatus {
-    READY, WAITING, DISQUALIFICATION
+    READY(1), WAITING(0), DISQUALIFICATION(2);
+
+    private final int status;
+
+    PlayerStatus(int status) { this.status = status; }
+
+    public int getStatus() { return status; }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -1,6 +1,7 @@
 package leaguehub.leaguehubbackend.service.match;
 
 import leaguehub.leaguehubbackend.dto.match.*;
+import leaguehub.leaguehubbackend.dto.participant.ParticipantIdResponseDto;
 import leaguehub.leaguehubbackend.entity.match.*;
 import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
 import leaguehub.leaguehubbackend.exception.match.exception.MatchAlreadyUpdateException;
@@ -33,8 +34,7 @@ import java.util.stream.IntStream;
 
 import static leaguehub.leaguehubbackend.entity.match.MatchPlayerResultStatus.ADVANCE;
 import static leaguehub.leaguehubbackend.entity.match.MatchPlayerResultStatus.DROPOUT;
-import static leaguehub.leaguehubbackend.entity.match.PlayerStatus.READY;
-import static leaguehub.leaguehubbackend.entity.match.PlayerStatus.WAITING;
+import static leaguehub.leaguehubbackend.entity.match.PlayerStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -299,7 +299,7 @@ public class MatchPlayerService {
     }
 
     @Transactional
-    public void markPlayerAsReady(MatchSetReadyMessage message, String matchIdStr) {
+    public ParticipantIdResponseDto markPlayerAsReady(MatchSetReadyMessage message, String matchIdStr) {
 
         Long matchId = Long.valueOf(matchIdStr);
         Long matchPlayerId = message.getMatchPlayerId();
@@ -315,6 +315,8 @@ public class MatchPlayerService {
         }
 
         matchPlayer.updatePlayerCheckInStatus(READY);
+
+        return new ParticipantIdResponseDto(message.getMatchPlayerId(), READY.getStatus());
     }
 
     public List<MatchSetStatusMessage> getAllPlayerStatusForMatch(Long matchId) {

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -14,14 +14,17 @@ import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.entity.participant.GameTier;
 import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.entity.participant.Role;
+import leaguehub.leaguehubbackend.exception.auth.exception.AuthInvalidTokenException;
 import leaguehub.leaguehubbackend.exception.email.exception.UnauthorizedEmailException;
 import leaguehub.leaguehubbackend.exception.global.exception.GlobalServerErrorException;
 import leaguehub.leaguehubbackend.exception.participant.exception.*;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRuleRepository;
 import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
+import leaguehub.leaguehubbackend.repository.member.MemberRepository;
 import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
 import leaguehub.leaguehubbackend.service.channel.ChannelService;
+import leaguehub.leaguehubbackend.service.jwt.JwtService;
 import leaguehub.leaguehubbackend.service.member.MemberService;
 import leaguehub.leaguehubbackend.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
@@ -61,6 +64,8 @@ public class ParticipantService {
     private String riot_api_key;
     private final ChannelRuleRepository channelRuleRepository;
     private final MatchPlayerRepository matchPlayerRepository;
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
 
 
     public int findParticipantPermission(String channelLink) {
@@ -139,7 +144,7 @@ public class ParticipantService {
     public List<ResponseStatusPlayerDto> loadObserverPlayerList(String channelLink) {
         Participant findParticipant = getParticipant(channelLink);
 
-        checkRoleHost(findParticipant.getRole());
+        checkRole(findParticipant.getRole(), HOST);
 
         List<Participant> findParticipants = participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, OBSERVER, NO_REQUEST);
 
@@ -156,7 +161,7 @@ public class ParticipantService {
      */
     public List<ResponseStatusPlayerDto> loadRequestStatusPlayerList(String channelLink) {
         Participant findParticipant = getParticipant(channelLink);
-        checkRoleHost(findParticipant.getRole());
+        checkRole(findParticipant.getRole(), HOST);
 
         List<Participant> findParticipants =
                 participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc
@@ -192,7 +197,7 @@ public class ParticipantService {
      */
     public void approveParticipantRequest(String channelLink, Long participantId) {
         Participant participant = getParticipant(channelLink);
-        checkRoleHost(participant.getRole());
+        checkRole(participant.getRole(), HOST);
 
         checkRealPlayerCount(participant.getChannel());
 
@@ -212,7 +217,7 @@ public class ParticipantService {
      */
     public void rejectedParticipantRequest(String channelLink, Long participantId) {
         Participant participant = getParticipant(channelLink);
-        checkRoleHost(participant.getRole());
+        checkRole(participant.getRole(), HOST);
 
 
         Participant findParticipant = getFindParticipant(channelLink, participantId);
@@ -222,18 +227,20 @@ public class ParticipantService {
         updateRealPlayerCount(channelLink, participant.getChannel());
     }
 
-    public void disqualifiedParticipant(String channelLink, Long participantId) {
-        Participant findParticipant = checkHostAndGetParticipant(channelLink, participantId);
+    public void disqualifiedParticipant(String channelLink, Long participantId, String accessToken) {
+        Participant myParticipant = findParticipantAccessToken(channelLink, accessToken);
+        checkRole(myParticipant.getRole(), HOST);
+
+        Participant findParticipant = getFindParticipant(channelLink, participantId);
 
         disqualificationParticipant(findParticipant);
     }
 
-    public void selfDisqualified(String channelLink, Long participantId){
-        //matchPlayerId -> ParticipantId로 변경해야함
-        Participant participant = participantRepository.findParticipantByIdAndChannel_ChannelLink(participantId, channelLink)
-                .orElseThrow(() -> new ParticipantNotFoundException());
+    public void selfDisqualified(String channelLink, String accessToken){
+        Participant myParticipant = findParticipantAccessToken(channelLink, accessToken);
+        checkRole(myParticipant.getRole(), PLAYER);
 
-        disqualificationParticipant(participant);
+        disqualificationParticipant(myParticipant);
     }
 
     private void disqualificationParticipant(Participant findParticipant) {
@@ -315,7 +322,7 @@ public class ParticipantService {
 
     public void checkAdminHost(String channelLink) {
         Participant participant = getParticipant(channelLink);
-        checkRoleHost(participant.getRole());
+        checkRole(participant.getRole(), HOST);
     }
 
     private void playCountRuleCheck(ChannelRule channelRule, String userGameInfo) {
@@ -328,6 +335,13 @@ public class ParticipantService {
         }
     }
 
+    private Participant findParticipantAccessToken(String channelLink, String accessToken) {
+        String personalId = jwtService.extractPersonalId(accessToken)
+                .orElseThrow(() -> new AuthInvalidTokenException());
+        Member member = memberRepository.findMemberByPersonalId(personalId).get();
+        Participant myParticipant = getParticipant(channelLink, member);
+        return myParticipant;
+    }
 
     private static void rankRuleCheck(ChannelRule channelRule, GameTier tier) {
 
@@ -406,7 +420,7 @@ public class ParticipantService {
 
     private Participant checkHostAndGetParticipant(String channelLink, Long participantId) {
         Participant participant = getParticipant(channelLink);
-        checkRoleHost(participant.getRole());
+        checkRole(participant.getRole(), HOST);
 
         return getFindParticipant(channelLink, participantId);
     }
@@ -602,8 +616,8 @@ public class ParticipantService {
         return userGameInfoDto;
     }
 
-    private void checkRoleHost(Role role) {
-        if (role != Role.HOST) {
+    private void checkRole(Role myRole, Role checkRole) {
+        if (myRole != checkRole) {
             throw new InvalidParticipantAuthException();
         }
     }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#400 

## 📝 Description

기권, 실격에 대한 기능을 웹소켓으로 전환하였어요
관리자가 실격을 시킬 경우 AcessToken으로 자신의 역할을 맞는지 확인한 후 받은 participantId로 실격처리를 합니다.
자신이 기권을 할 경우 똑같은 방식으로 자신이 플레이어인지 확인 후 그 플레이어Id로 기권처리를 합니다.

해당 기능은 Swagger가 적용이 안되므로 노션으로 적어놓을게요 

## ✨ Feature

- 기권처리 웹소켓으로 전환
- 실격처리 웹소켓으로 전환

## 👌 Review Change
- 열거형에 상수 추가
- 체크인 반환 값에 플레이어 상태 추가
- 실격, 기권 기능 통합

This closes #400 