### PR TITLE
Feat#421: 게임사 닉네임, 전적검색 요청 수정에 따른 기능 변경

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantDto.java
+++ b/src/main/java/leaguehub/leaguehubbackend/dto/participant/ParticipantDto.java
@@ -10,7 +10,7 @@ public class ParticipantDto {
 
 
     @NotBlank
-    @Schema(description = "참가하려는 게임 닉네임", example = "칸영기")
+    @Schema(description = "참가하려는 게임 닉네임과 태그", example = "칸영기#KR1")
     private String gameId;
 
     @NotBlank

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -60,20 +60,24 @@ public class MatchPlayerService {
      * @return puuid
      */
     public String getSummonerPuuid(String name) {
-        String summonerUrl = "https://kr.api.riotgames.com/tft/summoner/v1/summoners/by-name/";
+        String gameId = name.split("#")[0];
+        String gameTag = name.split("#")[1];
 
+        String summonerPuuidUrl = "https://asia.api.riotgames.com/riot/account/v1/accounts/by-riot-id/";
 
-        JSONObject summonerDetail = webClient.get()
-                .uri(summonerUrl + name + riot_api_key_1)
+        JSONObject userAccount = webClient.get()
+                .uri(summonerPuuidUrl + gameId + "/" + gameTag + riot_api_key_1)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ParticipantGameIdNotFoundException()))
-                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new GlobalServerErrorException()))
+                .onStatus(HttpStatusCode::is5xxServerError, response -> Mono.error(new GlobalServerErrorException()))
                 .bodyToMono(JSONObject.class)
                 .block();
 
-        String puuid = Objects.requireNonNull(summonerDetail).get("puuid").toString();
+
+        String puuid =  userAccount.get("puuid").toString();
 
         return puuid;
+
     }
 
     /**

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -509,23 +509,44 @@ public class ParticipantService {
     }
 
     /**
-     * 닉네임으로 고유id 추출
-     *
-     * @param nickname
-     * @return id
+     * 닉네임 + 태크로 고유 puuid 추출
+     * 받은 nickname으로 split 나누기
      */
-    public JSONObject getSummonerId(String nickname) {
-        String summonerUrl = "https://kr.api.riotgames.com/tft/summoner/v1/summoners/by-name/";
+    public String getSummonerPUuid(String nickname){
+        String pUuidURL = "https://asia.api.riotgames.com/riot/account/v1/accounts/by-riot-id/";
 
-        JSONObject summonerDetail = webClient.get()
-                .uri(summonerUrl + nickname + riot_api_key)
+        String gameId = nickname.split("#")[0];
+        String gameTag = nickname.split("#")[1];
+
+        JSONObject userAccount = webClient.get()
+                .uri(pUuidURL + gameId + "/" + gameTag + riot_api_key)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ParticipantGameIdNotFoundException()))
                 .onStatus(HttpStatusCode::is5xxServerError, response -> Mono.error(new GlobalServerErrorException()))
                 .bodyToMono(JSONObject.class)
                 .block();
 
-        return summonerDetail;
+        return userAccount.get("puuid").toString();
+    }
+
+    /**
+     * 고유 puuid로 유저의 정보 추출
+     *
+     * @param nickname
+     * @return id
+     */
+    public JSONObject getSummonerId(String nickname) {
+        String puuid = getSummonerPUuid(nickname);
+
+        String summonerUrl = "https://kr.api.riotgames.com/tft/summoner/v1/summoners/by-puuid/";
+
+        return webClient.get()
+                .uri(summonerUrl + puuid + riot_api_key)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ParticipantGameIdNotFoundException()))
+                .onStatus(HttpStatusCode::is5xxServerError, response -> Mono.error(new GlobalServerErrorException()))
+                .bodyToMono(JSONObject.class)
+                .block();
     }
 
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/participant/ParticipantService.java
@@ -518,6 +518,8 @@ public class ParticipantService {
         String gameId = nickname.split("#")[0];
         String gameTag = nickname.split("#")[1];
 
+
+
         JSONObject userAccount = webClient.get()
                 .uri(pUuidURL + gameId + "/" + gameTag + riot_api_key)
                 .retrieve()


### PR DESCRIPTION
## 🙆‍♂️ Issue

#421 

## 📝 Description

게임사에서 전적 검색 방식을 업데이트 함에 따라(닉네임 -> 닉네임 + 태그로 검색)
서비스에서 검색 방식을 수정하였어요
새로운 기능을 만들어서 검색하도록 하였어요
클라이언트에서 abc#1234로 gameId를 보내면 #을 기준으로 닉네임, 태그로 나눠 검색을 하여 사용자 티어, 매치 검색등을 반환하도록 설정하였어요

## ✨ Feature

- 게임 아이디와 태그를 가지고 검색하는 기능 메서드 추가
- 전적 검색 기능 수정
- 매치 점수 최신화 기능 수정

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #421 