### PR TITLE
fix#428: 채널 경기 배정시 이미 진행중인 매치 체크

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -457,6 +457,12 @@ public class MatchService {
                     .filter(match -> !match.getMatchStatus().equals(END))
                     .findAny()
                     .ifPresent(match -> { throw new MatchNotFoundException(); });
+
+            List<Match> presentMatch = findMatchList(channelLink, matchRound);
+            presentMatch.stream()
+                    .filter(match -> match.getMatchStatus().equals(PROGRESS))
+                    .findAny()
+                    .ifPresent(match -> { throw new MatchNotFoundException(); });
         }
     }
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#428 

## 📝 Description

관리자가 배정 버튼을 눌렀을 때 이미 매치가 진행중이면  배정을 못하게 만들었어요
해당 기능을 통하여 두 번이상 배정 못하게 할 수 있어요

## ✨ Feature

- 배정 시 이미 매치 진행중이면 에러 처리 기능

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #428 