### PR TITLE
Feat#430: 현재 라운드를 저장할 변수 추가 및 기능 수정

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/MatchController.java
@@ -37,7 +37,7 @@ public class MatchController {
     private final MatchService matchService;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final MatchChatService matchChatService;
-    @Operation(summary = "라운드 수(몇 강) 리스트 반환")
+    @Operation(summary = "라운드 수(몇 강) 리스트 반환 - 사용자")
     @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "라운드(몇 강) 리스트 반환", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MatchRoundListDto.class))),

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
@@ -38,6 +38,8 @@ public class Channel extends BaseTimeEntity {
     @Column(unique = true)
     private String channelLink;
 
+    private int liveRound;
+
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private MatchFormat matchFormat;
@@ -61,6 +63,7 @@ public class Channel extends BaseTimeEntity {
         channel.matchFormat = MatchFormat.getByNumber(matchFormat);
         channel.channelLink = channel.createParticipationLink(uuid);
         channel.channelImageUrl = channel.validateChannelImageUrl(channelImageUrl);
+        channel.liveRound = 0;
 
         return channel;
     }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/Channel.java
@@ -105,4 +105,8 @@ public class Channel extends BaseTimeEntity {
     public void updateChannelStatus(ChannelStatus channelStatus) {
         this.channelStatus = channelStatus;
     }
+
+    public void updateChannelLiveRound(Integer liveRound){
+        this.liveRound = liveRound;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -270,6 +270,7 @@ public class MatchPlayerService {
     private void checkMatchEnd(MatchSet matchSet, Match match) {
         if (match.getMatchSetCount().equals(matchSet.getSetCount())) {
             match.updateMatchStatus(MatchStatus.END);
+            match.getChannel().updateChannelLiveRound(0);
             updateEndMatchResult(match);
         } else {
             match.updateCurrentMatchSet(matchSet.getSetCount() + 1);

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchPlayerService.java
@@ -270,7 +270,6 @@ public class MatchPlayerService {
     private void checkMatchEnd(MatchSet matchSet, Match match) {
         if (match.getMatchSetCount().equals(matchSet.getSetCount())) {
             match.updateMatchStatus(MatchStatus.END);
-            match.getChannel().updateChannelLiveRound(0);
             updateEndMatchResult(match);
         } else {
             match.updateCurrentMatchSet(matchSet.getSetCount() + 1);

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -114,6 +114,7 @@ public class MatchService {
         List<Participant> playerList = getParticipantList(channelLink, matchRound);
 
         assignSubMatches(matchList, playerList);
+        participant.getChannel().updateChannelLiveRound(matchRound);
     }
 
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -261,7 +261,7 @@ public class MatchService {
                     matchList.stream()
                             .filter(match -> match.getMatchStatus().equals(MatchStatus.PROGRESS))
                             .findFirst()
-                            .ifPresent(match -> roundListDto.setLiveRound(match.getChannel().getLiveRound()));
+                            .ifPresent(match -> roundListDto.setLiveRound(match.getMatchRound()));
                 }
         );
     }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -76,7 +76,9 @@ public class MatchService {
      * @return 2 4 8 16 32 64
      */
     public MatchRoundListDto getRoundList(String channelLink) {
-        Channel findChannel = getChannel(channelLink);
+        Member member = memberService.findCurrentMember();
+        Participant participant = getParticipant(member.getId(), channelLink);
+        Channel findChannel = participant.getChannel();
 
         int maxPlayers = findChannel.getMaxPlayer();
         List<Integer> roundList = calculateRoundList(maxPlayers);
@@ -86,6 +88,9 @@ public class MatchService {
         roundListDto.setRoundList(roundList);
 
         findLiveRound(channelLink, roundList, roundListDto);
+
+        if(participant.getRole().equals(Role.HOST))
+            roundListDto.setLiveRound(findChannel.getLiveRound());
 
         return roundListDto;
     }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -260,7 +260,7 @@ public class MatchService {
                     matchList.stream()
                             .filter(match -> match.getMatchStatus().equals(MatchStatus.PROGRESS))
                             .findFirst()
-                            .ifPresent(match -> roundListDto.setLiveRound(match.getMatchRound()));
+                            .ifPresent(match -> roundListDto.setLiveRound(match.getChannel().getLiveRound()));
                 }
         );
     }

--- a/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/match/MatchService.java
@@ -461,7 +461,7 @@ public class MatchService {
 
             List<Match> presentMatch = findMatchList(channelLink, matchRound);
             presentMatch.stream()
-                    .filter(match -> match.getMatchStatus().equals(PROGRESS))
+                    .filter(match -> match.getMatchStatus().equals(MatchStatus.PROGRESS))
                     .findAny()
                     .ifPresent(match -> { throw new MatchNotFoundException(); });
         }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#430 

## 📝 Description

현재 라운드를 저장하는 변수를 만들었어요
라운드가 종료될 때 마다 현재 라운드를 0으로 변경해주고
라운드가 배정되면 현재 라운드를 배정된 라운드 수(1, 2, 3 ..)로 업데이트하여 실시간 라운드를 표시해줘요!
db를 업데이트 하기 위해서 update로 해주셔야해요!


## ✨ Feature

- 채널 테이블에 현재 라운드를 저장하는 Column 추가
- 라운드가 종료되면 현재 라운드 0으로 설정 기능
- 라운드가 배정되면 현재 라운드를 설정된 라운드로 업데이트 기능

## 👌 Review Change

- refactor: 열거형 변수 수정
- refactor: 현재 라운드 저장 방식 수정 및 삭제
- feat: 현재 진행 라운드에서 관리자일 때 반환되는 방식 수정

리뷰를 통해 수정한 부분을 나열해주세요.