### PR TITLE
Feat#455: Redis를 사용한 토큰 재발급

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
+++ b/src/main/java/leaguehub/leaguehubbackend/entity/member/Member.java
@@ -28,8 +28,6 @@ public class Member extends BaseTimeEntity {
 
     private String profileImageUrl;
 
-    private String refreshToken;
-
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "email_auth_id", referencedColumnName = "email_id")
     private EmailAuth emailAuth;
@@ -42,9 +40,6 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private BaseRole baseRole;
 
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
     public void updateRole(BaseRole role) { this.baseRole = role; }
 
     public static Member kakaoUserToMember(KakaoUserDto kakaoUserDto) {

--- a/src/main/java/leaguehub/leaguehubbackend/repository/member/MemberRepository.java
+++ b/src/main/java/leaguehub/leaguehubbackend/repository/member/MemberRepository.java
@@ -10,10 +10,8 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-
     Optional<Member> findMemberByPersonalId(String personalId);
     Optional<Member> findByNickname(String nickname);
-    Optional<Member> findByRefreshToken(String refreshToken);
     @Query("SELECT m FROM Member m JOIN m.emailAuth e WHERE e.email = :email")
     Optional<Member> findMemberByEmail(@Param("email") String email);
     @Query("SELECT m FROM Member m WHERE m.emailAuth = :emailAuth")

--- a/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/member/MemberService.java
@@ -17,6 +17,7 @@ import leaguehub.leaguehubbackend.exception.participant.exception.ParticipantNot
 import leaguehub.leaguehubbackend.repository.member.MemberRepository;
 import leaguehub.leaguehubbackend.repository.particiapnt.ParticipantRepository;
 import leaguehub.leaguehubbackend.service.jwt.JwtService;
+import leaguehub.leaguehubbackend.service.redis.RedisService;
 import leaguehub.leaguehubbackend.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -41,12 +42,10 @@ public class MemberService {
 
     private final JwtService jwtService;
 
+    private final RedisService redisService;
+
     public Optional<Member> findMemberByPersonalId(String personalId) {
         return memberRepository.findMemberByPersonalId(personalId);
-    }
-
-    public Optional<Member> findMemberByRefreshToken(String refreshToken) {
-        return memberRepository.findByRefreshToken(refreshToken);
     }
 
     @Transactional
@@ -77,7 +76,7 @@ public class MemberService {
 
         if (auth != null) {
             new SecurityContextLogoutHandler().logout(request, response, auth);
-            member.updateRefreshToken(null);
+            redisService.deleteRefreshToken(member.getPersonalId());
             SecurityContextHolder.clearContext();
             memberRepository.save(member);
         }

--- a/src/main/java/leaguehub/leaguehubbackend/service/redis/RedisService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/service/redis/RedisService.java
@@ -21,4 +21,8 @@ public class RedisService {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         return valueOperations.get(personalId);
     }
+
+    public void deleteRefreshToken(String personalId) {
+        redisTemplate.delete(personalId);
+    }
 }


### PR DESCRIPTION
## 🙆‍♂️ Issue

#455 

## 📝 Description

RefreshToken을 사용하여 Access, Refresh 토큰을 재발급 할 수 있습니다.
JwtController에 있는 로직을 Service로 이동을 하였습니다.
User Entity 에서 RefreshToken을 삭제하였습니다.

## ✨ Feature

1. Redis를 사용하여 토큰 재발급
2. JwtController 리팩토링
3. User Entity에 있는 RefrerhToken 관련코드 삭제

## 👌 Review Change
This closes #455 
리뷰를 통해 수정한 부분을 나열해주세요.