### PR TITLE
Refactor#458 : Participant 패키지 구조 개선

### DIFF
--- a/src/main/java/leaguehub/leaguehubbackend/domain/channel/controller/ChannelController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/channel/controller/ChannelController.java
@@ -15,6 +15,7 @@ import leaguehub.leaguehubbackend.domain.channel.service.ChannelDeleteService;
 import leaguehub.leaguehubbackend.domain.channel.service.ChannelService;
 import leaguehub.leaguehubbackend.domain.participant.exception.exception.InvalidParticipantAuthException;
 import leaguehub.leaguehubbackend.domain.participant.exception.exception.ParticipantNotGameHostException;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantQueryService;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,7 @@ public class ChannelController {
     private final ChannelService channelService;
     private final ParticipantService participantService;
     private final ChannelDeleteService channelDeleteService;
+    private final ParticipantQueryService participantQueryService;
 
     @Operation(summary = "채널 생성")
     @ApiResponses(value = {
@@ -62,11 +64,11 @@ public class ChannelController {
 
         ResponseChannelDto responseChannelDto = ResponseChannelDto.builder()
                 .gameCategory(channelInfo.getGameCategory().getNum())
-                .hostName(participantService.findChannelHost(channelLink))
+                .hostName(participantQueryService.findChannelHost(channelLink))
                 .participateNum(channelInfo.getRealPlayer())
                 .maxPlayer(channelInfo.getMaxPlayer())
                 .leagueTitle(channelInfo.getTitle())
-                .permission(participantService.findParticipantPermission(channelLink))
+                .permission(participantQueryService.findParticipantPermission(channelLink))
                 .build();
 
         return new ResponseEntity(responseChannelDto, OK);

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantCommandController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantCommandController.java
@@ -10,7 +10,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import leaguehub.leaguehubbackend.domain.channel.dto.ParticipantChannelDto;
-import leaguehub.leaguehubbackend.domain.participant.dto.*;
+import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantDto;
+import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdDto;
+import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdResponseDto;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,31 +27,22 @@ import java.util.List;
 
 import static org.springframework.http.HttpStatus.OK;
 
-@Tag(name = "Participants-Controller", description = "참가자 관련 API")
+@Tag(name = "Participants-Command-Controller", description = "참가자 명령 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-public class ParticipantController {
+public class ParticipantCommandController {
 
+    /*
+    * 롤토체스 경기에 참가 요청
+    *
+     */
+
+    //실격, 기권에 대한 웹소켓???
+    //disqualifiedParticipant
     private final ParticipantService participantService;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    @Operation(summary = "티어 검색 (참가 x)", description = "검색 버튼을 누르면 해당 카테고리와 게임 닉네임을 가지고 티어 검색 (참가 x)")
-    @Parameters(value = {
-            @Parameter(name = "gameid", description = "해당 게임 닉네임", example = "칸영기"),
-            @Parameter(name = "gamecategory", description = "게임 종류 (tft, lol, ...)", example = "0, 1, 2")
-    })
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "검색 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseUserGameInfoDto.class))),
-            @ApiResponse(responseCode = "404", description = "게임 ID를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @GetMapping("/participant/stat/{gameId}/{gameTag}")
-    public ResponseEntity getUserDetail(@PathVariable("gameId") String gameId, @PathVariable("gameTag") String gameTag) {
-
-        ResponseUserGameInfoDto userDetailDto = participantService.selectGameCategory(gameId + "#" + gameTag, 0);
-
-        return new ResponseEntity<>(userDetailDto, OK);
-    }
 
     @Operation(summary = "경기에 참가요청(TFT 만)", description = "관전자가 게임에 참가 요청")
     @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
@@ -58,43 +51,13 @@ public class ParticipantController {
             @ApiResponse(responseCode = "400", description = "해당 게임에 참여할 수 없는 상태입니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @PostMapping("/{channelLink}/participant")
-    public ResponseEntity participateMatch(@PathVariable("channelLink") String channelLink, @RequestBody @Valid ParticipantDto responseDto) {
+    public ResponseEntity participateMatch(@PathVariable("channelLink") String channelLink, @RequestBody @Valid ParticipantDto responseDto){
 
         participantService.participateMatch(responseDto, channelLink);
 
         return new ResponseEntity<>("Update Participant ROLE", OK);
     }
 
-
-    @Operation(summary = "게임 참가자(Player) 조회 ", description = "채널 내 게임 참가자(Player) 모두 조회")
-    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "참가자 검색 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseStatusPlayerDto.class))),
-            @ApiResponse(responseCode = "404", description = "해당 채널을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @GetMapping("/{channelLink}/players")
-    public ResponseEntity loadPlayer(@PathVariable("channelLink") String channelLink) {
-
-
-        List<ResponseStatusPlayerDto> players = participantService.loadPlayers(channelLink);
-
-        return new ResponseEntity<>(players, OK);
-    }
-
-
-    @Operation(summary = "게임 참가요청자(Request) 조회 ", description = "채널 내 게임 참가요청자(Request) 모두 조회")
-    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "요청자 검색 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseStatusPlayerDto.class))),
-            @ApiResponse(responseCode = "400", description = "해당 채널의 관리자가 아닙니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @GetMapping("/{channelLink}/player/requests")
-    public ResponseEntity loadRequestPlayer(@PathVariable("channelLink") String channelLink) {
-
-        List<ResponseStatusPlayerDto> responsePlayers = participantService.loadRequestStatusPlayerList(channelLink);
-
-        return new ResponseEntity<>(responsePlayers, OK);
-    }
 
     @Operation(summary = "참가요청 승인", description = "관리자가 해당 게임 참가요청자(request)를 승인")
     @Parameters(value = {
@@ -106,8 +69,8 @@ public class ParticipantController {
             @ApiResponse(responseCode = "404", description = "채널 참가자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @PostMapping("/{channelLink}/{participantId}/player")
-    public ResponseEntity approveParticipant(@PathVariable("channelLink") String channelLink,
-                                             @PathVariable("participantId") Long participantId) {
+    public ResponseEntity approveParticipantRequest(@PathVariable("channelLink") String channelLink,
+                                                    @PathVariable("participantId") Long participantId){
 
         participantService.approveParticipantRequest(channelLink, participantId);
 
@@ -124,24 +87,13 @@ public class ParticipantController {
             @ApiResponse(responseCode = "404", description = "채널 참가자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @PostMapping("/{channelLink}/{participantId}/observer")
-    public ResponseEntity rejectedParticipant(@PathVariable("channelLink") String channelLink,
-                                              @PathVariable("participantId") Long participantId) {
+    public ResponseEntity rejectParticipantRequest(@PathVariable("channelLink") String channelLink,
+                                                   @PathVariable("participantId") Long participantId){
 
         participantService.rejectedParticipantRequest(channelLink, participantId);
 
         return new ResponseEntity<>("reject participant", OK);
     }
-
-    //실격, 기권에 대한 웹소켓
-    @MessageMapping("/{channelLink}/{matchIdStr}/disqualification")
-    public void disqualifiedParticipant(@DestinationVariable("channelLink") String channelLink,
-                                        @DestinationVariable("matchIdStr") String matchIdStr,
-                                        @Payload ParticipantIdDto message) {
-        ParticipantIdResponseDto participantIdResponseDto = participantService.disqualifiedParticipant(channelLink, message);
-
-        simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, participantIdResponseDto);
-    }
-
 
     @Operation(summary = "관리자 권한 부여", description = "관리자가 관전자에게 권한을 부여")
     @Parameters(value = {
@@ -154,26 +106,11 @@ public class ParticipantController {
     })
     @PostMapping("/{channelLink}/{participantId}/host")
     public ResponseEntity updateHostParticipant(@PathVariable("channelLink") String channelLink,
-                                                @PathVariable("participantId") Long participantId) {
+                                                @PathVariable("participantId") Long participantId){
 
         participantService.updateHostRole(channelLink, participantId);
 
         return new ResponseEntity<>("update HOST", OK);
-    }
-
-    @Operation(summary = "채널 관전자(Observer) 조회 ", description = "채널 내 게임 관전자(Observer) 모두 조회")
-    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "관전자 검색 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseStatusPlayerDto.class))),
-            @ApiResponse(responseCode = "400", description = "해당 채널의 관리자가 아닙니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @GetMapping("/{channelLink}/observers")
-    public ResponseEntity loadObserverPlayer(@PathVariable("channelLink") String channelLink) {
-
-        List<ResponseStatusPlayerDto> responsePlayers = participantService.loadObserverPlayerList(channelLink);
-
-
-        return new ResponseEntity<>(responsePlayers, OK);
     }
 
     @Operation(summary = "채널 참가", description = "채널 링크를 통하여 해당 채널 참가")
@@ -183,7 +120,7 @@ public class ParticipantController {
             @ApiResponse(responseCode = "403", description = "해당 채널을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @PostMapping("/{channelLink}/participant/observer")
-    public ResponseEntity participateChannel(@PathVariable("channelLink") String channelLink) {
+    public ResponseEntity enterChannel(@PathVariable("channelLink") String channelLink){
 
         ParticipantChannelDto participantChannelDto = participantService.participateChannel(channelLink);
 
@@ -197,13 +134,12 @@ public class ParticipantController {
             @ApiResponse(responseCode = "403", description = "해당 채널을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
     })
     @DeleteMapping("/{channelLink}")
-    public ResponseEntity leaveChannel(@PathVariable("channelLink") String channelLink) {
+    public ResponseEntity leaveChannel(@PathVariable("channelLink") String channelLink){
 
         participantService.leaveChannel(channelLink);
 
         return new ResponseEntity<>("Leave this Channel", OK);
     }
-
 
     @Operation(summary = "채널 순서를 커스텀하게 구성 - 로그인시 사이드바 화면 구성을 커스텀할 수 있음",
             description = "입력과 반환 Dto가 동일하게 되어서 API요청 필요 없이 바로 회면 구성 가능")
@@ -211,26 +147,21 @@ public class ParticipantController {
             @ApiResponse(responseCode = "200", description = "Dto를 리스트로 반환",content = @Content(mediaType = "application/json", schema = @Schema(implementation = ParticipantChannelDto.class))),
     })
     @PostMapping("/channels/order")
-    public ResponseEntity updateCustomChannelIndex(@RequestBody List<ParticipantChannelDto> participantChannelDtoList) {
+    public ResponseEntity updateCustomChannelIndex(@RequestBody List<ParticipantChannelDto> participantChannelDtoList){
 
         List<ParticipantChannelDto> updateCustomChannelIndexList = participantService.updateCustomChannelIndex(participantChannelDtoList);
 
         return new ResponseEntity<>(updateCustomChannelIndexList, OK);
     }
 
-    @Operation(summary = "관리자 권한 확인", description = "관리자인지 확인하는 기능")
-    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Admin Check"),
-            @ApiResponse(responseCode = "401", description = "해당 권한이 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @GetMapping("/channel/{channelLink}/permission")
-    public ResponseEntity checkAdmin(@PathVariable("channelLink") String channelLink){
+    //실격, 기권에 대한 웹소켓
+    @MessageMapping("/{channelLink}/{matchIdStr}/disqualification")
+    public void disqualifiedParticipant(@DestinationVariable("channelLink") String channelLink,
+                                        @DestinationVariable("matchIdStr") String matchIdStr,
+                                        @Payload ParticipantIdDto message) {
+        ParticipantIdResponseDto participantIdResponseDto = participantService.disqualifiedParticipant(channelLink, message);
 
-        participantService.checkAdminHost(channelLink);
-
-        return new ResponseEntity<>("Admin Check", OK);
+        simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, participantIdResponseDto);
     }
-
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantCommandController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantCommandController.java
@@ -13,6 +13,7 @@ import leaguehub.leaguehubbackend.domain.channel.dto.ParticipantChannelDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdResponseDto;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantManagementService;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,7 @@ public class ParticipantCommandController {
     //disqualifiedParticipant
     private final ParticipantService participantService;
     private final SimpMessagingTemplate simpMessagingTemplate;
+    private final ParticipantManagementService participantManagementService;
 
 
     @Operation(summary = "경기에 참가요청(TFT 만)", description = "관전자가 게임에 참가 요청")
@@ -53,7 +55,7 @@ public class ParticipantCommandController {
     @PostMapping("/{channelLink}/participant")
     public ResponseEntity participateMatch(@PathVariable("channelLink") String channelLink, @RequestBody @Valid ParticipantDto responseDto){
 
-        participantService.participateMatch(responseDto, channelLink);
+        participantManagementService.participateMatch(responseDto, channelLink);
 
         return new ResponseEntity<>("Update Participant ROLE", OK);
     }
@@ -122,7 +124,7 @@ public class ParticipantCommandController {
     @PostMapping("/{channelLink}/participant/observer")
     public ResponseEntity enterChannel(@PathVariable("channelLink") String channelLink){
 
-        ParticipantChannelDto participantChannelDto = participantService.participateChannel(channelLink);
+        ParticipantChannelDto participantChannelDto = participantManagementService.participateChannel(channelLink);
 
         return new ResponseEntity<>(participantChannelDto, OK);
     }
@@ -136,7 +138,7 @@ public class ParticipantCommandController {
     @DeleteMapping("/{channelLink}")
     public ResponseEntity leaveChannel(@PathVariable("channelLink") String channelLink){
 
-        participantService.leaveChannel(channelLink);
+        participantManagementService.leaveChannel(channelLink);
 
         return new ResponseEntity<>("Leave this Channel", OK);
     }
@@ -159,7 +161,7 @@ public class ParticipantCommandController {
     public void disqualifiedParticipant(@DestinationVariable("channelLink") String channelLink,
                                         @DestinationVariable("matchIdStr") String matchIdStr,
                                         @Payload ParticipantIdDto message) {
-        ParticipantIdResponseDto participantIdResponseDto = participantService.disqualifiedParticipant(channelLink, message);
+        ParticipantIdResponseDto participantIdResponseDto = participantManagementService.disqualifiedParticipant(channelLink, message);
 
         simpMessagingTemplate.convertAndSend("/match/" + matchIdStr, participantIdResponseDto);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantCommandController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantCommandController.java
@@ -14,6 +14,7 @@ import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdResponseDto;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantManagementService;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantRoleAndPermissionService;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
@@ -39,11 +40,10 @@ public class ParticipantCommandController {
     *
      */
 
-    //실격, 기권에 대한 웹소켓???
-    //disqualifiedParticipant
     private final ParticipantService participantService;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final ParticipantManagementService participantManagementService;
+    private final ParticipantRoleAndPermissionService participantRoleAndPermissionService;
 
 
     @Operation(summary = "경기에 참가요청(TFT 만)", description = "관전자가 게임에 참가 요청")
@@ -74,7 +74,7 @@ public class ParticipantCommandController {
     public ResponseEntity approveParticipantRequest(@PathVariable("channelLink") String channelLink,
                                                     @PathVariable("participantId") Long participantId){
 
-        participantService.approveParticipantRequest(channelLink, participantId);
+        participantRoleAndPermissionService.approveParticipantRequest(channelLink, participantId);
 
         return new ResponseEntity<>("approve participant", OK);
     }
@@ -92,7 +92,7 @@ public class ParticipantCommandController {
     public ResponseEntity rejectParticipantRequest(@PathVariable("channelLink") String channelLink,
                                                    @PathVariable("participantId") Long participantId){
 
-        participantService.rejectedParticipantRequest(channelLink, participantId);
+        participantRoleAndPermissionService.rejectedParticipantRequest(channelLink, participantId);
 
         return new ResponseEntity<>("reject participant", OK);
     }
@@ -110,7 +110,7 @@ public class ParticipantCommandController {
     public ResponseEntity updateHostParticipant(@PathVariable("channelLink") String channelLink,
                                                 @PathVariable("participantId") Long participantId){
 
-        participantService.updateHostRole(channelLink, participantId);
+        participantRoleAndPermissionService.updateHostRole(channelLink, participantId);
 
         return new ResponseEntity<>("update HOST", OK);
     }
@@ -151,7 +151,7 @@ public class ParticipantCommandController {
     @PostMapping("/channels/order")
     public ResponseEntity updateCustomChannelIndex(@RequestBody List<ParticipantChannelDto> participantChannelDtoList){
 
-        List<ParticipantChannelDto> updateCustomChannelIndexList = participantService.updateCustomChannelIndex(participantChannelDtoList);
+        List<ParticipantChannelDto> updateCustomChannelIndexList = participantManagementService.updateCustomChannelIndex(participantChannelDtoList);
 
         return new ResponseEntity<>(updateCustomChannelIndexList, OK);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantManagementController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantManagementController.java
@@ -2,7 +2,6 @@ package leaguehub.leaguehubbackend.domain.participant.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,8 +13,6 @@ import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdResponseDto;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantManagementService;
-import leaguehub.leaguehubbackend.domain.participant.service.ParticipantRoleAndPermissionService;
-import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -29,21 +26,15 @@ import java.util.List;
 
 import static org.springframework.http.HttpStatus.OK;
 
-@Tag(name = "Participants-Command-Controller", description = "참가자 명령 관련 API")
+@Tag(name = "Participants-Management-Controller", description = "참가자 관리 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-public class ParticipantCommandController {
+public class ParticipantManagementController {
 
-    /*
-    * 롤토체스 경기에 참가 요청
-    *
-     */
 
-    private final ParticipantService participantService;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final ParticipantManagementService participantManagementService;
-    private final ParticipantRoleAndPermissionService participantRoleAndPermissionService;
 
 
     @Operation(summary = "경기에 참가요청(TFT 만)", description = "관전자가 게임에 참가 요청")
@@ -58,61 +49,6 @@ public class ParticipantCommandController {
         participantManagementService.participateMatch(responseDto, channelLink);
 
         return new ResponseEntity<>("Update Participant ROLE", OK);
-    }
-
-
-    @Operation(summary = "참가요청 승인", description = "관리자가 해당 게임 참가요청자(request)를 승인")
-    @Parameters(value = {
-            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
-            @Parameter(name = "participantId", description = "해당 채널 참가자의 고유 Id", example = "1")
-    })
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "승인 성공"),
-            @ApiResponse(responseCode = "404", description = "채널 참가자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @PostMapping("/{channelLink}/{participantId}/player")
-    public ResponseEntity approveParticipantRequest(@PathVariable("channelLink") String channelLink,
-                                                    @PathVariable("participantId") Long participantId){
-
-        participantRoleAndPermissionService.approveParticipantRequest(channelLink, participantId);
-
-        return new ResponseEntity<>("approve participant", OK);
-    }
-
-    @Operation(summary = "참가요청 거절", description = "관리자가 해당 게임 참가요청자(request)를 거절")
-    @Parameters(value = {
-            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
-            @Parameter(name = "participantId", description = "해당 채널 참가자의 고유 Id", example = "1")
-    })
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "거절 성공"),
-            @ApiResponse(responseCode = "404", description = "채널 참가자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @PostMapping("/{channelLink}/{participantId}/observer")
-    public ResponseEntity rejectParticipantRequest(@PathVariable("channelLink") String channelLink,
-                                                   @PathVariable("participantId") Long participantId){
-
-        participantRoleAndPermissionService.rejectedParticipantRequest(channelLink, participantId);
-
-        return new ResponseEntity<>("reject participant", OK);
-    }
-
-    @Operation(summary = "관리자 권한 부여", description = "관리자가 관전자에게 권한을 부여")
-    @Parameters(value = {
-            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
-            @Parameter(name = "participantId", description = "해당 채널 참가자의 고유 Id", example = "1")
-    })
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "관리자 권한 부여 성공"),
-            @ApiResponse(responseCode = "404", description = "채널 참가자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @PostMapping("/{channelLink}/{participantId}/host")
-    public ResponseEntity updateHostParticipant(@PathVariable("channelLink") String channelLink,
-                                                @PathVariable("participantId") Long participantId){
-
-        participantRoleAndPermissionService.updateHostRole(channelLink, participantId);
-
-        return new ResponseEntity<>("update HOST", OK);
     }
 
     @Operation(summary = "채널 참가", description = "채널 링크를 통하여 해당 채널 참가")

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantQueryController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantQueryController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import leaguehub.leaguehubbackend.domain.participant.dto.ResponseStatusPlayerDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ResponseUserGameInfoDto;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantQueryService;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantRoleAndPermissionService;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class ParticipantQueryController {
     private final ParticipantService participantService;
     private final ParticipantQueryService participantQueryService;
     private final SimpMessagingTemplate simpMessagingTemplate;
+    private final ParticipantRoleAndPermissionService participantRoleAndPermissionService;
 
     /*
     * 참가 x인 티어 검색
@@ -110,7 +112,7 @@ public class ParticipantQueryController {
     @GetMapping("/channel/{channelLink}/permission")
     public ResponseEntity checkHost(@PathVariable("channelLink") String channelLink){
 
-        participantService.checkAdminHost(channelLink);
+        participantRoleAndPermissionService.checkAdminHost(channelLink);
 
         return new ResponseEntity<>("Admin Check", OK);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantQueryController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantQueryController.java
@@ -1,0 +1,117 @@
+package leaguehub.leaguehubbackend.domain.participant.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import leaguehub.leaguehubbackend.domain.participant.dto.ResponseStatusPlayerDto;
+import leaguehub.leaguehubbackend.domain.participant.dto.ResponseUserGameInfoDto;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
+import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Tag(name = "Participants-Query-Controller", description = "참가자 조회 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ParticipantQueryController {
+
+    private final ParticipantService participantService;
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    /*
+    * 참가 x인 티어 검색
+    * 롤토체스 경기에 참가 요청
+    *
+     */
+
+    @Operation(summary = "티어 검색 (참가 x)", description = "검색 버튼을 누르면 해당 카테고리와 게임 닉네임을 가지고 티어 검색 (참가 x)")
+    @Parameters(value = {
+            @Parameter(name = "gameid", description = "해당 게임 닉네임", example = "칸영기"),
+            @Parameter(name = "gamecategory", description = "게임 종류 (tft, lol, ...)", example = "0, 1, 2")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseUserGameInfoDto.class))),
+            @ApiResponse(responseCode = "404", description = "게임 ID를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/participant/stat/{gameId}/{gameTag}")
+    public ResponseEntity getTFTRanked(@PathVariable("gameId") String gameId, @PathVariable("gameTag") String gameTag){
+
+        ResponseUserGameInfoDto userDetailDto = participantService.selectGameCategory(gameId + "#" + gameTag, 0);
+
+        return new ResponseEntity<>(userDetailDto, OK);
+    }
+
+
+    @Operation(summary = "게임 참가자(Player) 조회 ", description = "채널 내 게임 참가자(Player) 모두 조회")
+    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "참가자 검색 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseStatusPlayerDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 채널을 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/{channelLink}/players")
+    public ResponseEntity getPlayers(@PathVariable("channelLink") String channelLink){
+
+        List<ResponseStatusPlayerDto> players = participantService.loadPlayers(channelLink);
+
+        return new ResponseEntity<>(players, OK);
+    }
+
+    @Operation(summary = "게임 참가요청자(Request) 조회 ", description = "채널 내 게임 참가요청자(Request) 모두 조회")
+    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청자 검색 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseStatusPlayerDto.class))),
+            @ApiResponse(responseCode = "400", description = "해당 채널의 관리자가 아닙니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/{channelLink}/player/requests")
+    public ResponseEntity getRequestPlayers(@PathVariable("channelLink") String channelLink){
+
+        List<ResponseStatusPlayerDto> responsePlayers = participantService.loadRequestStatusPlayerList(channelLink);
+
+        return new ResponseEntity<>(responsePlayers, OK);
+    }
+
+    @Operation(summary = "채널 관전자(Observer) 조회 ", description = "채널 내 게임 관전자(Observer) 모두 조회")
+    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "관전자 검색 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseStatusPlayerDto.class))),
+            @ApiResponse(responseCode = "400", description = "해당 채널의 관리자가 아닙니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/{channelLink}/observers")
+    public ResponseEntity getObserverPlayer(@PathVariable("channelLink") String channelLink){
+
+        List<ResponseStatusPlayerDto> responsePlayers = participantService.loadObserverPlayerList(channelLink);
+
+        return new ResponseEntity<>(responsePlayers, OK);
+    }
+
+    @Operation(summary = "관리자 권한 확인", description = "관리자인지 확인하는 기능")
+    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Admin Check"),
+            @ApiResponse(responseCode = "401", description = "해당 권한이 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/channel/{channelLink}/permission")
+    public ResponseEntity checkHost(@PathVariable("channelLink") String channelLink){
+
+        participantService.checkAdminHost(channelLink);
+
+        return new ResponseEntity<>("Admin Check", OK);
+    }
+
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantQueryController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantQueryController.java
@@ -11,12 +11,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import leaguehub.leaguehubbackend.domain.participant.dto.ResponseStatusPlayerDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ResponseUserGameInfoDto;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantQueryService;
-import leaguehub.leaguehubbackend.domain.participant.service.ParticipantRoleAndPermissionService;
-import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,16 +29,8 @@ import static org.springframework.http.HttpStatus.OK;
 @RequestMapping("/api")
 public class ParticipantQueryController {
 
-    private final ParticipantService participantService;
     private final ParticipantQueryService participantQueryService;
-    private final SimpMessagingTemplate simpMessagingTemplate;
-    private final ParticipantRoleAndPermissionService participantRoleAndPermissionService;
 
-    /*
-    * 참가 x인 티어 검색
-    * 롤토체스 경기에 참가 요청
-    *
-     */
 
     @Operation(summary = "티어 검색 (참가 x)", description = "검색 버튼을 누르면 해당 카테고리와 게임 닉네임을 가지고 티어 검색 (참가 x)")
     @Parameters(value = {
@@ -103,19 +92,7 @@ public class ParticipantQueryController {
         return new ResponseEntity<>(responsePlayers, OK);
     }
 
-    @Operation(summary = "관리자 권한 확인", description = "관리자인지 확인하는 기능")
-    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Admin Check"),
-            @ApiResponse(responseCode = "401", description = "해당 권한이 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @GetMapping("/channel/{channelLink}/permission")
-    public ResponseEntity checkHost(@PathVariable("channelLink") String channelLink){
 
-        participantRoleAndPermissionService.checkAdminHost(channelLink);
-
-        return new ResponseEntity<>("Admin Check", OK);
-    }
 
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantQueryController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantQueryController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import leaguehub.leaguehubbackend.domain.participant.dto.ResponseStatusPlayerDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ResponseUserGameInfoDto;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantQueryService;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ import static org.springframework.http.HttpStatus.OK;
 public class ParticipantQueryController {
 
     private final ParticipantService participantService;
+    private final ParticipantQueryService participantQueryService;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
     /*
@@ -51,7 +53,7 @@ public class ParticipantQueryController {
     @GetMapping("/participant/stat/{gameId}/{gameTag}")
     public ResponseEntity getTFTRanked(@PathVariable("gameId") String gameId, @PathVariable("gameTag") String gameTag){
 
-        ResponseUserGameInfoDto userDetailDto = participantService.selectGameCategory(gameId + "#" + gameTag, 0);
+        ResponseUserGameInfoDto userDetailDto = participantQueryService.selectGameCategory(gameId + "#" + gameTag, 0);
 
         return new ResponseEntity<>(userDetailDto, OK);
     }
@@ -66,7 +68,7 @@ public class ParticipantQueryController {
     @GetMapping("/{channelLink}/players")
     public ResponseEntity getPlayers(@PathVariable("channelLink") String channelLink){
 
-        List<ResponseStatusPlayerDto> players = participantService.loadPlayers(channelLink);
+        List<ResponseStatusPlayerDto> players = participantQueryService.loadPlayers(channelLink);
 
         return new ResponseEntity<>(players, OK);
     }
@@ -80,7 +82,7 @@ public class ParticipantQueryController {
     @GetMapping("/{channelLink}/player/requests")
     public ResponseEntity getRequestPlayers(@PathVariable("channelLink") String channelLink){
 
-        List<ResponseStatusPlayerDto> responsePlayers = participantService.loadRequestStatusPlayerList(channelLink);
+        List<ResponseStatusPlayerDto> responsePlayers = participantQueryService.loadRequestStatusPlayerList(channelLink);
 
         return new ResponseEntity<>(responsePlayers, OK);
     }
@@ -94,7 +96,7 @@ public class ParticipantQueryController {
     @GetMapping("/{channelLink}/observers")
     public ResponseEntity getObserverPlayer(@PathVariable("channelLink") String channelLink){
 
-        List<ResponseStatusPlayerDto> responsePlayers = participantService.loadObserverPlayerList(channelLink);
+        List<ResponseStatusPlayerDto> responsePlayers = participantQueryService.loadObserverPlayerList(channelLink);
 
         return new ResponseEntity<>(responsePlayers, OK);
     }

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantRoleAndPermissionController.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/controller/ParticipantRoleAndPermissionController.java
@@ -1,0 +1,97 @@
+package leaguehub.leaguehubbackend.domain.participant.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantRoleAndPermissionService;
+import leaguehub.leaguehubbackend.global.exception.global.ExceptionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Tag(name = "Participants-RoleAndPermission-Controller", description = "참가자 역할 및 권한 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ParticipantRoleAndPermissionController {
+
+
+    private final ParticipantRoleAndPermissionService participantRoleAndPermissionService;
+
+
+    @Operation(summary = "참가요청 승인", description = "관리자가 해당 게임 참가요청자(request)를 승인")
+    @Parameters(value = {
+            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
+            @Parameter(name = "participantId", description = "해당 채널 참가자의 고유 Id", example = "1")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "승인 성공"),
+            @ApiResponse(responseCode = "404", description = "채널 참가자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/{channelLink}/{participantId}/player")
+    public ResponseEntity approveParticipantRequest(@PathVariable("channelLink") String channelLink,
+                                                    @PathVariable("participantId") Long participantId){
+
+        participantRoleAndPermissionService.approveParticipantRequest(channelLink, participantId);
+
+        return new ResponseEntity<>("approve participant", OK);
+    }
+
+
+    @Operation(summary = "참가요청 거절", description = "관리자가 해당 게임 참가요청자(request)를 거절")
+    @Parameters(value = {
+            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
+            @Parameter(name = "participantId", description = "해당 채널 참가자의 고유 Id", example = "1")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "거절 성공"),
+            @ApiResponse(responseCode = "404", description = "채널 참가자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/{channelLink}/{participantId}/observer")
+    public ResponseEntity rejectParticipantRequest(@PathVariable("channelLink") String channelLink,
+                                                   @PathVariable("participantId") Long participantId){
+
+        participantRoleAndPermissionService.rejectedParticipantRequest(channelLink, participantId);
+
+        return new ResponseEntity<>("reject participant", OK);
+    }
+
+    @Operation(summary = "관리자 권한 부여", description = "관리자가 관전자에게 권한을 부여")
+    @Parameters(value = {
+            @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88"),
+            @Parameter(name = "participantId", description = "해당 채널 참가자의 고유 Id", example = "1")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "관리자 권한 부여 성공"),
+            @ApiResponse(responseCode = "404", description = "채널 참가자를 찾을 수 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/{channelLink}/{participantId}/host")
+    public ResponseEntity updateHostParticipant(@PathVariable("channelLink") String channelLink,
+                                                @PathVariable("participantId") Long participantId){
+
+        participantRoleAndPermissionService.updateHostRole(channelLink, participantId);
+
+        return new ResponseEntity<>("update HOST", OK);
+    }
+
+    @Operation(summary = "관리자 권한 확인", description = "관리자인지 확인하는 기능")
+    @Parameter(name = "channelLink", description = "해당 채널의 링크", example = "42aa1b11ab88")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Admin Check"),
+            @ApiResponse(responseCode = "401", description = "해당 권한이 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @GetMapping("/channel/{channelLink}/permission")
+    public ResponseEntity checkHost(@PathVariable("channelLink") String channelLink){
+
+        participantRoleAndPermissionService.checkAdminHost(channelLink);
+
+        return new ResponseEntity<>("Admin Check", OK);
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantManagementService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantManagementService.java
@@ -1,0 +1,292 @@
+package leaguehub.leaguehubbackend.domain.participant.service;
+
+import leaguehub.leaguehubbackend.domain.channel.dto.ParticipantChannelDto;
+import leaguehub.leaguehubbackend.domain.channel.entity.Channel;
+import leaguehub.leaguehubbackend.domain.channel.entity.ChannelRule;
+import leaguehub.leaguehubbackend.domain.channel.repository.ChannelRuleRepository;
+import leaguehub.leaguehubbackend.domain.channel.service.ChannelService;
+import leaguehub.leaguehubbackend.domain.match.entity.MatchPlayerResultStatus;
+import leaguehub.leaguehubbackend.domain.match.entity.PlayerStatus;
+import leaguehub.leaguehubbackend.domain.match.repository.MatchPlayerRepository;
+import leaguehub.leaguehubbackend.domain.member.entity.Member;
+import leaguehub.leaguehubbackend.domain.member.exception.auth.exception.AuthInvalidTokenException;
+import leaguehub.leaguehubbackend.domain.member.repository.MemberRepository;
+import leaguehub.leaguehubbackend.domain.member.service.JwtService;
+import leaguehub.leaguehubbackend.domain.member.service.MemberService;
+import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantDto;
+import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdDto;
+import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantIdResponseDto;
+import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantSummonerDetail;
+import leaguehub.leaguehubbackend.domain.participant.entity.GameTier;
+import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
+import leaguehub.leaguehubbackend.domain.participant.exception.exception.*;
+import leaguehub.leaguehubbackend.domain.participant.repository.ParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static leaguehub.leaguehubbackend.domain.match.entity.PlayerStatus.DISQUALIFICATION;
+import static leaguehub.leaguehubbackend.domain.participant.entity.RequestStatus.*;
+import static leaguehub.leaguehubbackend.domain.participant.entity.Role.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ParticipantManagementService {
+
+    private final MemberService memberService;
+    private final ChannelService channelService;
+    private final ParticipantRepository participantRepository;
+    private final MemberRepository memberRepository;
+    private final MatchPlayerRepository matchPlayerRepository;
+    private final ChannelRuleRepository channelRuleRepository;
+    private final ParticipantService participantService;
+    private final JwtService jwtService;
+    private final ParticipantWebClientService participantWebClientService;
+    private final ParticipantRuleValidationService participantRuleValidationService;
+
+    /**
+     * 사용자가 지정한 Channel을 참가
+     *
+     * @param channelLink
+     * @return Participant participant
+     */
+    public ParticipantChannelDto participateChannel(String channelLink) {
+
+        Member member = memberService.findCurrentMember();
+
+        Channel channel = channelService.getChannel(channelLink);
+
+        duplicateParticipant(member, channelLink);
+
+        Participant participant = Participant.participateChannel(member, channel);
+        participant.newCustomChannelIndex(participantRepository.findMaxIndexByParticipant(member.getId()));
+        participantRepository.save(participant);
+
+        return new ParticipantChannelDto(
+                channel.getId(),
+                channel.getChannelLink(),
+                channel.getTitle(),
+                channel.getGameCategory().getNum(),
+                channel.getChannelImageUrl(),
+                participant.getIndex()
+        );
+    }
+
+    /**
+     * 해당 채널 나가기
+     *
+     * @param channelLink
+     */
+    public void leaveChannel(String channelLink) {
+        Member member = memberService.findCurrentMember();
+
+        Participant participant = participantService.getParticipant(channelLink, member);
+
+        participantRepository.deleteById(participant.getId());
+
+        List<Participant> participantAfterDelete = participantRepository.findAllByMemberIdAndAndIndexGreaterThan(
+                member.getId(), participant.getIndex());
+
+        for (Participant allParticipantByMember : participantAfterDelete) {
+            allParticipantByMember.updateCustomChannelIndex(allParticipantByMember.getIndex() - 1);
+        }
+    }
+
+
+    /**
+     * 대회 참가자 실격 & 기권 서비스
+     *
+     * @param channelLink
+     * @param message
+     * @return
+     */
+    public ParticipantIdResponseDto disqualifiedParticipant(String channelLink, ParticipantIdDto message) {
+        if (message.getRole() == HOST.getNum()) {
+            return disqualifiedToHost(channelLink, message);
+        }
+
+        if (message.getRole() == PLAYER.getNum()) {
+            return selfDisqualified(channelLink, message);
+        }
+
+        throw new InvalidParticipantAuthException();
+    }
+
+
+//    participateMatch
+
+    /**
+     * 관전자인 사용자가 해당 채널의 경기에 참가
+     *
+     * @param responseDto
+     */
+    public void participateMatch(ParticipantDto responseDto, String channelLink) {
+        Participant participant = participantService.getParticipant(channelLink);
+
+        checkParticipateMatch(participant);
+
+        ChannelRule channelRule = channelRuleRepository
+                .findChannelRuleByChannel_ChannelLink(channelLink);
+
+        checkDuplicateNickname(responseDto.getGameId(), channelLink);
+
+        ParticipantSummonerDetail participantSummonerDetail = participantWebClientService.requestUserGameInfo(responseDto.getGameId());
+        String userGameInfo = participantSummonerDetail.getUserGameInfo();
+        String puuid = participantSummonerDetail.getPuuid();
+
+        GameTier tier = participantWebClientService.searchTier(userGameInfo);
+
+        checkRule(channelRule, userGameInfo, tier);
+
+        participant.updateParticipantStatus(responseDto.getGameId(), tier.toString(), responseDto.getNickname(), puuid);
+    }
+
+
+    /**
+     * 참가자 중복검사
+     *
+     * @param member
+     * @param channelLink
+     */
+    private void duplicateParticipant(Member member, String channelLink) {
+        Optional<Participant> existingParticipant = participantRepository.findParticipantByMemberIdAndChannel_ChannelLink(member.getId(), channelLink);
+
+        if (existingParticipant.isPresent()) {
+            throw new ParticipantDuplicatedGameIdException();
+        }
+    }
+
+
+    /**
+     * 관리자가 직접 참가자 실격시키는 메서드
+     *
+     * @param channelLink
+     * @param message
+     * @return
+     */
+    private ParticipantIdResponseDto disqualifiedToHost(String channelLink, ParticipantIdDto message) {
+        Participant myParticipant = findParticipantAccessToken(channelLink, message.getAccessToken());
+        participantService.checkRole(myParticipant.getRole(), HOST);
+
+        Participant findParticipant = participantService.getFindParticipant(channelLink, message.getParticipantId());
+
+        disqualificationParticipant(findParticipant);
+
+        return new ParticipantIdResponseDto(message.getMatchPlayerId(), DISQUALIFICATION.getStatus());
+    }
+
+
+    /**
+     * 참가자가 직접 기권하는 메서드
+     *
+     * @param channelLink
+     * @param message
+     * @return
+     */
+    private ParticipantIdResponseDto selfDisqualified(String channelLink, ParticipantIdDto message) {
+        Participant myParticipant = findParticipantAccessToken(channelLink, message.getAccessToken());
+        participantService.checkRole(myParticipant.getRole(), PLAYER);
+
+        disqualificationParticipant(myParticipant);
+
+        return new ParticipantIdResponseDto(message.getMatchPlayerId(), DISQUALIFICATION.getStatus());
+    }
+
+
+    /**
+     * 상태를 실격으로 변경시키는 메서드
+     *
+     * @param findParticipant
+     */
+    private void disqualificationParticipant(Participant findParticipant) {
+        findParticipant.disqualificationParticipant();
+        matchPlayerRepository.findMatchPlayersByParticipantId(findParticipant.getId())
+                .forEach(matchPlayer -> {
+                            matchPlayer.updatePlayerCheckInStatus(PlayerStatus.DISQUALIFICATION);
+                            matchPlayer.updateMatchPlayerResultStatus(MatchPlayerResultStatus.DISQUALIFICATION);
+                            matchPlayer.updateMatchPlayerScoreDisqualified();
+                        }
+                );
+    }
+
+    /**
+     * AccessToken을 찾는 메서드
+     *
+     * @param channelLink
+     * @param accessToken
+     * @return
+     */
+    private Participant findParticipantAccessToken(String channelLink, String accessToken) {
+        String personalId = jwtService.extractPersonalId(accessToken)
+                .orElseThrow(() -> new AuthInvalidTokenException());
+        Member member = memberRepository.findMemberByPersonalId(personalId).get();
+        Participant myParticipant = participantService.getParticipant(channelLink, member);
+        return myParticipant;
+    }
+
+    /**
+     * 채널에 이미 참가되어 있는지 확인하는 메서드
+     *
+     * @param participant
+     */
+    private void checkParticipateMatch(Participant participant) {
+
+        if (participant.getRole() != OBSERVER
+                || participant.getRequestStatus() == DONE) throw new ParticipantInvalidRoleException();
+
+        if (participant.getRequestStatus() == REQUEST) throw new ParticipantAlreadyRequestedException();
+
+        if (participant.getRequestStatus() == REJECT) throw new ParticipantRejectedRequestedException();
+
+    }
+
+    private void checkDuplicateNickname(String gameId, String channelLink) {
+        List<Participant> participantList = participantRepository.findAllByChannel_ChannelLink(channelLink);
+
+        boolean checkDuplicate = participantList.stream()
+                .anyMatch(participant -> participant.getGameId().equals(gameId));
+
+        if (checkDuplicate) {
+            throw new ParticipantDuplicatedGameIdException();
+        }
+    }
+
+    /**
+     * 해당 채널의 룰을 확인
+     *
+     * @param channelRule
+     * @param userGameInfo
+     * @param tier
+     */
+    private void checkRule(ChannelRule channelRule, String userGameInfo, GameTier tier) {
+
+        rankRuleCheck(channelRule, tier);
+        playCountRuleCheck(channelRule, userGameInfo);
+    }
+
+    private static void rankRuleCheck(ChannelRule channelRule, GameTier tier) {
+
+        if (channelRule.getTier()) {
+            int tierMax = channelRule.getTierMax();
+            int tierMin = channelRule.getTierMin();
+
+            int userRankScore = tier.getScore();
+            if (userRankScore > tierMax || userRankScore < tierMin) throw new ParticipantInvalidRankException();
+        }
+    }
+
+    private void playCountRuleCheck(ChannelRule channelRule, String userGameInfo) {
+
+        if (channelRule.getPlayCount()) {
+            int limitedPlayCount = channelRule.getLimitedPlayCount();
+            int userPlayCount = participantWebClientService.getPlayCount(userGameInfo);
+            if (userPlayCount < limitedPlayCount)
+                throw new ParticipantInvalidPlayCountException();
+        }
+    }
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantQueryService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantQueryService.java
@@ -1,0 +1,151 @@
+package leaguehub.leaguehubbackend.domain.participant.service;
+
+import leaguehub.leaguehubbackend.domain.member.entity.Member;
+import leaguehub.leaguehubbackend.domain.member.service.MemberService;
+import leaguehub.leaguehubbackend.domain.participant.dto.ResponseStatusPlayerDto;
+import leaguehub.leaguehubbackend.domain.participant.dto.ResponseUserGameInfoDto;
+import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
+import leaguehub.leaguehubbackend.domain.participant.repository.ParticipantRepository;
+import leaguehub.leaguehubbackend.global.util.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static leaguehub.leaguehubbackend.domain.member.entity.BaseRole.USER;
+import static leaguehub.leaguehubbackend.domain.participant.entity.RequestStatus.*;
+import static leaguehub.leaguehubbackend.domain.participant.entity.Role.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ParticipantQueryService {
+
+
+    private final MemberService memberService;
+    private final ParticipantRepository participantRepository;
+    private final ParticipantService participantService;
+    private final ParticipantWebClientService participantWebClientService;
+
+
+    /**
+     * 참여자의 권한 확인 메소드
+     *
+     * @param channelLink
+     * @return
+     */
+    public int findParticipantPermission(String channelLink) {
+        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
+        if (userDetails == null) return OBSERVER.getNum();
+        Member member = memberService.validateMember(userDetails.getUsername());
+
+
+        Optional<Participant> findParticipant = participantRepository.findParticipantByMemberIdAndChannel_ChannelLink(member.getId(), channelLink);
+
+        return findParticipant.map(participant -> participant.getRole().getNum())
+                .orElse(OBSERVER.getNum());
+    }
+
+
+    /**
+     * 해당 채널의 첫 번째 관리자 반환 메소드
+     *
+     * @param channelLink
+     * @return
+     */
+    public String findChannelHost(String channelLink) {
+        return participantRepository.findParticipantByRoleAndChannel_ChannelLinkOrderById(HOST, channelLink).get(0).getNickname();
+    }
+
+
+    /**
+     * 해당 채널의 관전자인 유저들을 조회
+     *
+     * @param channelLink
+     * @return
+     */
+    public List<ResponseStatusPlayerDto> loadObserverPlayerList(String channelLink) {
+        Participant findParticipant = participantService.getParticipant(channelLink);
+
+        participantService.checkRole(findParticipant.getRole(), HOST);
+
+        List<Participant> findParticipants = participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, OBSERVER, NO_REQUEST);
+
+        return findParticipants.stream()
+                .filter(participant -> participant.getMember().getBaseRole() == USER)
+                .map(participant -> mapToResponseStatusPlayerDto(participant))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 요청을 보낸 사람들을 조회
+     *
+     * @param channelLink
+     * @return
+     */
+    public List<ResponseStatusPlayerDto> loadRequestStatusPlayerList(String channelLink) {
+        Participant findParticipant = participantService.getParticipant(channelLink);
+        participantService.checkRole(findParticipant.getRole(), HOST);
+
+        List<Participant> findParticipants =
+                participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc
+                        (channelLink, OBSERVER, REQUEST);
+
+        return findParticipants.stream()
+                .map(participant -> mapToResponseStatusPlayerDto(participant))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 해당 채널의 PLAYER 역할인 유저들을 반환
+     *
+     * @param channelLink
+     * @return RequestPlayerDtoList
+     */
+    public List<ResponseStatusPlayerDto> loadPlayers(String channelLink) {
+
+        return participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc
+                        (channelLink, PLAYER, DONE)
+                .stream()
+                .map(participant -> mapToResponseStatusPlayerDto(participant))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 게임 카테고리에 따라 요청 분할
+     *
+     * @param gameId
+     * @param category
+     * @return
+     */
+    public ResponseUserGameInfoDto selectGameCategory(String gameId, Integer category) {
+        ResponseUserGameInfoDto userGameInfoDto = new ResponseUserGameInfoDto();
+
+        if (category.equals(0)) {
+            userGameInfoDto = participantWebClientService.getTierAndPlayCount(gameId);
+        }
+
+        return userGameInfoDto;
+    }
+
+    /**
+     * 쿼리 컨트롤러에 반환할 DTO 정제하는 서비스
+     *
+     * @param participant
+     * @return
+     */
+    private ResponseStatusPlayerDto mapToResponseStatusPlayerDto(Participant participant) {
+        ResponseStatusPlayerDto responsePlayerDto = new ResponseStatusPlayerDto();
+        responsePlayerDto.setPk(participant.getId());
+        responsePlayerDto.setNickname(participant.getNickname());
+        responsePlayerDto.setImgSrc(participant.getProfileImageUrl());
+        responsePlayerDto.setGameId(participant.getGameId());
+        responsePlayerDto.setTier(participant.getGameTier());
+        return responsePlayerDto;
+    }
+}

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantQueryService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantQueryService.java
@@ -8,7 +8,6 @@ import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
 import leaguehub.leaguehubbackend.domain.participant.repository.ParticipantRepository;
 import leaguehub.leaguehubbackend.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantRoleAndPermissionService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantRoleAndPermissionService.java
@@ -1,0 +1,129 @@
+package leaguehub.leaguehubbackend.domain.participant.service;
+
+
+import leaguehub.leaguehubbackend.domain.channel.entity.Channel;
+import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
+import leaguehub.leaguehubbackend.domain.participant.exception.exception.InvalidParticipantAuthException;
+import leaguehub.leaguehubbackend.domain.participant.exception.exception.ParticipantRealPlayerIsMaxException;
+import leaguehub.leaguehubbackend.domain.participant.repository.ParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static leaguehub.leaguehubbackend.domain.member.entity.BaseRole.GUEST;
+import static leaguehub.leaguehubbackend.domain.participant.entity.RequestStatus.DONE;
+import static leaguehub.leaguehubbackend.domain.participant.entity.Role.HOST;
+import static leaguehub.leaguehubbackend.domain.participant.entity.Role.PLAYER;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ParticipantRoleAndPermissionService {
+
+
+    private final ParticipantService participantService;
+    private final ParticipantRepository participantRepository;
+
+    /**
+     * 해당 채널의 요청한 참가자를 승인해줌
+     *
+     * @param channelLink
+     * @param participantId
+     */
+    public void approveParticipantRequest(String channelLink, Long participantId) {
+        Participant participant = participantService.getParticipant(channelLink);
+        participantService.checkRole(participant.getRole(), HOST);
+
+        checkRealPlayerCount(participant.getChannel());
+
+        Participant findParticipant = participantService.getFindParticipant(channelLink, participantId);
+
+        findParticipant.approveParticipantMatch();
+
+        updateRealPlayerCount(channelLink, participant.getChannel());
+    }
+
+
+    /**
+     * 해당 채널의 요청한 참가자를 거절함
+     *
+     * @param channelLink
+     * @param participantId
+     */
+    public void rejectedParticipantRequest(String channelLink, Long participantId) {
+        Participant participant = participantService.getParticipant(channelLink);
+        participantService.checkRole(participant.getRole(), HOST);
+
+
+        Participant findParticipant = participantService.getFindParticipant(channelLink, participantId);
+
+        findParticipant.rejectParticipantRequest();
+
+        updateRealPlayerCount(channelLink, participant.getChannel());
+    }
+
+
+    /**
+     * 사용자를 관리자로 권한을 변경한다.
+     *
+     * @param channelLink
+     * @param participantId
+     */
+    public void updateHostRole(String channelLink, Long participantId) {
+        Participant findParticipant = checkHostAndGetParticipant(channelLink, participantId);
+        if (findParticipant.getMember().getBaseRole() == GUEST)
+            throw new InvalidParticipantAuthException();
+
+        findParticipant.updateHostRole();
+    }
+
+
+    /**
+     * 해당 사용자가 호스트인지 확인
+     * @param channelLink
+     */
+    public void checkAdminHost(String channelLink) {
+        Participant participant = participantService.getParticipant(channelLink);
+        participantService.checkRole(participant.getRole(), HOST);
+    }
+
+
+
+    /**
+     * 해당 채널의 경기 참여자 횟수 체크
+     * @param channel
+     */
+    private void checkRealPlayerCount(Channel channel) {
+        if (channel.getRealPlayer() >= channel.getMaxPlayer())
+            throw new ParticipantRealPlayerIsMaxException();
+    }
+
+
+    /**
+     * 참여된 참가자 수 업데이트
+     * @param channelLink
+     * @param channel
+     */
+    private void updateRealPlayerCount(String channelLink, Channel channel) {
+        List<Participant> playerLists = participantRepository
+                .findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, PLAYER, DONE);
+
+        channel.updateRealPlayer(playerLists.size());
+    }
+
+    /**
+     * 호스트 확인 및 그 사용자를 반환하는 메서드
+     * @param channelLink
+     * @param participantId
+     * @return
+     */
+    private Participant checkHostAndGetParticipant(String channelLink, Long participantId) {
+        Participant participant = participantService.getParticipant(channelLink);
+        participantService.checkRole(participant.getRole(), HOST);
+
+        return participantService.getFindParticipant(channelLink, participantId);
+    }
+
+}

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantService.java
@@ -2,43 +2,29 @@ package leaguehub.leaguehubbackend.domain.participant.service;
 
 import leaguehub.leaguehubbackend.domain.channel.dto.ParticipantChannelDto;
 import leaguehub.leaguehubbackend.domain.channel.entity.Channel;
-import leaguehub.leaguehubbackend.domain.channel.entity.ChannelRule;
-import leaguehub.leaguehubbackend.domain.channel.repository.ChannelRuleRepository;
 import leaguehub.leaguehubbackend.domain.channel.service.ChannelService;
 import leaguehub.leaguehubbackend.domain.email.exception.exception.UnauthorizedEmailException;
-import leaguehub.leaguehubbackend.domain.match.entity.MatchPlayerResultStatus;
-import leaguehub.leaguehubbackend.domain.match.entity.PlayerStatus;
-import leaguehub.leaguehubbackend.domain.match.repository.MatchPlayerRepository;
 import leaguehub.leaguehubbackend.domain.member.entity.BaseRole;
 import leaguehub.leaguehubbackend.domain.member.entity.Member;
-import leaguehub.leaguehubbackend.domain.member.exception.auth.exception.AuthInvalidTokenException;
-import leaguehub.leaguehubbackend.domain.member.repository.MemberRepository;
-import leaguehub.leaguehubbackend.domain.member.service.JwtService;
 import leaguehub.leaguehubbackend.domain.member.service.MemberService;
-import leaguehub.leaguehubbackend.domain.participant.dto.*;
-import leaguehub.leaguehubbackend.domain.participant.entity.GameTier;
 import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
 import leaguehub.leaguehubbackend.domain.participant.entity.Role;
-import leaguehub.leaguehubbackend.domain.participant.exception.exception.*;
+import leaguehub.leaguehubbackend.domain.participant.exception.exception.InvalidParticipantAuthException;
+import leaguehub.leaguehubbackend.domain.participant.exception.exception.ParticipantNotFoundException;
+import leaguehub.leaguehubbackend.domain.participant.exception.exception.ParticipantRealPlayerIsMaxException;
 import leaguehub.leaguehubbackend.domain.participant.repository.ParticipantRepository;
-import leaguehub.leaguehubbackend.global.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
-import org.json.simple.parser.JSONParser;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
-import static leaguehub.leaguehubbackend.domain.match.entity.PlayerStatus.DISQUALIFICATION;
 import static leaguehub.leaguehubbackend.domain.member.entity.BaseRole.GUEST;
 import static leaguehub.leaguehubbackend.domain.member.entity.BaseRole.USER;
-import static leaguehub.leaguehubbackend.domain.participant.entity.RequestStatus.*;
-import static leaguehub.leaguehubbackend.domain.participant.entity.Role.*;
+import static leaguehub.leaguehubbackend.domain.participant.entity.RequestStatus.DONE;
+import static leaguehub.leaguehubbackend.domain.participant.entity.Role.HOST;
+import static leaguehub.leaguehubbackend.domain.participant.entity.Role.PLAYER;
 
 
 @Service
@@ -48,97 +34,9 @@ public class ParticipantService {
 
     private final ParticipantRepository participantRepository;
     private final MemberService memberService;
-    private final WebClient webClient;
-    private final JSONParser jsonParser;
     private final ChannelService channelService;
     @Value("${riot-api-key-1}")
     private String riot_api_key;
-    private final ChannelRuleRepository channelRuleRepository;
-    private final MatchPlayerRepository matchPlayerRepository;
-    private final JwtService jwtService;
-    private final MemberRepository memberRepository;
-
-    private final ParticipantWebClientService participantWebClientService;
-
-
-    //참여자의 권한 확인하는 서비스 - > 쿼리(조회해서 그냥 넘겨주기 떄문에)
-    public int findParticipantPermission(String channelLink) {
-        UserDetails userDetails = SecurityUtils.getAuthenticatedUser();
-        if (userDetails == null) return OBSERVER.getNum();
-        Member member = memberService.validateMember(userDetails.getUsername());
-
-
-        Optional<Participant> findParticipant = participantRepository.findParticipantByMemberIdAndChannel_ChannelLink(member.getId(), channelLink);
-
-        return findParticipant.map(participant -> participant.getRole().getNum())
-                .orElse(OBSERVER.getNum());
-    }
-
-    //해당 채널의 첫 번째 관리자를 찾는 서비스 - 쿼리
-    public String findChannelHost(String channelLink) {
-        return participantRepository.findParticipantByRoleAndChannel_ChannelLinkOrderById(HOST, channelLink).get(0).getNickname();
-    }
-
-
-    //채널 유저 조회 서비스  -> 쿼리
-
-    /**
-     * 해당 채널의 관전자인 유저들을 조회
-     *
-     * @param channelLink
-     * @return
-     */
-    public List<ResponseStatusPlayerDto> loadObserverPlayerList(String channelLink) {
-        Participant findParticipant = getParticipant(channelLink);
-
-        checkRole(findParticipant.getRole(), HOST);
-
-        List<Participant> findParticipants = participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, OBSERVER, NO_REQUEST);
-
-        return findParticipants.stream()
-                .filter(participant -> participant.getMember().getBaseRole() == USER)
-                .map(participant -> mapToResponseStatusPlayerDto(participant))
-                .collect(Collectors.toList());
-    }
-
-    //채널 유저 조회 서비스 --> 쿼리
-
-    /**
-     * 요청을 보낸 사람들을 조회
-     *
-     * @param channelLink
-     * @return
-     */
-    public List<ResponseStatusPlayerDto> loadRequestStatusPlayerList(String channelLink) {
-        Participant findParticipant = getParticipant(channelLink);
-        checkRole(findParticipant.getRole(), HOST);
-
-        List<Participant> findParticipants =
-                participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc
-                        (channelLink, OBSERVER, REQUEST);
-
-        return findParticipants.stream()
-                .map(participant -> mapToResponseStatusPlayerDto(participant))
-                .collect(Collectors.toList());
-    }
-
-    //채널 유저 조회 서비스 -->쿼리
-
-    /**
-     * 해당 채널의 PLAYER 역할인 유저들을 반환
-     *
-     * @param channelLink
-     * @return RequestPlayerDtoList
-     */
-
-    public List<ResponseStatusPlayerDto> loadPlayers(String channelLink) {
-
-        return participantRepository.findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc
-                        (channelLink, PLAYER, DONE)
-                .stream()
-                .map(participant -> mapToResponseStatusPlayerDto(participant))
-                .collect(Collectors.toList());
-    }
 
 
     //관리자가 요청 참가자 승인 서비스 -> 커맨드
@@ -184,40 +82,6 @@ public class ParticipantService {
     }
 
 
-    //관리자가 대회 참가자 실격 서비스 -> 커맨드
-    private ParticipantIdResponseDto disqualifiedToHost(String channelLink, ParticipantIdDto message) {
-        Participant myParticipant = findParticipantAccessToken(channelLink, message.getAccessToken());
-        checkRole(myParticipant.getRole(), HOST);
-
-        Participant findParticipant = getFindParticipant(channelLink, message.getParticipantId());
-
-        disqualificationParticipant(findParticipant);
-
-        return new ParticipantIdResponseDto(message.getMatchPlayerId(), DISQUALIFICATION.getStatus());
-    }
-
-    //대회 참가자가 기권 서비스 -> 커맨드
-    private ParticipantIdResponseDto selfDisqualified(String channelLink, ParticipantIdDto message) {
-        Participant myParticipant = findParticipantAccessToken(channelLink, message.getAccessToken());
-        checkRole(myParticipant.getRole(), PLAYER);
-
-        disqualificationParticipant(myParticipant);
-
-        return new ParticipantIdResponseDto(message.getMatchPlayerId(), DISQUALIFICATION.getStatus());
-    }
-
-    //기권 시키는 서비스 -> 커맨드
-    private void disqualificationParticipant(Participant findParticipant) {
-        findParticipant.disqualificationParticipant();
-        matchPlayerRepository.findMatchPlayersByParticipantId(findParticipant.getId())
-                .forEach(matchPlayer -> {
-                            matchPlayer.updatePlayerCheckInStatus(PlayerStatus.DISQUALIFICATION);
-                            matchPlayer.updateMatchPlayerResultStatus(MatchPlayerResultStatus.DISQUALIFICATION);
-                            matchPlayer.updateMatchPlayerScoreDisqualified();
-                        }
-                );
-    }
-
     //관리자가 관전자를 관리자로 권한 변경 서비스 -> 커맨드
 
     /**
@@ -234,40 +98,11 @@ public class ParticipantService {
         findParticipant.updateHostRole();
     }
 
-    //게임 카테고리에 따른 전적 검색 서비스 -> 쿼리
-
-    /**
-     * 게임 카테고리에 따라 요청 분할
-     *
-     * @param gameId
-     * @param category
-     * @return
-     */
-    public ResponseUserGameInfoDto selectGameCategory(String gameId, Integer category) {
-        ResponseUserGameInfoDto userGameInfoDto = new ResponseUserGameInfoDto();
-
-        if (category.equals(0)) {
-            userGameInfoDto = participantWebClientService.getTierAndPlayCount(gameId);
-        }
-
-        return userGameInfoDto;
-    }
-
 
     //해당 사용자가 호스트인지 확인 -> 커맨드
     public void checkAdminHost(String channelLink) {
         Participant participant = getParticipant(channelLink);
         checkRole(participant.getRole(), HOST);
-    }
-
-
-    //해당 사용자의 AccessToken 확인 서비스 - 커맨드(내부 동작)
-    private Participant findParticipantAccessToken(String channelLink, String accessToken) {
-        String personalId = jwtService.extractPersonalId(accessToken)
-                .orElseThrow(() -> new AuthInvalidTokenException());
-        Member member = memberRepository.findMemberByPersonalId(personalId).get();
-        Participant myParticipant = getParticipant(channelLink, member);
-        return myParticipant;
     }
 
 
@@ -277,8 +112,6 @@ public class ParticipantService {
             throw new ParticipantRealPlayerIsMaxException();
     }
 
-
-    //사용자의 이메일 인증인지 확인 - 내부 동작 여기 남는다
 
     /**
      * 이메일이 인증되었는지 확인
@@ -305,7 +138,6 @@ public class ParticipantService {
         return channelService.findParticipantChannelList();
     }
 
-    //
 
     /**
      * channelLink와 member로 해당 채널에서의 참가자 찾기 -> 쿼리
@@ -320,7 +152,6 @@ public class ParticipantService {
         return participant;
     }
 
-    //제 3자가 채널에서의 참가자 찾기
 
     /**
      * 제 3자가 channelLink와 participantId로 해당 채널에서의 참가자 찾기 --> 쿼리
@@ -352,8 +183,6 @@ public class ParticipantService {
     }
 
 
-    //자기 자신의 id를 가져오는 서비스 -> 내부동작 여기 남는다
-
     /**
      * 자기 자신이 participant를 찾을 때
      *
@@ -371,16 +200,6 @@ public class ParticipantService {
         return participant;
     }
 
-    //쿼리 컨트롤러에 반환할 dto를 정제하는 서비스 -> 쿼리 내부 메소드로 들어간다
-    private ResponseStatusPlayerDto mapToResponseStatusPlayerDto(Participant participant) {
-        ResponseStatusPlayerDto responsePlayerDto = new ResponseStatusPlayerDto();
-        responsePlayerDto.setPk(participant.getId());
-        responsePlayerDto.setNickname(participant.getNickname());
-        responsePlayerDto.setImgSrc(participant.getProfileImageUrl());
-        responsePlayerDto.setGameId(participant.getGameId());
-        responsePlayerDto.setTier(participant.getGameTier());
-        return responsePlayerDto;
-    }
 
     //해당 채널의 Rule이 맞는지 확인 -> 여기에 남는다
     public void checkRole(Role myRole, Role checkRole) {

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantService.java
@@ -1,8 +1,5 @@
 package leaguehub.leaguehubbackend.domain.participant.service;
 
-import leaguehub.leaguehubbackend.domain.channel.dto.ParticipantChannelDto;
-import leaguehub.leaguehubbackend.domain.channel.entity.Channel;
-import leaguehub.leaguehubbackend.domain.channel.service.ChannelService;
 import leaguehub.leaguehubbackend.domain.email.exception.exception.UnauthorizedEmailException;
 import leaguehub.leaguehubbackend.domain.member.entity.BaseRole;
 import leaguehub.leaguehubbackend.domain.member.entity.Member;
@@ -11,20 +8,12 @@ import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
 import leaguehub.leaguehubbackend.domain.participant.entity.Role;
 import leaguehub.leaguehubbackend.domain.participant.exception.exception.InvalidParticipantAuthException;
 import leaguehub.leaguehubbackend.domain.participant.exception.exception.ParticipantNotFoundException;
-import leaguehub.leaguehubbackend.domain.participant.exception.exception.ParticipantRealPlayerIsMaxException;
 import leaguehub.leaguehubbackend.domain.participant.repository.ParticipantRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
-import static leaguehub.leaguehubbackend.domain.member.entity.BaseRole.GUEST;
 import static leaguehub.leaguehubbackend.domain.member.entity.BaseRole.USER;
-import static leaguehub.leaguehubbackend.domain.participant.entity.RequestStatus.DONE;
-import static leaguehub.leaguehubbackend.domain.participant.entity.Role.HOST;
-import static leaguehub.leaguehubbackend.domain.participant.entity.Role.PLAYER;
 
 
 @Service
@@ -34,128 +23,10 @@ public class ParticipantService {
 
     private final ParticipantRepository participantRepository;
     private final MemberService memberService;
-    private final ChannelService channelService;
-    @Value("${riot-api-key-1}")
-    private String riot_api_key;
-
-
-    //관리자가 요청 참가자 승인 서비스 -> 커맨드
-
-    /**
-     * 해당 채널의 요청한 참가자를 승인해줌
-     *
-     * @param channelLink
-     * @param participantId
-     */
-    public void approveParticipantRequest(String channelLink, Long participantId) {
-        Participant participant = getParticipant(channelLink);
-        checkRole(participant.getRole(), HOST);
-
-        checkRealPlayerCount(participant.getChannel());
-
-        Participant findParticipant = getFindParticipant(channelLink, participantId);
-
-        findParticipant.approveParticipantMatch();
-
-        updateRealPlayerCount(channelLink, participant.getChannel());
-    }
-
-
-    //관리자가 요청 참가자 거절 서비스 -> 커맨드
-
-    /**
-     * 해당 채널의 요청한 참가자를 거절함
-     *
-     * @param channelLink
-     * @param participantId
-     */
-    public void rejectedParticipantRequest(String channelLink, Long participantId) {
-        Participant participant = getParticipant(channelLink);
-        checkRole(participant.getRole(), HOST);
-
-
-        Participant findParticipant = getFindParticipant(channelLink, participantId);
-
-        findParticipant.rejectParticipantRequest();
-
-        updateRealPlayerCount(channelLink, participant.getChannel());
-    }
-
-
-    //관리자가 관전자를 관리자로 권한 변경 서비스 -> 커맨드
-
-    /**
-     * 사용자를 관리자로 권한을 변경한다.
-     *
-     * @param channelLink
-     * @param participantId
-     */
-    public void updateHostRole(String channelLink, Long participantId) {
-        Participant findParticipant = checkHostAndGetParticipant(channelLink, participantId);
-        if (findParticipant.getMember().getBaseRole() == GUEST)
-            throw new InvalidParticipantAuthException();
-
-        findParticipant.updateHostRole();
-    }
-
-
-    //해당 사용자가 호스트인지 확인 -> 커맨드
-    public void checkAdminHost(String channelLink) {
-        Participant participant = getParticipant(channelLink);
-        checkRole(participant.getRole(), HOST);
-    }
-
-
-    //해당 채널의 경기 참여자 횟수 체크 - 커맨드
-    private void checkRealPlayerCount(Channel channel) {
-        if (channel.getRealPlayer() >= channel.getMaxPlayer())
-            throw new ParticipantRealPlayerIsMaxException();
-    }
 
 
     /**
-     * 이메일이 인증되었는지 확인
-     *
-     * @param baseRole
-     */
-    public void checkEmail(BaseRole baseRole) {
-        if (baseRole != USER) throw new UnauthorizedEmailException();
-    }
-
-
-    //참여 채널의 순서를 커스텀 - 커맨드
-    public List<ParticipantChannelDto> updateCustomChannelIndex(List<ParticipantChannelDto> participantChannelDtoList) {
-        Member member = memberService.findCurrentMember();
-
-        List<Participant> allByMemberId = participantRepository.findAllByMemberId(member.getId());
-
-        participantChannelDtoList.forEach(participantChannelDto -> {
-            allByMemberId.stream()
-                    .filter(participant -> participant.getChannel().getChannelLink().equals(participantChannelDto.getChannelLink()))
-                    .forEach(participant -> participant.updateCustomChannelIndex(participantChannelDto.getCustomChannelIndex()));
-        });
-
-        return channelService.findParticipantChannelList();
-    }
-
-
-    /**
-     * channelLink와 member로 해당 채널에서의 참가자 찾기 -> 쿼리
-     *
-     * @param channelLink
-     * @param member
-     * @return
-     */
-    public Participant getParticipant(String channelLink, Member member) {
-        Participant participant = participantRepository.findParticipantByMemberIdAndChannel_ChannelLink(member.getId(), channelLink)
-                .orElseThrow(ParticipantNotFoundException::new);
-        return participant;
-    }
-
-
-    /**
-     * 제 3자가 channelLink와 participantId로 해당 채널에서의 참가자 찾기 --> 쿼리
-     *
+     * 제 3자가 channelLink와 participantId로 해당 채널에서의 참가자 찾기
      * @param channelLink
      * @param participantId
      * @return
@@ -166,26 +37,9 @@ public class ParticipantService {
         return findParticipant;
     }
 
-    //현재 채널의 경기 참여자 수 업데이트 -> 커맨드
-    private void updateRealPlayerCount(String channelLink, Channel channel) {
-        List<Participant> playerLists = participantRepository
-                .findAllByChannel_ChannelLinkAndRoleAndRequestStatusOrderByNicknameAsc(channelLink, PLAYER, DONE);
-
-        channel.updateRealPlayer(playerLists.size());
-    }
-
-    //호스트 확인 및 그 사용자를 가져오는 서비스 -> 쿼리
-    private Participant checkHostAndGetParticipant(String channelLink, Long participantId) {
-        Participant participant = getParticipant(channelLink);
-        checkRole(participant.getRole(), HOST);
-
-        return getFindParticipant(channelLink, participantId);
-    }
-
 
     /**
      * 자기 자신이 participant를 찾을 때
-     *
      * @param channelLink
      * @return
      */
@@ -201,11 +55,25 @@ public class ParticipantService {
     }
 
 
-    //해당 채널의 Rule이 맞는지 확인 -> 여기에 남는다
+    /**
+     * 해당 채널의 역할이 맞는지 확인
+     * @param myRole
+     * @param checkRole
+     */
     public void checkRole(Role myRole, Role checkRole) {
         if (myRole != checkRole) {
             throw new InvalidParticipantAuthException();
         }
     }
+
+    /**
+     * 이메일이 인증되었는지 확인
+     *
+     * @param baseRole
+     */
+    private void checkEmail(BaseRole baseRole) {
+        if (baseRole != USER) throw new UnauthorizedEmailException();
+    }
+
 
 }

--- a/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantWebClientService.java
+++ b/src/main/java/leaguehub/leaguehubbackend/domain/participant/service/ParticipantWebClientService.java
@@ -1,0 +1,183 @@
+package leaguehub.leaguehubbackend.domain.participant.service;
+
+import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantSummonerDetail;
+import leaguehub.leaguehubbackend.domain.participant.dto.ResponseUserGameInfoDto;
+import leaguehub.leaguehubbackend.domain.participant.entity.GameTier;
+import leaguehub.leaguehubbackend.domain.participant.exception.exception.ParticipantGameIdNotFoundException;
+import leaguehub.leaguehubbackend.global.exception.global.exception.GlobalServerErrorException;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ParticipantWebClientService {
+
+
+    private final WebClient webClient;
+    private final JSONParser jsonParser;
+
+    @Value("${riot-api-key-1}")
+    private String riot_api_key;
+
+
+    /**
+     * 닉네임 + 태크로 고유 puuid 추출
+     * 받은 nickname으로 split 나누기
+     */
+    public String getSummonerPUuid(String nickname) {
+        String pUuidURL = "https://asia.api.riotgames.com/riot/account/v1/accounts/by-riot-id/";
+
+        String gameId = nickname.split("#")[0];
+        String gameTag = nickname.split("#")[1];
+
+
+        JSONObject userAccount = webClient.get()
+                .uri(pUuidURL + gameId + "/" + gameTag + riot_api_key)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ParticipantGameIdNotFoundException()))
+                .onStatus(HttpStatusCode::is5xxServerError, response -> Mono.error(new GlobalServerErrorException()))
+                .bodyToMono(JSONObject.class)
+                .block();
+
+        return userAccount.get("puuid").toString();
+    }
+
+    /**
+     * 고유 puuid로 유저의 정보 추출
+     *
+     * @param nickname
+     * @return id
+     */
+    public JSONObject getSummonerId(String nickname) {
+        String puuid = getSummonerPUuid(nickname);
+
+        String summonerUrl = "https://kr.api.riotgames.com/tft/summoner/v1/summoners/by-puuid/";
+
+        return webClient.get()
+                .uri(summonerUrl + puuid + riot_api_key)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> Mono.error(new ParticipantGameIdNotFoundException()))
+                .onStatus(HttpStatusCode::is5xxServerError, response -> Mono.error(new GlobalServerErrorException()))
+                .bodyToMono(JSONObject.class)
+                .block();
+    }
+
+    /**
+     * 외부 api호출로 유저 상세정보 출력
+     *
+     * @param nickname
+     * @return
+     */
+    public ParticipantSummonerDetail requestUserGameInfo(String nickname) {
+
+        JSONObject summonerDetail = getSummonerId(nickname);
+
+        String gameId = summonerDetail.get("id").toString();
+        String puuid = summonerDetail.get("puuid").toString();
+
+        String tierUrl = "https://kr.api.riotgames.com/tft/league/v1/entries/by-summoner/";
+
+
+        JSONArray summonerDetails = webClient.get()
+                .uri(tierUrl + gameId + riot_api_key)
+                .retrieve()
+                .bodyToMono(JSONArray.class)
+                .block();
+
+        String arraytoString = summonerDetails.toJSONString();
+
+        ParticipantSummonerDetail participantSummonerDetail = new ParticipantSummonerDetail();
+        participantSummonerDetail.setPuuid(puuid);
+        participantSummonerDetail.setUserGameInfo(arraytoString);
+
+        return participantSummonerDetail;
+
+    }
+
+    /**
+     * 고유 id로 티어추출
+     *
+     * @param userGameInfo
+     * @return Tier
+     */
+    @SneakyThrows
+    public GameTier searchTier(String userGameInfo) {
+
+        String jsonToString = userGameInfo.replaceAll("[\\[\\[\\]]", "");
+
+        if (jsonToString.isEmpty()) {
+            return GameTier.getUnranked();
+        }
+
+        JSONObject summonerDetail = (JSONObject) jsonParser.parse(jsonToString);
+        String tier = summonerDetail.get("tier").toString();
+        String rank = summonerDetail.get("rank").toString();
+
+
+        return GameTier.findGameTier(tier, rank);
+
+    }
+
+    /**
+     * 플레이 횟수 검색
+     *
+     * @param userGameInfo
+     * @return
+     */
+    public Integer getPlayCount(String userGameInfo) {
+
+        String jsonToString = userGameInfo.replaceAll("[\\[\\[\\]]", "");
+
+        if (jsonToString.isEmpty())
+            return 0;
+
+        return stringToIntegerPlayCount(jsonToString);
+
+    }
+
+    /**
+     * 플레이 횟수 문자열을 정수형으로 변환
+     *
+     * @param userGameInfoJSON
+     * @return
+     */
+    @SneakyThrows
+    public Integer stringToIntegerPlayCount(String userGameInfoJSON) {
+        JSONObject summonerDetail = (JSONObject) jsonParser.parse(userGameInfoJSON);
+
+        return Integer.parseInt(summonerDetail.get("wins").toString()) + Integer.parseInt(summonerDetail.get("losses").toString());
+    }
+
+    /**
+     * 티어와 플레이 횟수를 받아 반환
+     *
+     * @param nickname
+     * @return
+     */
+    public ResponseUserGameInfoDto getTierAndPlayCount(String nickname) {
+
+        ParticipantSummonerDetail participantSummonerDetail = requestUserGameInfo(nickname);
+        String userGameInfo = participantSummonerDetail.getUserGameInfo();
+
+        GameTier tier = searchTier(userGameInfo);
+
+        Integer playCount = getPlayCount(userGameInfo);
+
+        ResponseUserGameInfoDto userGameInfoDto = new ResponseUserGameInfoDto();
+        userGameInfoDto.setTier(tier.toString());
+        userGameInfoDto.setPlayCount(playCount);
+
+        return userGameInfoDto;
+    }
+
+}

--- a/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
@@ -10,6 +10,7 @@ import leaguehub.leaguehubbackend.domain.channel.entity.ChannelBoard;
 import leaguehub.leaguehubbackend.domain.channel.entity.ChannelRule;
 import leaguehub.leaguehubbackend.domain.member.entity.Member;
 import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantManagementService;
 import leaguehub.leaguehubbackend.fixture.ChannelFixture;
 import leaguehub.leaguehubbackend.fixture.ParticipantFixture;
 import leaguehub.leaguehubbackend.fixture.UserFixture;
@@ -66,6 +67,9 @@ class ParticipantControllerTest {
     ParticipantRepository participantRepository;
     @Autowired
     ChannelRuleRepository channelRuleRepository;
+
+    @Autowired
+    ParticipantManagementService participantManagementService;
 
     @Autowired
     ObjectMapper mapper;
@@ -597,7 +601,7 @@ class ParticipantControllerTest {
                 .mapToObj(i -> createCustomChannel(false, false, 800, null, 100))
                 .peek(channel -> {
                     channelRepository.save(channel);
-                    participantService.participateChannel(channel.getChannelLink());
+                    participantManagementService.participateChannel(channel.getChannelLink());
                 })
                 .collect(Collectors.toList());
 

--- a/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
@@ -2,7 +2,6 @@ package leaguehub.leaguehubbackend.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
-import leaguehub.leaguehubbackend.domain.participant.controller.ParticipantController;
 import leaguehub.leaguehubbackend.domain.channel.dto.CreateChannelDto;
 import leaguehub.leaguehubbackend.domain.channel.dto.ParticipantChannelDto;
 import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantDto;
@@ -50,8 +49,6 @@ class ParticipantControllerTest {
     @Autowired
     MockMvc mockMvc;
 
-    @Autowired
-    ParticipantController participantController;
 
     @Autowired
     ParticipantService participantService;

--- a/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/controller/ParticipantControllerTest.java
@@ -11,6 +11,7 @@ import leaguehub.leaguehubbackend.domain.channel.entity.ChannelRule;
 import leaguehub.leaguehubbackend.domain.member.entity.Member;
 import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantManagementService;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantRoleAndPermissionService;
 import leaguehub.leaguehubbackend.fixture.ChannelFixture;
 import leaguehub.leaguehubbackend.fixture.ParticipantFixture;
 import leaguehub.leaguehubbackend.fixture.UserFixture;
@@ -70,6 +71,8 @@ class ParticipantControllerTest {
 
     @Autowired
     ParticipantManagementService participantManagementService;
+    @Autowired
+    ParticipantRoleAndPermissionService participantRoleAndPermissionService;
 
     @Autowired
     ObjectMapper mapper;
@@ -538,7 +541,7 @@ class ParticipantControllerTest {
             dummyParticipant.approveParticipantMatch();
         }
         Participant dummy = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
-        participantService.approveParticipantRequest(channel.getChannelLink(), dummy.getId());
+        participantRoleAndPermissionService.approveParticipantRequest(channel.getChannelLink(), dummy.getId());
 
         Participant dummy1 = getParticipant("DummyName2", channel, "DummyGameId2", "DummyNickname2");
 

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -2,6 +2,7 @@ package leaguehub.leaguehubbackend.service.participant;
 
 import jakarta.transaction.Transactional;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantManagementService;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantQueryService;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.domain.channel.dto.CreateChannelDto;
 import leaguehub.leaguehubbackend.domain.channel.dto.ParticipantChannelDto;
@@ -75,6 +76,8 @@ class ParticipantServiceTest {
     ParticipantWebClientService participantWebClientService;
     @Autowired
     ParticipantManagementService participantManagementService;
+    @Autowired
+    ParticipantQueryService participantQueryService;
 
     Member getMemberId() throws Exception {
 
@@ -394,7 +397,7 @@ class ParticipantServiceTest {
 
 
         //when
-        List<ResponseStatusPlayerDto> requestPlayerDto = participantService.loadPlayers(channel.getChannelLink());
+        List<ResponseStatusPlayerDto> requestPlayerDto = participantQueryService.loadPlayers(channel.getChannelLink());
 
         //then
         assertThat(part2.getNickname()).isEqualTo(requestPlayerDto.get(0).getNickname());
@@ -425,7 +428,7 @@ class ParticipantServiceTest {
         dummy2.updateParticipantStatus("DummyGameId2", "iron III", "DummyNickname2", "xKzO3XyPc7DLH5n6P-XC8z0DvQqhmZy8y8JZZxjXSSvPQ5qXqohUw1sehtNdSYIpsH0ckWagN5wnOQ");
 
         //when
-        assertThatThrownBy(() -> participantService.loadRequestStatusPlayerList(channel.getChannelLink()))
+        assertThatThrownBy(() -> participantQueryService.loadRequestStatusPlayerList(channel.getChannelLink()))
                 .isInstanceOf(InvalidParticipantAuthException.class);
 
     }
@@ -445,7 +448,7 @@ class ParticipantServiceTest {
         dummy1.updateParticipantStatus("DummyGameId1", "platinum III", "DummyNickname1", "xKzO3XyPc7DLH5n6P-XC8z0DvQqhmZy8y8JZZxjXSSvPQ5qXqohUw1sehtNdSYIpsH0ckWagN5wnOQ");
 
         //when
-        List<ResponseStatusPlayerDto> DtoList = participantService.loadRequestStatusPlayerList(channel.getChannelLink());
+        List<ResponseStatusPlayerDto> DtoList = participantQueryService.loadRequestStatusPlayerList(channel.getChannelLink());
 
 
         //then
@@ -578,7 +581,7 @@ class ParticipantServiceTest {
 
 
         //when
-        List<ResponseStatusPlayerDto> DtoList = participantService.loadObserverPlayerList(channel.getChannelLink());
+        List<ResponseStatusPlayerDto> DtoList = participantQueryService.loadObserverPlayerList(channel.getChannelLink());
 
         //then
         assertThat(dummy1.getId()).isEqualTo(DtoList.get(0).getPk());
@@ -608,7 +611,7 @@ class ParticipantServiceTest {
         Participant dummy2 = participantRepository.save(Participant.participateChannel(dummyMember2, channel));
 
         //when
-        assertThatThrownBy(() -> participantService.loadObserverPlayerList(channel.getChannelLink()))
+        assertThatThrownBy(() -> participantQueryService.loadObserverPlayerList(channel.getChannelLink()))
                 .isInstanceOf(InvalidParticipantAuthException.class);
 
     }

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -1,33 +1,30 @@
 package leaguehub.leaguehubbackend.service.participant;
 
 import jakarta.transaction.Transactional;
-import leaguehub.leaguehubbackend.domain.participant.service.ParticipantManagementService;
-import leaguehub.leaguehubbackend.domain.participant.service.ParticipantQueryService;
-import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.domain.channel.dto.CreateChannelDto;
 import leaguehub.leaguehubbackend.domain.channel.dto.ParticipantChannelDto;
-import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantDto;
-import leaguehub.leaguehubbackend.domain.participant.dto.ResponseStatusPlayerDto;
-import leaguehub.leaguehubbackend.domain.participant.dto.ResponseUserGameInfoDto;
 import leaguehub.leaguehubbackend.domain.channel.entity.Channel;
 import leaguehub.leaguehubbackend.domain.channel.entity.ChannelBoard;
 import leaguehub.leaguehubbackend.domain.channel.entity.ChannelRule;
 import leaguehub.leaguehubbackend.domain.channel.entity.GameCategory;
-import leaguehub.leaguehubbackend.domain.member.entity.Member;
-import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
-import leaguehub.leaguehubbackend.domain.participant.entity.RequestStatus;
-import leaguehub.leaguehubbackend.domain.participant.entity.Role;
-import leaguehub.leaguehubbackend.domain.email.exception.exception.UnauthorizedEmailException;
-import leaguehub.leaguehubbackend.domain.participant.exception.exception.*;
-import leaguehub.leaguehubbackend.domain.participant.service.ParticipantWebClientService;
-import leaguehub.leaguehubbackend.fixture.ChannelFixture;
-import leaguehub.leaguehubbackend.fixture.UserFixture;
 import leaguehub.leaguehubbackend.domain.channel.repository.ChannelBoardRepository;
 import leaguehub.leaguehubbackend.domain.channel.repository.ChannelRepository;
 import leaguehub.leaguehubbackend.domain.channel.repository.ChannelRuleRepository;
+import leaguehub.leaguehubbackend.domain.email.exception.exception.UnauthorizedEmailException;
+import leaguehub.leaguehubbackend.domain.member.entity.Member;
 import leaguehub.leaguehubbackend.domain.member.repository.MemberRepository;
-import leaguehub.leaguehubbackend.domain.participant.repository.ParticipantRepository;
 import leaguehub.leaguehubbackend.domain.member.service.MemberService;
+import leaguehub.leaguehubbackend.domain.participant.dto.ParticipantDto;
+import leaguehub.leaguehubbackend.domain.participant.dto.ResponseStatusPlayerDto;
+import leaguehub.leaguehubbackend.domain.participant.dto.ResponseUserGameInfoDto;
+import leaguehub.leaguehubbackend.domain.participant.entity.Participant;
+import leaguehub.leaguehubbackend.domain.participant.entity.RequestStatus;
+import leaguehub.leaguehubbackend.domain.participant.entity.Role;
+import leaguehub.leaguehubbackend.domain.participant.exception.exception.*;
+import leaguehub.leaguehubbackend.domain.participant.repository.ParticipantRepository;
+import leaguehub.leaguehubbackend.domain.participant.service.*;
+import leaguehub.leaguehubbackend.fixture.ChannelFixture;
+import leaguehub.leaguehubbackend.fixture.UserFixture;
 import leaguehub.leaguehubbackend.global.util.SecurityUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
@@ -78,6 +75,8 @@ class ParticipantServiceTest {
     ParticipantManagementService participantManagementService;
     @Autowired
     ParticipantQueryService participantQueryService;
+    @Autowired
+    ParticipantRoleAndPermissionService participantRoleAndPermissionService;
 
     Member getMemberId() throws Exception {
 
@@ -471,7 +470,7 @@ class ParticipantServiceTest {
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
         //when
-        participantService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId());
+        participantRoleAndPermissionService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId());
 
         Participant updateDummy = participantRepository.findParticipantByIdAndChannel_ChannelLink(dummy1.getId(), channel.getChannelLink()).get();
         Optional<Channel> channel1 = channelRepository.findByChannelLink(channel.getChannelLink());
@@ -493,7 +492,7 @@ class ParticipantServiceTest {
         Channel channel = createCustomChannel(true, true, 2400, null, 20);
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
-        assertThatThrownBy(() -> participantService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId()))
+        assertThatThrownBy(() -> participantRoleAndPermissionService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId()))
                 .isInstanceOf(InvalidParticipantAuthException.class);
 
     }
@@ -507,7 +506,7 @@ class ParticipantServiceTest {
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
         //when
-        participantService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId());
+        participantRoleAndPermissionService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId());
 
         Participant updateDummy = participantRepository.findParticipantByIdAndChannel_ChannelLink(dummy1.getId(), channel.getChannelLink()).get();
 
@@ -527,7 +526,7 @@ class ParticipantServiceTest {
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
 
-        assertThatThrownBy(() -> participantService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId()))
+        assertThatThrownBy(() -> participantRoleAndPermissionService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId()))
                 .isInstanceOf(InvalidParticipantAuthException.class);
 
 
@@ -543,7 +542,7 @@ class ParticipantServiceTest {
         dummy1.approveParticipantMatch();
 
         //when
-        participantService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId());
+        participantRoleAndPermissionService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId());
 
         Participant updateDummy = participantRepository.findParticipantByIdAndChannel_ChannelLink(dummy1.getId(), channel.getChannelLink()).get();
 
@@ -562,7 +561,7 @@ class ParticipantServiceTest {
         Channel channel = createCustomChannel(true, true, 2400, null, 20);
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
-        assertThatThrownBy(() -> participantService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId()))
+        assertThatThrownBy(() -> participantRoleAndPermissionService.rejectedParticipantRequest(channel.getChannelLink(), dummy1.getId()))
                 .isInstanceOf(InvalidParticipantAuthException.class);
 
     }
@@ -630,8 +629,8 @@ class ParticipantServiceTest {
         dummy1.updateParticipantStatus("DummyGameId1", "platinum", "DummyNickname1", "xKzO3XyPc7DLH5n6P-XC8z0DvQqhmZy8y8JZZxjXSSvPQ5qXqohUw1sehtNdSYIpsH0ckWagN5wnOQ");
 
         //when
-        participantService.updateHostRole(channel.getChannelLink(), dummy1.getId());
-        participantService.updateHostRole(channel.getChannelLink(), dummy2.getId());
+        participantRoleAndPermissionService.updateHostRole(channel.getChannelLink(), dummy1.getId());
+        participantRoleAndPermissionService.updateHostRole(channel.getChannelLink(), dummy2.getId());
 
         Participant updateDummy1 = participantRepository.findParticipantByIdAndChannel_ChannelLink(dummy1.getId(), channel.getChannelLink()).get();
         Participant updateDummy2 = participantRepository.findParticipantByIdAndChannel_ChannelLink(dummy2.getId(), channel.getChannelLink()).get();
@@ -655,7 +654,7 @@ class ParticipantServiceTest {
         Channel channel = createCustomChannel(true, true, 2400, null, 20);
         Participant dummy1 = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
 
-        assertThatThrownBy(() -> participantService.updateHostRole(channel.getChannelLink(), dummy1.getId()))
+        assertThatThrownBy(() -> participantRoleAndPermissionService.updateHostRole(channel.getChannelLink(), dummy1.getId()))
                 .isInstanceOf(InvalidParticipantAuthException.class);
 
     }
@@ -675,11 +674,11 @@ class ParticipantServiceTest {
         }
 
         Participant dummy = getParticipant("DummyName1", channel, "DummyGameId1", "DummyNickname1");
-        participantService.approveParticipantRequest(channel.getChannelLink(), dummy.getId());
+        participantRoleAndPermissionService.approveParticipantRequest(channel.getChannelLink(), dummy.getId());
 
         Participant dummy1 = getParticipant("DummyName2", channel, "DummyGameId2", "DummyNickname2");
 
-        assertThatThrownBy(() -> participantService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId()))
+        assertThatThrownBy(() -> participantRoleAndPermissionService.approveParticipantRequest(channel.getChannelLink(), dummy1.getId()))
                 .isInstanceOf(ParticipantRealPlayerIsMaxException.class);
 
     }
@@ -784,7 +783,7 @@ class ParticipantServiceTest {
                 })
                 .collect(Collectors.toList());
 
-        participantService.updateCustomChannelIndex(participantChannelDtos);
+        participantManagementService.updateCustomChannelIndex(participantChannelDtos);
 
         List<Participant> all = participantRepository.findAllByMemberIdOrderByIndex(findMember.getId());
         assertThat(all.get(0).getIndex()).isEqualTo(0);

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -1,6 +1,7 @@
 package leaguehub.leaguehubbackend.service.participant;
 
 import jakarta.transaction.Transactional;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantManagementService;
 import leaguehub.leaguehubbackend.domain.participant.service.ParticipantService;
 import leaguehub.leaguehubbackend.domain.channel.dto.CreateChannelDto;
 import leaguehub.leaguehubbackend.domain.channel.dto.ParticipantChannelDto;
@@ -72,6 +73,8 @@ class ParticipantServiceTest {
 
     @Autowired
     ParticipantWebClientService participantWebClientService;
+    @Autowired
+    ParticipantManagementService participantManagementService;
 
     Member getMemberId() throws Exception {
 
@@ -175,7 +178,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("서초임");
 
-        participantService.participateMatch(responseDto, channel.getChannelLink());
+        participantManagementService.participateMatch(responseDto, channel.getChannelLink());
 
         //when
 
@@ -200,7 +203,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("연습용아이디가됨");
 
-        participantService.participateMatch(responseDto, channel.getChannelLink());
+        participantManagementService.participateMatch(responseDto, channel.getChannelLink());
 
         //when
 
@@ -224,7 +227,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("연습용아이디가됨");
 
-        participantService.participateMatch(responseDto, channel.getChannelLink());
+        participantManagementService.participateMatch(responseDto, channel.getChannelLink());
 
         //when
 
@@ -248,7 +251,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("participantGameId2");
 
-        assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantDuplicatedGameIdException.class);
 
     }
@@ -263,7 +266,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("participantGameId2");
 
-        assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantInvalidRoleException.class);
 
     }
@@ -278,7 +281,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("participantGameId1");
 
-        assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantAlreadyRequestedException.class);
 
     }
@@ -293,7 +296,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("participantGameId4");
 
-        assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantRejectedRequestedException.class);
 
     }
@@ -308,7 +311,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("연습용아이디가됨");
 
-        assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantInvalidRankException.class);
 
     }
@@ -323,7 +326,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("연습용아이디가됨");
 
-        assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantInvalidRankException.class);
 
     }
@@ -339,7 +342,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("서초임");
 
-        assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantInvalidPlayCountException.class);
 
     }
@@ -355,7 +358,7 @@ class ParticipantServiceTest {
         responseDto.setGameId("연습용아이디가됨");
 
         //when
-        assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(ParticipantInvalidRankException.class);
     }
 
@@ -687,7 +690,7 @@ class ParticipantServiceTest {
         Channel channel = createCustomChannel(true, true, 2400, null, 20);
 
         //when
-        ParticipantChannelDto participantChannelDto  = participantService.participateChannel(channel.getChannelLink());
+        ParticipantChannelDto participantChannelDto  = participantManagementService.participateChannel(channel.getChannelLink());
         //then
 
         assertThat(participantChannelDto.getChannelLink()).isEqualTo(channel.getChannelLink());
@@ -703,7 +706,7 @@ class ParticipantServiceTest {
         Channel channel = createCustomChannel(true, true, 2400, null, 20);
 
         //then
-        assertThatThrownBy(() -> participantService.participateChannel(channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateChannel(channel.getChannelLink()))
                 .isInstanceOf(ParticipantDuplicatedGameIdException.class);
 
     }
@@ -725,7 +728,7 @@ class ParticipantServiceTest {
         long count = participantRepository.count();
 
         //when
-        participantService.leaveChannel(channel.getChannelLink());
+        participantManagementService.leaveChannel(channel.getChannelLink());
 
         //then
         long deleteCount = participantRepository.count();
@@ -746,7 +749,7 @@ class ParticipantServiceTest {
 
         responseDto.setGameId("urlGuestGameId");
 
-        assertThatThrownBy(() -> participantService.participateMatch(responseDto, channel.getChannelLink()))
+        assertThatThrownBy(() -> participantManagementService.participateMatch(responseDto, channel.getChannelLink()))
                 .isInstanceOf(UnauthorizedEmailException.class);
 
     }
@@ -761,7 +764,7 @@ class ParticipantServiceTest {
                 .mapToObj(i -> createCustomChannel(false, false, 800, null, 100))
                 .peek(channel -> {
                     channelRepository.save(channel);
-                    participantService.participateChannel(channel.getChannelLink());
+                    participantManagementService.participateChannel(channel.getChannelLink());
                 })
                 .collect(Collectors.toList());
 

--- a/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
+++ b/src/test/java/leaguehub/leaguehubbackend/service/participant/ParticipantServiceTest.java
@@ -17,6 +17,7 @@ import leaguehub.leaguehubbackend.domain.participant.entity.RequestStatus;
 import leaguehub.leaguehubbackend.domain.participant.entity.Role;
 import leaguehub.leaguehubbackend.domain.email.exception.exception.UnauthorizedEmailException;
 import leaguehub.leaguehubbackend.domain.participant.exception.exception.*;
+import leaguehub.leaguehubbackend.domain.participant.service.ParticipantWebClientService;
 import leaguehub.leaguehubbackend.fixture.ChannelFixture;
 import leaguehub.leaguehubbackend.fixture.UserFixture;
 import leaguehub.leaguehubbackend.domain.channel.repository.ChannelBoardRepository;
@@ -68,6 +69,9 @@ class ParticipantServiceTest {
     ParticipantRepository participantRepository;
     @Autowired
     ChannelRuleRepository channelRuleRepository;
+
+    @Autowired
+    ParticipantWebClientService participantWebClientService;
 
     Member getMemberId() throws Exception {
 
@@ -140,9 +144,9 @@ class ParticipantServiceTest {
     @DisplayName("티어, 플레이 횟수 검색 테스트 - 성공")
     void getDetailSuccessTest() throws Exception {
 
-        ResponseUserGameInfoDto testDto1 = participantService.getTierAndPlayCount("손성한");
-        ResponseUserGameInfoDto testDto2 = participantService.getTierAndPlayCount("서초임");
-        ResponseUserGameInfoDto testDto3 = participantService.getTierAndPlayCount("채수채수밭");
+        ResponseUserGameInfoDto testDto1 = participantWebClientService.getTierAndPlayCount("손성한");
+        ResponseUserGameInfoDto testDto2 = participantWebClientService.getTierAndPlayCount("서초임");
+        ResponseUserGameInfoDto testDto3 = participantWebClientService.getTierAndPlayCount("채수채수밭");
 
 
         assertThat(testDto2.getTier()).isEqualTo("UNRANKED");
@@ -156,7 +160,7 @@ class ParticipantServiceTest {
     @DisplayName("티어, 플레이 횟수 검색 테스트 - 실패")
     void getDetailFailTest() throws Exception {
 
-        assertThatThrownBy(() -> participantService.getTierAndPlayCount("saovkovsk"))
+        assertThatThrownBy(() -> participantWebClientService.getTierAndPlayCount("saovkovsk"))
                 .isInstanceOf(ParticipantGameIdNotFoundException.class);
     }
 


### PR DESCRIPTION
## 🙆‍♂️ Issue

#458 

## 📝 Description

프로젝트 내 Participant Controller, Participant Service를 메서드의 기능에 따라서 분할하였어요 
분할 전과 분할 후의 사진을 미리 보여드릴게요

패키지 분할 
![패키지 분할 이전사진](https://github.com/TheUpperPart/leaguehub-backend/assets/87762815/5df1d7e8-7337-475d-a071-50d39563389b)

패키지 분할 후
![패키지 분할 후 컨트롤러 서비스](https://github.com/TheUpperPart/leaguehub-backend/assets/87762815/9eb0b5a9-ff52-4ae9-abe6-ddaa9c8b2424)


Participant Controller부분은 명령을 실행하는 Command와 조회하는 Query부분으로 나누었어요

Participant Service부분은 기존의 Service부분과 함께 총 5가지로 나누었어요
QueryService는 조회가 필요할 때 사용하는 서비스
WebClientService는 외부 API를 사용할 때 사용하는 서비스
ManagementService는 사용자가 채널에 참가, 퇴장, 실격등 Participant를 관리할 때 사용하는 서비스이며
RoleAndPermissionService는 참가 요청에 대한 승인과 & 거절, 해당 사용자의 권한 확인과 같이 역할과 권한에 대한 메서드를 모아놓은 클래스에요

마지막으로 기존의 ParticipantService는 다른 4곳에서 공통적으로 사용하는 메서드를 모아놓은 클래스에요

궁금한 점이 있으시면 남겨주세요

## ✨ Feature

- Participant Controller 분할 (Command, Query)
- Participant Service 분할(Management, Query, RoleAndPermission, WebClient)

## 👌 Review Change

컨트롤러부분도 서비스부분과 같이 세분화하여 나눴어요

컨트롤러 패키지 분할 후
![image](https://github.com/TheUpperPart/leaguehub-backend/assets/87762815/258b823f-45d3-4f02-bde8-022869689f18)

ParticipantWebClientController는 직접적으로 사용하는 부분이 없어 QueryController와 합쳤어요


