### PR TITLE
Feat#435: 채널 삭제 기능 구현

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/controller/channel/ChannelController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import leaguehub.leaguehubbackend.dto.channel.*;
 import leaguehub.leaguehubbackend.exception.global.ExceptionResponse;
+import leaguehub.leaguehubbackend.service.channel.ChannelDeleteService;
 import leaguehub.leaguehubbackend.service.channel.ChannelService;
 import leaguehub.leaguehubbackend.service.participant.ParticipantService;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class ChannelController {
 
     private final ChannelService channelService;
     private final ParticipantService participantService;
+    private final ChannelDeleteService channelDeleteService;
 
     @Operation(summary = "채널 생성")
     @ApiResponses(value = {
@@ -109,5 +111,13 @@ public class ChannelController {
                                               @RequestParam("status") Integer status) {
         channelService.updateChannelStatus(channelLink, status);
         return new ResponseEntity("Channel Status Successfully updated", OK);
+    }
+
+    @DeleteMapping("/channel/{channelLink}")
+    public ResponseEntity deleteChannel(@PathVariable("channelLink") String channelLink) {
+
+        channelDeleteService.deleteChannel(channelLink);
+
+        return new ResponseEntity(OK);
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelBoard.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelBoard.java
@@ -81,4 +81,8 @@ public class ChannelBoard extends BaseTimeEntity {
         this.index = updateIndex;
     }
 
+    public void deleteChannel() {
+        this.channel = null;
+    }
+
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelInfo.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelInfo.java
@@ -54,6 +54,7 @@ public class ChannelInfo extends BaseTimeEntity {
         return this;
     }
 
-
-
+    public void deleteChannel() {
+        this.channel = null;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelRule.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/channel/ChannelRule.java
@@ -91,4 +91,8 @@ public class ChannelRule extends BaseTimeEntity {
             throw new ChannelRequestException();
         }
     }
+
+    public void deleteChannel() {
+        this.channel = null;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/Match.java
@@ -75,5 +75,7 @@ public class Match extends BaseTimeEntity {
 
     public void updateOffAlarm(){ this.alarm = false; }
 
-
+    public void deleteChannel() {
+        this.channel = null;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchPlayer.java
@@ -60,4 +60,9 @@ public class MatchPlayer extends BaseTimeEntity {
     public void updateMatchPlayerResultStatus(MatchPlayerResultStatus matchPlayerResultStatus) {
         this.matchPlayerResultStatus = matchPlayerResultStatus;
     }
+
+    public void deleteParticipantAndMatch() {
+        this.participant = null;
+        this.match = null;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchRank.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchRank.java
@@ -32,4 +32,8 @@ public class MatchRank extends BaseTimeEntity {
 
         return matchRank;
     }
+
+    public void deleteMatchSet() {
+        this.matchSet = null;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchSet.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/match/MatchSet.java
@@ -29,7 +29,7 @@ public class MatchSet extends BaseTimeEntity {
 
     private Integer setCount;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "matchSet")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "matchSet", cascade = CascadeType.REMOVE, orphanRemoval = true)
     List<MatchRank> matchRankList = new ArrayList<>();
 
     public void updateRiotMatchUuid(String riotMatchUuid) {
@@ -51,5 +51,10 @@ public class MatchSet extends BaseTimeEntity {
 
     public void addMatchRankList(List<MatchRank> matchRankList) {
         this.matchRankList = matchRankList;
+    }
+
+    public void deleteMatchAndMatchRankList() {
+        this.match = null;
+        this.matchRankList.clear();
     }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/participant/Participant.java
@@ -143,4 +143,9 @@ public class Participant extends BaseTimeEntity {
     }
 
     public void updateNickname(String newNickname) { this.nickname = newNickname; }
+
+    public void deleteChannelAndMember() {
+        this.channel = null;
+        this.member = null;
+    }
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelBoardRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelBoardRepository.java
@@ -21,6 +21,8 @@ public interface ChannelBoardRepository extends JpaRepository<ChannelBoard, Long
 
     List<ChannelBoard> findAllByChannelAndIndexGreaterThan(Channel channel, int deleteIndex);
 
+    List<ChannelBoard> findChannelBoardsByChannel_ChannelLink(String channelLink);
+
     @Query("SELECT MAX(b.index) FROM ChannelBoard b WHERE b.channel = :channel")
     Integer findMaxIndexByChannel(@Param("channel") Channel channel);
 }

--- a/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelInfoRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/channel/ChannelInfoRepository.java
@@ -1,9 +1,9 @@
 package leaguehub.leaguehubbackend.repository.channel;
 
-import io.lettuce.core.dynamic.annotation.Param;
 import leaguehub.leaguehubbackend.entity.channel.ChannelInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 

--- a/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelDeleteService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/channel/ChannelDeleteService.java
@@ -1,0 +1,149 @@
+package leaguehub.leaguehubbackend.service.channel;
+
+import leaguehub.leaguehubbackend.entity.channel.Channel;
+import leaguehub.leaguehubbackend.entity.channel.ChannelBoard;
+import leaguehub.leaguehubbackend.entity.channel.ChannelRule;
+import leaguehub.leaguehubbackend.entity.match.Match;
+import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
+import leaguehub.leaguehubbackend.entity.match.MatchSet;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.entity.participant.Participant;
+import leaguehub.leaguehubbackend.exception.channel.exception.ChannelNotFoundException;
+import leaguehub.leaguehubbackend.exception.channel.exception.ChannelStatusAlreadyException;
+import leaguehub.leaguehubbackend.exception.participant.exception.InvalidParticipantAuthException;
+import leaguehub.leaguehubbackend.exception.participant.exception.ParticipantNotGameHostException;
+import leaguehub.leaguehubbackend.repository.channel.ChannelBoardRepository;
+import leaguehub.leaguehubbackend.repository.channel.ChannelInfoRepository;
+import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
+import leaguehub.leaguehubbackend.repository.channel.ChannelRuleRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchSetRepository;
+import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
+import leaguehub.leaguehubbackend.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static leaguehub.leaguehubbackend.entity.channel.ChannelStatus.PREPARING;
+import static leaguehub.leaguehubbackend.entity.participant.Role.HOST;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ChannelDeleteService {
+
+    private final ChannelRepository channelRepository;
+    private final MemberService memberService;
+    private final ChannelBoardRepository channelBoardRepository;
+    private final ParticipantRepository participantRepository;
+    private final MatchPlayerRepository matchPlayerRepository;
+    private final ChannelRuleRepository channelRuleRepository;
+    private final MatchSetRepository matchSetRepository;
+    private final ChannelInfoRepository channelInfoRepository;
+    private final MatchRepository matchRepository;
+
+    @Transactional
+    public void deleteChannel(String channelLink) {
+        Member member = memberService.findCurrentMember();
+        Participant participant = getParticipant(member.getId(), channelLink);
+        Channel channel = getChannel(channelLink);
+
+        if (channel.getChannelStatus() != PREPARING) {
+            throw new ChannelStatusAlreadyException();
+        }
+
+        if (participant.getRole() != HOST) {
+            throw new ParticipantNotGameHostException();
+        }
+
+        deleteParticipant(channelLink);
+        deleteMatch(channelLink);
+
+        deleteChannelBoards(channelLink);
+
+        deleteChannelInfo(channelLink);
+
+        deleteChannelRule(channelLink);
+
+        channelRepository.delete(channel);
+        channelRepository.flush();
+    }
+
+    private void deleteChannelBoards(String channelLink) {
+        List<ChannelBoard> channelBoards = channelBoardRepository.findChannelBoardsByChannel_ChannelLink(channelLink);
+        channelBoards.stream().forEach(channelBoard -> {
+            channelBoard.deleteChannel();
+        });
+
+        channelBoardRepository.deleteAllInBatch(channelBoards);
+        channelBoardRepository.flush();
+    }
+
+    private void deleteChannelInfo(String channelLink) {
+        channelInfoRepository.findChannelInfoByChannel_ChannelLink(channelLink).ifPresent(
+                channelInfo -> {
+                    channelInfo.deleteChannel();
+                    channelInfoRepository.delete(channelInfo);
+                }
+        );
+
+        channelInfoRepository.flush();
+    }
+
+    private void deleteChannelRule(String channelLink) {
+        ChannelRule channelRule = channelRuleRepository.findChannelRuleByChannel_ChannelLink(channelLink);
+        channelRule.deleteChannel();
+        channelRuleRepository.delete(channelRule);
+        channelRuleRepository.flush();
+    }
+
+    private void deleteMatch(String channelLink) {
+        List<Match> matchList = matchRepository.findAllByChannel_ChannelLink(channelLink);
+
+        matchList.stream().forEach(match -> {
+            match.deleteChannel();
+            List<MatchSet> matchSetList = matchSetRepository.findAllByMatch_Channel_ChannelLink(channelLink);
+            matchSetList.stream().forEach(matchSet -> {
+                matchSet.getMatchRankList().stream().forEach(matchRank -> {
+                    matchRank.deleteMatchSet();
+                });
+                matchSet.deleteMatchAndMatchRankList();
+            });
+
+            matchSetRepository.deleteAllInBatch(matchSetList);
+        });
+
+        matchRepository.deleteAllInBatch(matchList);
+    }
+
+    private void deleteParticipant(String channelLink) {
+        List<Participant> participants = participantRepository.findAllByChannel_ChannelLink(channelLink);
+
+        participants.stream().forEach(p -> {
+            p.deleteChannelAndMember();
+            List<MatchPlayer> matchPlayers = matchPlayerRepository.findMatchPlayersByParticipantId(p.getId());
+            matchPlayers.stream().forEach(mp -> {
+                mp.deleteParticipantAndMatch();
+            });
+            matchPlayerRepository.deleteAllInBatch(matchPlayers);
+        });
+
+        participantRepository.deleteAllInBatch(participants);
+    }
+
+    private Channel getChannel(String channelLink) {
+        Channel channel = channelRepository.findByChannelLink(channelLink)
+                .orElseThrow(ChannelNotFoundException::new);
+        return channel;
+    }
+
+
+    private Participant getParticipant(Long memberId, String channelLink) {
+        return participantRepository
+                .findParticipantByMemberIdAndChannel_ChannelLink(memberId, channelLink)
+                .orElseThrow(() -> new InvalidParticipantAuthException());
+    }
+}

--- a/src/test/java/leaguehub/leaguehubbackend/service/channel/ChannelDeleteServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/channel/ChannelDeleteServiceTest.java
@@ -1,0 +1,130 @@
+package leaguehub.leaguehubbackend.service.channel;
+
+import leaguehub.leaguehubbackend.dto.channel.CreateChannelDto;
+import leaguehub.leaguehubbackend.dto.channel.ParticipantChannelDto;
+import leaguehub.leaguehubbackend.entity.channel.Channel;
+import leaguehub.leaguehubbackend.entity.channel.ChannelBoard;
+import leaguehub.leaguehubbackend.entity.channel.ChannelRule;
+import leaguehub.leaguehubbackend.entity.match.Match;
+import leaguehub.leaguehubbackend.entity.match.MatchPlayer;
+import leaguehub.leaguehubbackend.entity.member.Member;
+import leaguehub.leaguehubbackend.entity.participant.Participant;
+import leaguehub.leaguehubbackend.fixture.ChannelFixture;
+import leaguehub.leaguehubbackend.fixture.UserFixture;
+import leaguehub.leaguehubbackend.repository.channel.ChannelBoardRepository;
+import leaguehub.leaguehubbackend.repository.channel.ChannelRepository;
+import leaguehub.leaguehubbackend.repository.channel.ChannelRuleRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
+import leaguehub.leaguehubbackend.repository.match.MatchRepository;
+import leaguehub.leaguehubbackend.repository.member.MemberRepository;
+import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@TestPropertySource(locations = "classpath:application-test.properties")
+class ChannelDeleteServiceTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    ChannelService channelService;
+    @Autowired
+    ChannelRepository channelRepository;
+    @Autowired
+    ChannelBoardService channelBoardService;
+    @Autowired
+    ChannelBoardRepository channelBoardRepository;
+    @Autowired
+    ParticipantRepository participantRepository;
+    @Autowired
+    ChannelRuleRepository channelRuleRepository;
+    @Autowired
+    ChannelDeleteService channelDeleteService;
+    @Autowired
+    MatchRepository matchRepository;
+    @Autowired
+    MatchPlayerRepository matchPlayerRepository;
+    private Member member1;
+
+    private Match savedMatch;
+    private Channel channel;
+
+    @BeforeEach
+    public void setUp() {
+        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                .username("member1")
+                .password("member1")
+                .roles("USER")
+                .build();
+
+        GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetailsUser, null
+                , authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        member1 = memberRepository.save(UserFixture.createCustomeMember("member1"));
+        Member member2 = memberRepository.save(UserFixture.createCustomeMember("member2"));
+        Member member3 = memberRepository.save(UserFixture.createCustomeMember("member3"));
+        Member member4 = memberRepository.save(UserFixture.createCustomeMember("member4"));
+
+        CreateChannelDto channelDto = ChannelFixture.createAllPropertiesCustomChannelDto(false, false, 2400, null, 20);
+        channel = Channel.createChannel(channelDto.getTitle(),
+                channelDto.getGameCategory(), channelDto.getMaxPlayer(),
+                channelDto.getMatchFormat(), channelDto.getChannelImageUrl());
+        ChannelRule channelRule = ChannelRule.createChannelRule(channel, channelDto.getTier(), channelDto.getTierMax(), channelDto.getTierMin(),
+                channelDto.getPlayCount(),
+                channelDto.getPlayCountMin());
+        channelRepository.save(channel);
+        channelRuleRepository.save(channelRule);
+
+        // Participant 생성 및 저장
+        Participant participant1 = participantRepository.save(Participant.createHostChannel(member1, channel));
+        Participant participant2 = participantRepository.save(Participant.createHostChannel(member2, channel));
+        Participant participant3 = participantRepository.save(Participant.createHostChannel(member3, channel));
+        Participant participant4 = participantRepository.save(Participant.createHostChannel(member4, channel));
+
+        // Match 생성 및 저장
+        Integer matchRound = 1;
+        String matchName = "Sample Match";
+        Match match = Match.createMatch(matchRound, channel, matchName);
+        savedMatch = matchRepository.save(match);
+
+        // MatchPlayer 생성
+        MatchPlayer matchPlayer1 = MatchPlayer.createMatchPlayer(participant1, savedMatch);
+        MatchPlayer matchPlayer2 = MatchPlayer.createMatchPlayer(participant2, savedMatch);
+        MatchPlayer matchPlayer3 = MatchPlayer.createMatchPlayer(participant3, savedMatch);
+        MatchPlayer matchPlayer4 = MatchPlayer.createMatchPlayer(participant4, savedMatch);
+        matchPlayer1.updateMatchPlayerScore(1);
+        matchPlayer2.updateMatchPlayerScore(2);
+        matchPlayer3.updateMatchPlayerScore(2);
+        matchPlayer4.updateMatchPlayerScore(3);
+
+        matchPlayerRepository.save(matchPlayer1);
+        matchPlayerRepository.save(matchPlayer2);
+        matchPlayerRepository.save(matchPlayer3);
+        matchPlayerRepository.save(matchPlayer4);
+    }
+
+    @Test
+    void deleteChannel() {
+        channelDeleteService.deleteChannel(channel.getChannelLink());
+    }
+}

--- a/src/test/java/leaguehub/leaguehubbackend/service/channel/ChannelDeleteServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/channel/ChannelDeleteServiceTest.java
@@ -18,6 +18,7 @@ import leaguehub.leaguehubbackend.repository.match.MatchPlayerRepository;
 import leaguehub.leaguehubbackend.repository.match.MatchRepository;
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
 import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @SpringBootTest
@@ -126,5 +129,12 @@ class ChannelDeleteServiceTest {
     @Test
     void deleteChannel() {
         channelDeleteService.deleteChannel(channel.getChannelLink());
+
+        List<Participant> allByMemberId = participantRepository.findAllByMemberId(member1.getId());
+
+        Assertions.assertThat(allByMemberId.size()).isEqualTo(0);
+
+        Assertions.assertThatThrownBy(() -> channelRepository.findByChannelLink(channel.getChannelLink()).get())
+                .isInstanceOf(NoSuchElementException.class);
     }
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#435 

## 📝 Description

채널 삭제 기능을 구현했어요. 채널이 삭제 되면서 
- 채널과 연관된 ChannelInfo, ChannelBoards, ChannelRule
- Participant, MatchPlayer
- Match, MatchSet,MatchRank
항목을 삭제해요. 연관관계를 Null로 만드는 메서드도 추가했고, deleteAllInBatch를 활용해서 flush 없이 List로 되어있는 엔티티를 삭제했고, 단건 쿼리는 delete와 flush를 활용해서 영속성 컨텍스트에 캐시를 다시 비우고 최상위 channel을 삭제해 줬어요.
단건 쿼리는 성능에 크게 영향이 없을 것 같아  delete와 flush를 사용했어요.

그리고 해당 기능은 대회가 시작되기 전에만 PREPARING 상태에서만 가능해요.

Batch 및 Flush 같은 것들을 사용했는데, 나중에 리팩터링 진행하게 된다면 다시 면밀히 검토해볼께요.

그리고 너무 Service나 Controller들이 비대하고 역할이 나누어져 있지 않은데 리팩터링을 통해 최대한 잘게 나누어볼까 해요
그리고 위에서 말한 점과 서버 배포에 관한 것은 토요일 회의에 만나서 자세히 얘기할께요.


## ✨ Feature

- 채널 삭제
- 채널 삭제에 따른 연관된 테이블 모두 삭제(Member, EmailAuth 제외)
- 테스트

## 👌 Review Change

리뷰를 통해 수정한 부분을 나열해주세요.

This closes #435 