### PR TITLE
Feat#433: FC online, 롤, 하스스톤 공지 스크래핑 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/exception/notice/NoticeExceptionCode.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/notice/NoticeExceptionCode.java
@@ -1,0 +1,21 @@
+package leaguehub.leaguehubbackend.exception.notice;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeExceptionCode implements ExceptionCode {
+
+    NOTICE_UNSUPPORTED(BAD_REQUEST, "NT-C-002", "지원되지 않는 공지사항 기능입니다."),
+    WEB_SCRAPING_ERROR(BAD_REQUEST, "WS-C-001", "웹 페이지에서 정보를 추출하는 과정에서 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/notice/NoticeExceptionHandler.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/notice/NoticeExceptionHandler.java
@@ -1,0 +1,46 @@
+package leaguehub.leaguehubbackend.exception.notice;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.exception.member.exception.MemberNotFoundException;
+import leaguehub.leaguehubbackend.exception.notice.exception.NoticeUnsupportedException;
+import leaguehub.leaguehubbackend.exception.notice.exception.WebScrapingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class NoticeExceptionHandler {
+
+    @ExceptionHandler(NoticeUnsupportedException.class)
+    public ResponseEntity<ExceptionResponse> noticeUnsupportedException(
+            NoticeUnsupportedException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+    @ExceptionHandler(WebScrapingException.class)
+    public ResponseEntity<ExceptionResponse> webScrapingException(
+            WebScrapingException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", exceptionCode.getMessage());
+
+        return new ResponseEntity<>(
+                new ExceptionResponse(exceptionCode),
+                exceptionCode.getHttpStatus()
+        );
+    }
+
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/notice/exception/NoticeUnsupportedException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/notice/exception/NoticeUnsupportedException.java
@@ -1,0 +1,21 @@
+package leaguehub.leaguehubbackend.exception.notice.exception;
+
+import static leaguehub.leaguehubbackend.exception.notice.NoticeExceptionCode.NOTICE_UNSUPPORTED;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.exception.ResourceNotFoundException;
+
+public class NoticeUnsupportedException extends ResourceNotFoundException {
+
+    private final ExceptionCode exceptionCode;
+
+    public NoticeUnsupportedException() {
+        super(NOTICE_UNSUPPORTED);
+        this.exceptionCode = NOTICE_UNSUPPORTED;
+    }
+
+    @Override
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/exception/notice/exception/WebScrapingException.java
+++ b/src/main/java/leaguehub/leaguehubbackend/exception/notice/exception/WebScrapingException.java
@@ -1,0 +1,21 @@
+package leaguehub.leaguehubbackend.exception.notice.exception;
+
+import static leaguehub.leaguehubbackend.exception.notice.NoticeExceptionCode.WEB_SCRAPING_ERROR;
+
+import leaguehub.leaguehubbackend.exception.global.ExceptionCode;
+import leaguehub.leaguehubbackend.exception.global.exception.ResourceNotFoundException;
+
+public class WebScrapingException extends ResourceNotFoundException {
+
+    private final ExceptionCode exceptionCode;
+
+    public WebScrapingException() {
+        super(WEB_SCRAPING_ERROR);
+        this.exceptionCode = WEB_SCRAPING_ERROR;
+    }
+
+    @Override
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/service/notice/NoticeService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/notice/NoticeService.java
@@ -2,26 +2,77 @@ package leaguehub.leaguehubbackend.service.notice;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import leaguehub.leaguehubbackend.dto.notice.Notice;
+import leaguehub.leaguehubbackend.exception.notice.exception.NoticeUnsupportedException;
+import leaguehub.leaguehubbackend.exception.notice.exception.WebScrapingException;
 import lombok.RequiredArgsConstructor;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 
 
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
+    private static final String TFT_URL = "https://www.leagueoflegends.com/ko-kr/news/game-updates/";
+    private static final String TFT_SELECTOR = "#gatsby-focus-wrapper > div > div.style__Wrapper-sc-1ynvx8h-0.style__ResponsiveWrapper-sc-1ynvx8h-6.bNRNtU.dzWqHp > div > div.style__Wrapper-sc-106zuld-0.style__ResponsiveWrapper-sc-106zuld-4.enQqER.jYHLfd.style__List-sc-1ynvx8h-3.qfKFn > div > ol > li";
+    private static final String TFT_TITLE_SELECTOR = "a > article > div.style__Info-sc-1h41bzo-6.eBtwVi > div > h2";
+    private static final String LOL_URL = "https://www.leagueoflegends.com/ko-kr/news/notices/";
+    private static final String LOL_SELECTOR = "#gatsby-focus-wrapper > div > div.style__Wrapper-sc-1ynvx8h-0.style__ResponsiveWrapper-sc-1ynvx8h-6.bNRNtU.dzWqHp > div > div.style__Wrapper-sc-106zuld-0.style__ResponsiveWrapper-sc-106zuld-4.enQqER.jYHLfd.style__List-sc-1ynvx8h-3.qfKFn > div > ol > li";
+    private static final String LOL_TITLE_SELECTOR = "a > article > div.style__Info-sc-1h41bzo-6.eBtwVi > div > h2";
+    private static final String FC_URL = "https://fconline.nexon.com/news/notice/list";
+    private static final String FC_SELECTOR = "#divListPart > div.board_list > div.content > div.list_wrap > div.tbody > div:nth-child(%d) > a";
+    private static final String FC_TITLE_SELECTOR = "a > span.td.subject";
+    private static final String HOS_URL = "https://news.blizzard.com/ko-kr/hearthstone";
+    private static final String HOS_SELECTOR = "#recent-articles > li:nth-child(%d) > article > a";
 
-    public List<Notice> getNotice(String target) {
-        if ("tft".equals(target)) {
-            return scrapeTftNotice();
-        } else {
-            return getLeagueHubNotice();
+    public List<Notice> getNotice(String target) throws NoticeUnsupportedException {
+        return switch (target) {
+            case "tft" -> scrapeNotices(TFT_URL, TFT_SELECTOR, TFT_TITLE_SELECTOR, null, null);
+            case "lol" -> scrapeNotices(LOL_URL, LOL_SELECTOR, LOL_TITLE_SELECTOR, null, null);
+            case "fc" -> scrapeNotices(FC_URL, FC_SELECTOR, FC_TITLE_SELECTOR, 4, 9);
+            case "hos" -> scrapeNotices(HOS_URL, HOS_SELECTOR, null, 1, 6);
+            case "main" -> getLeagueHubNotice();
+            default -> throw new NoticeUnsupportedException();
+        };
+    }
+
+    private List<Notice> scrapeNotices(String url, String itemSelector, String titleSelector, Integer start, Integer end) throws WebScrapingException {
+        List<Notice> notices = new ArrayList<>();
+        try {
+            Document doc = Jsoup.connect(url).get();
+
+            int startIndex = start != null ? start : 1;
+            int endIndex = end != null ? end : doc.select(itemSelector).size();
+
+            return IntStream.rangeClosed(startIndex, endIndex)
+                    .mapToObj(i -> doc.select(String.format(itemSelector, i)))
+                    .filter(elements -> !elements.isEmpty())
+                    .map(Elements::first).filter(Objects::nonNull)
+                    .map(newsItem ->
+                            createNoticeFromElement(newsItem, titleSelector))
+                    .collect(Collectors.toList());
+
+        } catch (Exception e) {
+            throw new WebScrapingException();
         }
     }
+
+    private Notice createNoticeFromElement(Element element, String titleSelector) {
+        String newsLink = element.select("a").attr("abs:href");
+        String title = titleSelector != null ? element.select(titleSelector).text() : element.text();
+
+        return Notice.builder()
+                .noticeLink(newsLink)
+                .noticeTitle(title)
+                .build();
+    }
+
     private List<Notice> getLeagueHubNotice() {
         List<Notice> notices = new ArrayList<>();
 
@@ -37,35 +88,5 @@ public class NoticeService {
                 .noticeTitle(title)
                 .noticeInfo(info)
                 .build();
-    }
-
-
-    private List<Notice> scrapeTftNotice() {
-        List<Notice> notices = new ArrayList<>();
-        try {
-            Document doc = Jsoup.connect("https://www.leagueoflegends.com/ko-kr/news/game-updates/").get();
-
-            Elements newsItems = doc.select(
-                    "#gatsby-focus-wrapper > div > div.style__Wrapper-sc-1ynvx8h-0.style__ResponsiveWrapper-sc-1ynvx8h-6.bNRNtU.dzWqHp > div > div.style__Wrapper-sc-106zuld-0.style__ResponsiveWrapper-sc-106zuld-4.enQqER.jYHLfd.style__List-sc-1ynvx8h-3.qfKFn > div > ol > li");
-
-            for (Element item : newsItems) {
-                String newsLink = item.select("a").attr("abs:href");
-                String title = item.select("a > article > div.style__Info-sc-1h41bzo-6.eBtwVi > div > h2").text();
-                String metaData = item.select(
-                                "a > article > div.style__Info-sc-1h41bzo-6.eBtwVi > div > div.style__Meta-sc-1h41bzo-10.hGstqB")
-                        .text();
-
-                Notice notice = Notice.builder()
-                        .noticeLink(newsLink)
-                        .noticeTitle(title)
-                        .noticeInfo(metaData)
-                        .build();
-
-                notices.add(notice);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return notices;
     }
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#433 

## 📝 Description

FC 온라인, 롤, 하스스톤 공지를 스크래핑을 하는 기능을 구현했습니다. 
또한 공지가 유효하지 않을때 에러처리를 했습니다.

리그허브 공지 삭제, 추가는 같이 고민 해봐야할거 같네요

## ✨ Feature

1. 하스스톤, FC, 롤 공지 스크래핑
2. 공지 에러처리

## 👌 Review Change
This closes #433 
리뷰를 통해 수정한 부분을 나열해주세요.