### PR TITLE
Feat#417: 해당 채널에 대한 정보 테이블 추가

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
@@ -28,7 +28,7 @@ public class ChannelInfoController {
     @Operation(summary = "채널 상품, 참가조건, 경기시간 정보 수정하기")
     @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ChannelInfoDto.class))),
+            @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", description = "채널 링크가 올바르지 않음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @PostMapping("/channel/{channelLink}/main")

--- a/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
@@ -1,0 +1,54 @@
+package leaguehub.leaguehubbackend.controller.channel;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import leaguehub.leaguehubbackend.dto.channel.ChannelBoardDto;
+import leaguehub.leaguehubbackend.dto.channel.ChannelInfoDto;
+import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.service.channel.ChannelInfoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ChannelInfoController {
+
+    private final ChannelInfoService channelInfoService;
+
+    @Operation(summary = "채널 상품, 참가조건, 경기시간 정보 수정하기")
+    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ChannelInfoDto.class))),
+            @ApiResponse(responseCode = "400", description = "채널 링크가 올바르지 않음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/channel/{channelLink}/main")
+    public ResponseEntity updateChannelInfo(@PathVariable("channelLink") String channelLink,
+                                            @RequestBody @Valid ChannelInfoDto channelInfoDto) {
+
+        return new ResponseEntity("수정이 완료되었습니다.",OK);
+    }
+
+    @Operation(summary = "채널 상품, 참가조건, 경기시간 정보 가져오기")
+    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ChannelInfoDto.class))),
+            @ApiResponse(responseCode = "400", description = "채널 링크가 올바르지 않음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/channel/{channelLink/main}")
+    public ResponseEntity getChannelInfo(@PathVariable("channelLink") String channelLink) {
+
+        ChannelInfoDto channelInfoDto = channelInfoService.getChannelInfoDto(channelLink);
+
+        return new ResponseEntity(OK);
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
@@ -46,7 +46,7 @@ public class ChannelInfoController {
             @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ChannelInfoDto.class))),
             @ApiResponse(responseCode = "400", description = "채널 링크가 올바르지 않음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
-    @GetMapping("/channel/{channelLink/main}")
+    @GetMapping("/channel/{channelLink}/main")
     public ResponseEntity getChannelInfo(@PathVariable("channelLink") String channelLink) {
 
         ChannelInfoDto channelInfoDto = channelInfoService.getChannelInfoDto(channelLink);

--- a/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
@@ -35,6 +35,8 @@ public class ChannelInfoController {
     public ResponseEntity updateChannelInfo(@PathVariable("channelLink") String channelLink,
                                             @RequestBody @Valid ChannelInfoDto channelInfoDto) {
 
+        channelInfoService.updateChannelInfo(channelLink, channelInfoDto);
+
         return new ResponseEntity("수정이 완료되었습니다.",OK);
     }
 

--- a/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelInfoController.java
@@ -51,6 +51,6 @@ public class ChannelInfoController {
 
         ChannelInfoDto channelInfoDto = channelInfoService.getChannelInfoDto(channelLink);
 
-        return new ResponseEntity(OK);
+        return new ResponseEntity(channelInfoDto, OK);
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/dto/channel/ChannelInfoDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/channel/ChannelInfoDto.java
@@ -11,6 +11,14 @@ import lombok.NoArgsConstructor;
 public class ChannelInfoDto {
 
     @NotBlank
+    @Schema(description = "해당 채널의 제목", example = "부경대 대회")
+    private String channelTitleInfo;
+
+    @NotBlank
+    @Schema(description = "해당 채널의 소제목", example = "안녕하세요 부경대 대회입니다.")
+    private String channelContentInfo;
+
+    @NotBlank
     @Schema(description = "해당 채널의 참가조건", example = "브론즈 이상 마스터 이하")
     private String channelRuleInfo;
 
@@ -22,7 +30,9 @@ public class ChannelInfoDto {
     @Schema(description = "해당 채널의 상품 ", example = "1등 1,000원 2등 100원 3등 10원 4등 1원 5등 꽝")
     private String channelPrizeInfo;
 
-    public ChannelInfoDto(String channelRuleInfo, String channelTimeInfo, String channelPrizeInfo){
+    public ChannelInfoDto(String channelTitleInfo, String channelContentInfo, String channelRuleInfo, String channelTimeInfo, String channelPrizeInfo) {
+        this.channelTitleInfo = channelTitleInfo;
+        this.channelContentInfo = channelContentInfo;
         this.channelRuleInfo = channelRuleInfo;
         this.channelTimeInfo = channelTimeInfo;
         this.channelPrizeInfo = channelPrizeInfo;

--- a/src/main/java/leaguehub/leaguehubbackend/dto/channel/ChannelInfoDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/channel/ChannelInfoDto.java
@@ -1,0 +1,30 @@
+package leaguehub.leaguehubbackend.dto.channel;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ChannelInfoDto {
+
+    @NotBlank
+    @Schema(description = "해당 채널의 참가조건", example = "브론즈 이상 마스터 이하")
+    private String channelRuleInfo;
+
+    @NotBlank
+    @Schema(description = "해당 채널의 대회 시간", example = "해당 대회는 2023-11-18 오후 9시부터 시작입니다.")
+    private String channelTimeInfo;
+
+    @NotBlank
+    @Schema(description = "해당 채널의 상품 ", example = "1등 1,000원 2등 100원 3등 10원 4등 1원 5등 꽝")
+    private String channelPrizeInfo;
+
+    public ChannelInfoDto(String channelRuleInfo, String channelTimeInfo, String channelPrizeInfo){
+        this.channelRuleInfo = channelRuleInfo;
+        this.channelTimeInfo = channelTimeInfo;
+        this.channelPrizeInfo = channelPrizeInfo;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelInfo.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelInfo.java
@@ -18,6 +18,9 @@ public class ChannelInfo extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
+    private String channelContentInfo;
+
+    @Column(nullable = false)
     private String channelRuleInfo;
 
     @Column(nullable = false)
@@ -32,6 +35,7 @@ public class ChannelInfo extends BaseTimeEntity {
 
     public static ChannelInfo createChannelInfo(Channel channel){
         ChannelInfo channelInfo = new ChannelInfo();
+        channelInfo.channelContentInfo = "대회의 소제목을 입력해주세요";
         channelInfo.channelTimeInfo = "대회 진행 시간을 입력해주세요";
         channelInfo.channelRuleInfo = "대회 참가 조건을 입력해주세요";
         channelInfo.channelPrizeInfo ="대회 상품 & 상금을 입력해주세요";
@@ -40,7 +44,9 @@ public class ChannelInfo extends BaseTimeEntity {
         return channelInfo;
     }
 
-    public ChannelInfo updateChannelBoard(String channelTimeInfo, String channelRuleInfo, String channelPrizeInfo){
+
+    public ChannelInfo updateChannelBoard(String channelContentInfo, String channelTimeInfo, String channelRuleInfo, String channelPrizeInfo){
+        this.channelContentInfo = channelContentInfo;
         this.channelPrizeInfo = channelPrizeInfo;
         this.channelTimeInfo = channelTimeInfo;
         this.channelRuleInfo = channelRuleInfo;

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelInfo.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelInfo.java
@@ -1,0 +1,53 @@
+package leaguehub.leaguehubbackend.entity.channel;
+
+
+import jakarta.persistence.*;
+import leaguehub.leaguehubbackend.entity.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+public class ChannelInfo extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "channel_info_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String channelRuleInfo;
+
+    @Column(nullable = false)
+    private String channelTimeInfo;
+
+    @Column(nullable = false)
+    private String channelPrizeInfo;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id")
+    private Channel channel;
+
+    public static ChannelInfo createChannelInfo(Channel channel){
+        ChannelInfo channelInfo = new ChannelInfo();
+        channelInfo.channelTimeInfo = "대회 진행 시간을 입력해주세요";
+        channelInfo.channelRuleInfo = "대회 참가 조건을 입력해주세요";
+        channelInfo.channelPrizeInfo ="대회 상품 & 상금을 입력해주세요";
+        channelInfo.channel = channel;
+
+        return channelInfo;
+    }
+
+    public ChannelInfo updateChannelBoard(String channelTimeInfo, String channelRuleInfo, String channelPrizeInfo){
+        this.channelPrizeInfo = channelPrizeInfo;
+        this.channelTimeInfo = channelTimeInfo;
+        this.channelRuleInfo = channelRuleInfo;
+
+        return this;
+    }
+
+
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelInfoRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelInfoRepository.java
@@ -1,0 +1,7 @@
+package leaguehub.leaguehubbackend.repository.channel;
+
+import leaguehub.leaguehubbackend.entity.channel.ChannelInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelInfoRepository extends JpaRepository<ChannelInfo, Long> {
+}

--- a/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelInfoRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelInfoRepository.java
@@ -1,11 +1,14 @@
 package leaguehub.leaguehubbackend.repository.channel;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import leaguehub.leaguehubbackend.entity.channel.ChannelInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface ChannelInfoRepository extends JpaRepository<ChannelInfo, Long> {
 
-    Optional<ChannelInfo> findChannelInfoByChannel_ChannelLink(String channelLink);
+    @Query("select c from ChannelInfo c join fetch c.channel where c.channel.channelLink = :channelLink")
+    Optional<ChannelInfo> findChannelInfoByChannel_ChannelLink(@Param("channelLink") String channelLink);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelInfoRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelInfoRepository.java
@@ -3,5 +3,9 @@ package leaguehub.leaguehubbackend.repository.channel;
 import leaguehub.leaguehubbackend.entity.channel.ChannelInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChannelInfoRepository extends JpaRepository<ChannelInfo, Long> {
+
+    Optional<ChannelInfo> findChannelInfoByChannel_ChannelLink(String channelLink);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelInfoService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelInfoService.java
@@ -1,0 +1,33 @@
+package leaguehub.leaguehubbackend.service.channel;
+
+
+import jakarta.transaction.Transactional;
+import leaguehub.leaguehubbackend.dto.channel.ChannelInfoDto;
+import leaguehub.leaguehubbackend.entity.channel.ChannelInfo;
+import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundException;
+import leaguehub.leaguehubbackend.repository.channel.ChannelInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChannelInfoService {
+
+    private final ChannelInfoRepository channelInfoRepository;
+    private final ChannelService channelService;
+
+
+    public ChannelInfoDto getChannelInfoDto(String channelLink) {
+
+        ChannelInfo channelInfo = validateChannelBoard(channelLink);
+
+        return new ChannelInfoDto(channelInfo.getChannelRuleInfo(), channelInfo.getChannelTimeInfo(), channelInfo.getChannelPrizeInfo());
+    }
+
+
+    public ChannelInfo validateChannelBoard(String channelLink) {
+        return channelInfoRepository.findChannelInfoByChannel_ChannelLink(channelLink)
+                .orElseThrow(() -> new ChannelNotFoundException());
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelInfoService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelInfoService.java
@@ -4,8 +4,11 @@ package leaguehub.leaguehubbackend.service.channel;
 import jakarta.transaction.Transactional;
 import leaguehub.leaguehubbackend.dto.channel.ChannelInfoDto;
 import leaguehub.leaguehubbackend.entity.channel.ChannelInfo;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundException;
 import leaguehub.leaguehubbackend.repository.channel.ChannelInfoRepository;
+import leaguehub.leaguehubbackend.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +19,8 @@ public class ChannelInfoService {
 
     private final ChannelInfoRepository channelInfoRepository;
     private final ChannelService channelService;
+    private final MemberService memberService;
+
 
 
     public ChannelInfoDto getChannelInfoDto(String channelLink) {
@@ -23,6 +28,16 @@ public class ChannelInfoService {
         ChannelInfo channelInfo = validateChannelBoard(channelLink);
 
         return new ChannelInfoDto(channelInfo.getChannelRuleInfo(), channelInfo.getChannelTimeInfo(), channelInfo.getChannelPrizeInfo());
+    }
+
+    public void updateChannelInfo(String channelLink, ChannelInfoDto channelInfoDto){
+        Member member = memberService.findCurrentMember();
+        Participant participant = channelService.getParticipant(member.getId(), channelLink);
+        channelService.checkRoleHost(participant.getRole());
+
+        ChannelInfo findChannelInfo = validateChannelBoard(channelLink);
+
+        findChannelInfo.updateChannelBoard(channelInfoDto.getChannelTimeInfo(), channelInfoDto.getChannelRuleInfo(), channelInfoDto.getChannelPrizeInfo());
     }
 
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelInfoService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelInfoService.java
@@ -22,22 +22,22 @@ public class ChannelInfoService {
     private final MemberService memberService;
 
 
-
     public ChannelInfoDto getChannelInfoDto(String channelLink) {
 
         ChannelInfo channelInfo = validateChannelBoard(channelLink);
+        String channelTitle = channelInfo.getChannel().getTitle();
 
-        return new ChannelInfoDto(channelInfo.getChannelRuleInfo(), channelInfo.getChannelTimeInfo(), channelInfo.getChannelPrizeInfo());
+        return new ChannelInfoDto(channelTitle, channelInfo.getChannelContentInfo(), channelInfo.getChannelRuleInfo(), channelInfo.getChannelTimeInfo(), channelInfo.getChannelPrizeInfo());
     }
 
-    public void updateChannelInfo(String channelLink, ChannelInfoDto channelInfoDto){
+    public void updateChannelInfo(String channelLink, ChannelInfoDto channelInfoDto) {
         Member member = memberService.findCurrentMember();
         Participant participant = channelService.getParticipant(member.getId(), channelLink);
         channelService.checkRoleHost(participant.getRole());
 
         ChannelInfo findChannelInfo = validateChannelBoard(channelLink);
 
-        findChannelInfo.updateChannelBoard(channelInfoDto.getChannelTimeInfo(), channelInfoDto.getChannelRuleInfo(), channelInfoDto.getChannelPrizeInfo());
+        findChannelInfo.updateChannelBoard(channelInfoDto.getChannelContentInfo(), channelInfoDto.getChannelTimeInfo(), channelInfoDto.getChannelRuleInfo(), channelInfoDto.getChannelPrizeInfo());
     }
 
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelService.java
@@ -4,10 +4,7 @@ import leaguehub.leaguehubbackend.dto.channel.ChannelDto;
 import leaguehub.leaguehubbackend.dto.channel.CreateChannelDto;
 import leaguehub.leaguehubbackend.dto.channel.ParticipantChannelDto;
 import leaguehub.leaguehubbackend.dto.channel.UpdateChannelDto;
-import leaguehub.leaguehubbackend.entity.channel.Channel;
-import leaguehub.leaguehubbackend.entity.channel.ChannelBoard;
-import leaguehub.leaguehubbackend.entity.channel.ChannelRule;
-import leaguehub.leaguehubbackend.entity.channel.ChannelStatus;
+import leaguehub.leaguehubbackend.entity.channel.*;
 import leaguehub.leaguehubbackend.entity.member.Member;
 import leaguehub.leaguehubbackend.entity.participant.Participant;
 import leaguehub.leaguehubbackend.entity.participant.Role;
@@ -15,6 +12,7 @@ import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundExc
 import leaguehub.leaguehubbackend.exception.email.exception.UnauthorizedEmailException;
 import leaguehub.leaguehubbackend.exception.participant.exception.InvalidParticipantAuthException;
 import leaguehub.leaguehubbackend.repository.channel.ChannelBoardRepository;
+import leaguehub.leaguehubbackend.repository.channel.ChannelInfoRepository;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
 import leaguehub.leaguehubbackend.repository.channel.ChannelRuleRepository;
 import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
@@ -45,6 +43,7 @@ public class ChannelService {
     private final MatchService matchService;
     private final ChannelRuleRepository channelRuleRepository;
     private final MatchChatService matchChatService;
+    private final ChannelInfoRepository channelInfoRepository;
 
     @Transactional
     public ParticipantChannelDto createChannel(CreateChannelDto createChannelDto) {
@@ -67,6 +66,7 @@ public class ChannelService {
 
         channelRuleRepository.save(channelRule);
         channelBoardRepository.saveAll(ChannelBoard.createDefaultBoard(channel));
+        channelInfoRepository.save(ChannelInfo.createChannelInfo(channel));
 
         Participant participant = Participant.createHostChannel(member, channel);
         participant.newCustomChannelIndex(participantRepository.findMaxIndexByParticipant(member.getId()));


### PR DESCRIPTION
## 🙆‍♂️ Issue

#417 

## 📝 Description

채널마다 메인이 되는 페이지의 정보를 받는 테이블을 추가하였어요
채널이 만들어질 때 기본 정보가 있는 ChannelInfo가 생성되며
수정 및 반환할 때 ChannelInfoDto를 수정, 반환을 해요
정확한 반환값은 Swagger UI에서 확인할 수 있어요

## ✨ Feature

- 채널 메인 정보 테이블 구현
- 채널 메인 정보 수정 & 반환 기능 구현

## 👌 Review Change
- fix: 컨트롤러 중괄호 수정
- feat: 채널 메인의 소제목 추가에 따른 기능 수정

This closes #417 