### PR TITLE
Refactor#464 : 안전한 토큰 저장을 위한 HttpOnly와 Secure 쿠키 설정

### DIFF
--- a/src/test/java/leaguehub/leaguehubbackend/controller/KakaoControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/KakaoControllerTest.java
@@ -1,15 +1,20 @@
 package leaguehub.leaguehubbackend.controller;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import leaguehub.leaguehubbackend.domain.member.controller.KakaoController;
 import leaguehub.leaguehubbackend.domain.member.dto.kakao.KakaoTokenResponseDto;
 import leaguehub.leaguehubbackend.domain.member.dto.kakao.KakaoUserDto;
 import leaguehub.leaguehubbackend.domain.member.dto.member.LoginMemberResponse;
-import leaguehub.leaguehubbackend.domain.member.entity.Member;
-import leaguehub.leaguehubbackend.domain.member.exception.kakao.exception.KakaoInvalidCodeException;
-import leaguehub.leaguehubbackend.fixture.UserFixture;
 import leaguehub.leaguehubbackend.domain.member.service.JwtService;
 import leaguehub.leaguehubbackend.domain.member.service.KakaoService;
 import leaguehub.leaguehubbackend.domain.member.service.MemberService;
+import leaguehub.leaguehubbackend.fixture.UserFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -17,19 +22,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-
-import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @SpringBootTest
@@ -55,17 +51,14 @@ public class KakaoControllerTest {
     @Test
     @DisplayName("유효하지 않은 카카오 코드시 KakaoInvalidCodeException")
     public void whenKakaoCodeIsMissingOrEmpty_thenThrowKakaoInvalidCodeException() throws Exception {
-        HttpHeaders headers = new HttpHeaders();
+        mockMvc.perform(post("/api/member/oauth/kakao")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
 
-        assertThrows(KakaoInvalidCodeException.class, () -> {
-            kakaoController.handleKakaoLogin(headers);
-        });
-
-        headers.add("Kakao-Code", "");
-
-        assertThrows(KakaoInvalidCodeException.class, () -> {
-            kakaoController.handleKakaoLogin(headers);
-        });
+        mockMvc.perform(post("/api/member/oauth/kakao")
+                        .header("Kakao-Code", "")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -74,19 +67,44 @@ public class KakaoControllerTest {
         KakaoTokenResponseDto kakaoTokenResponseDto = new KakaoTokenResponseDto();
         kakaoTokenResponseDto.setAccessToken("validToken");
         KakaoUserDto kakaoUserDto = new KakaoUserDto();
-        Member member = UserFixture.createMember();
         LoginMemberResponse loginMemberResponse = UserFixture.createLoginResponse();
 
         when(kakaoService.getKakaoToken(anyString())).thenReturn(kakaoTokenResponseDto);
         when(kakaoService.getKakaoUser(kakaoTokenResponseDto)).thenReturn(kakaoUserDto);
-        when(memberService.findMemberByPersonalId(String.valueOf(kakaoUserDto.getId()))).thenReturn(Optional.empty());
-        when(memberService.saveMember(kakaoUserDto)).thenReturn(Optional.of(member));
-        when(jwtService.createTokens(String.valueOf(kakaoUserDto.getId()))).thenReturn(loginMemberResponse);
+        when(memberService.findOrSaveMember(kakaoUserDto)).thenReturn(loginMemberResponse);
 
         mockMvc.perform(post("/api/member/oauth/kakao")
-                        .header("Kakao-Code", "testCode")
+                        .header("Kakao-Code", "validCode")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("유효한 카카오 코드로 로그인 시 200 OK와 헤더 반환")
+    void whenValidKakaoCode_thenReturns200AndHeaders() throws Exception {
+        String kakaoCode = "validKakaoCode";
+        KakaoTokenResponseDto kakaoTokenResponseDto = new KakaoTokenResponseDto();
+        kakaoTokenResponseDto.setAccessToken("validAccessToken");
+        kakaoTokenResponseDto.setRefreshToken("validRefreshToken");
+        kakaoTokenResponseDto.setExpiresIn(3600);
+        kakaoTokenResponseDto.setRefreshTokenExpiresIn(14 * 24 * 3600);
+
+        KakaoUserDto kakaoUserDto = new KakaoUserDto();
+        LoginMemberResponse loginMemberResponse = LoginMemberResponse.builder()
+                .accessToken("validAccessToken")
+                .refreshToken("validRefreshToken")
+                .verifiedUser(true)
+                .build();
+
+        given(kakaoService.getKakaoToken(kakaoCode)).willReturn(kakaoTokenResponseDto);
+        given(kakaoService.getKakaoUser(kakaoTokenResponseDto)).willReturn(kakaoUserDto);
+        given(memberService.findOrSaveMember(kakaoUserDto)).willReturn(loginMemberResponse);
+
+        mockMvc.perform(post("/api/member/oauth/kakao")
+                        .header("Kakao-Code", kakaoCode)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Authorization", "Bearer validAccessToken"));
     }
 
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#464 

## 📝 Description

로그인 시 `refreshToken`을 쿠키에 안전하게 저장하도록 로그인 응답 로직을 변경했습니다. 
로그인 응답 로직 변경에 따라 관련 테스트 코드도 수정되었습니다.

`refreshToken`을 저장하는 로직은 컨트롤러에 추가되었습니다. 이에 대한 다른 의견이 있으시다면 리뷰를 부탁드립니다.

## ✨ Feature
1. 로그인 응답 변경:클라이언트에게 `refreshToken`을 쿠키로 반환하도록 로직을 수정했습니다. 이는 XSS 공격으로부터 보안을 강화합니다.
2. 로그인 테스트 코드 수정: 새로운 로그인 응답 로직에 맞춰 테스트 코드를 업데이트했습니다.

## 👌 Review Change
This closes #464 
