### PR TITLE
Feat#453 RefreshToken Redis에 저장

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/config/RedisConfig.java
+++ b/src/main/java/leaguehub/leaguehubbackend/config/RedisConfig.java
@@ -32,6 +32,14 @@ public class RedisConfig {
         template.setConnectionFactory(factory);
         return template;
     }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        return template;
+    }
+
     @Bean
     public MessageListenerAdapter messageListener(MatchChatSubscriber subscriber) {
         return new MessageListenerAdapter(subscriber);

--- a/src/main/java/leaguehub/leaguehubbackend/service/redis/RedisService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/redis/RedisService.java
@@ -1,0 +1,24 @@
+package leaguehub.leaguehubbackend.service.redis;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void saveRefreshToken(String personalId, String refreshToken) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(personalId, refreshToken, 7, TimeUnit.DAYS);
+    }
+
+    public String getRefreshToken(String personalId) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(personalId);
+    }
+}


### PR DESCRIPTION
## 🙆‍♂️ Issue

#453 

## 📝 Description

회원가입, 로그인시 생성되는 RefreshToken을 redis에 저장합니다.
저장기간은 7일으로 했습니다.

재발급 기능과 Entity 수정은 다른 이슈로 나눠 올리겠습니다.

## ✨ Feature

1. RefreshToken Redis 에 저장

## 👌 Review Change
This closes #453 
리뷰를 통해 수정한 부분을 나열해주세요.