### PR TITLE
Test#436: Board, Email 테스트 수정

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardService.java
@@ -57,7 +57,6 @@ public class ChannelBoardService {
     @Transactional
     public ChannelBoardInfoDto loadChannelBoards(String channelLink) {
 
-        MyMatchDto matchDto = matchService.getMyMatchRound(channelLink);
 
         channelService.getChannel(channelLink);
 
@@ -67,6 +66,7 @@ public class ChannelBoardService {
                 .map(channelBoard -> new ChannelBoardLoadDto(channelBoard.getId(), channelBoard.getTitle(), channelBoard.getIndex()))
                 .collect(Collectors.toList());
 
+        MyMatchDto matchDto = matchService.getMyMatchRound(channelLink);
 
         return new ChannelBoardInfoDto(matchDto.getMyMatchRound(), matchDto.getMyMatchId(), channelBoardLoadDtoList);
     }

--- a/src/test/java/leaguehub/leaguehubbackend/controller/channel/ChannelBoardControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/channel/ChannelBoardControllerTest.java
@@ -61,16 +61,15 @@ class ChannelBoardControllerTest {
     MockMvc mockMvc;
     @Autowired
     private ChannelRuleRepository channelRuleRepository;
+    Member member;
 
     @BeforeEach
     void setUp() {
-        memberRepository.save(UserFixture.createMember());
+        member = memberRepository.save(UserFixture.createMember());
         UserFixture.setUpAuth();
-
     }
 
     Channel createCustomChannel(Boolean tier, Boolean playCount, Integer tierMax, Integer tierMin, int playCountMin) throws Exception {
-        Member member = memberRepository.save(UserFixture.createMember());
         Member ironMember = memberRepository.save(UserFixture.createCustomeMember("썹맹구"));
         Member unrankedMember = memberRepository.save(UserFixture.createCustomeMember("서초임"));
         Member platinumMember = memberRepository.save(UserFixture.createCustomeMember("손성한"));

--- a/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
+++ b/src/test/java/leaguehub/leaguehubbackend/fixture/UserFixture.java
@@ -21,7 +21,7 @@ public class UserFixture {
                 .emailAuth(new EmailAuth("id@example.com", "authToken"))
                 .loginProvider(LoginProvider.KAKAO).baseRole(BaseRole.USER)
                 .build();
-
+        member.verifyEmail();
         return member;
     }
 

--- a/src/test/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/channel/ChannelBoardServiceTest.java
@@ -55,11 +55,10 @@ class ChannelBoardServiceTest {
     ParticipantRepository participantRepository;
     @Autowired
     ChannelRuleRepository channelRuleRepository;
-
+    Member member;
     private String channelLink;
 
     Channel createCustomChannel(Boolean tier, Boolean playCount, Integer tierMax, Integer tierMin, int playCountMin) throws Exception {
-        Member member = memberRepository.save(UserFixture.createMember());
         Member ironMember = memberRepository.save(UserFixture.createCustomeMember("썹맹구"));
         Member unrankedMember = memberRepository.save(UserFixture.createCustomeMember("서초임"));
         Member platinumMember = memberRepository.save(UserFixture.createCustomeMember("손성한"));
@@ -106,7 +105,7 @@ class ChannelBoardServiceTest {
 
     @BeforeEach
     void setUp() {
-        memberRepository.save(UserFixture.createMember());
+        member = memberRepository.save(UserFixture.createMember());
         UserFixture.setUpAuth();
         CreateChannelDto createChannelDto = ChannelFixture.createChannelDto();
         ParticipantChannelDto participantChannelDto = channelService.createChannel(createChannelDto);


### PR DESCRIPTION
## 🙆‍♂️ Issue

#436 

## 📝 Description

리팩터링 및 기능 확장으로 인해서 돌아가지 않던 테스트들을 일부 수정해서 돌아가도록 했어요.
멤버 쪽에서 문제가 있어 코드를 고쳤으니 확인해보시면 될 것 같아요.
아래는 아직 테스트 중에 돌아가지 않는 테스트이고, 대부분 이전 테스트 DB에 있던 값들이 돌아가지 않고, 이번 태그 추가 이슈로 인해서 돌아가지 않는 경우가 대부분이라 천천히 고치면 될 것 같아요.

<img width="297" alt="image" src="https://github.com/TheUpperPart/leaguehub-backend/assets/102659136/cb4957f1-cb3d-4f33-9e30-b07ad0c1316e">

## ✨ Feature

- Board  채널 생성시 중복 멤버 주입하던 버그 수정
- 이메일 중복 검사시 확인된 이메일인지 확인 하던 과정이 있어서 UserFixture에 이 부분을 추가

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This is closes #436 